### PR TITLE
chore: add Renovate config ahead of supply-chain pinning

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,0 +1,40 @@
+{
+  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+  "description": [
+    "Supply-chain policy for ronl-business-api. Companion to .github/zizmor.yml",
+    "and the Supply-chain audit workflow: zizmor enforces that every action",
+    "reference is a commit digest, Renovate keeps those digests current.",
+    "dependencyDashboardApproval is TEMPORARY - see the note on that key."
+  ],
+  "extends": ["config:recommended", "helpers:pinGitHubActionDigests"],
+  "minimumReleaseAge": "14 days",
+  "internalChecksFilter": "strict",
+  "dependencyDashboardApproval": true,
+  "vulnerabilityAlerts": {
+    "description": [
+      "Security advisories bypass the cooldown. Without this override the",
+      "14-day wait would delay exactly the updates that must not wait, which",
+      "is why such policies get disabled mid-incident. Requires GitHub",
+      "Dependabot ALERTS to be enabled on the repository; Dependabot security",
+      "UPDATES must stay off, or it opens competing PRs that ignore the cooldown."
+    ],
+    "minimumReleaseAge": null,
+    "labels": ["security"]
+  },
+  "packageRules": [
+    {
+      "description": [
+        "Azure/static-web-apps-deploy publishes v1 as BOTH a 2021 tag",
+        "(1a947af9992250f3bc2e68ad0754c0b0c11566c9) and a 2024 branch head",
+        "(4d27395796ac319302594769cfe812bd207490b1). The workflows pin the",
+        "branch head; Renovate's github-tags datasource resolves the tag, so it",
+        "would open a routine-looking digest update that reverts nine deploy",
+        "steps to 3.5-year-old code. minimumReleaseAge gives no protection - the",
+        "target commit is years old. See SECURITY-PIPELINE.md."
+      ],
+      "matchManagers": ["github-actions"],
+      "matchDepNames": ["Azure/static-web-apps-deploy"],
+      "enabled": false
+    }
+  ]
+}


### PR DESCRIPTION
One file: `renovate.json`. Deliberately standalone — no dependency on the pinning work in progress on `feat/pa-cockpit-duplication-guards`.

## Why this lands before the App is installed

Renovate reads its config **only from the default branch** (`acc`). Install it with no config present and it onboards with defaults: no 14-day cooldown, no digest pinning, and — the one that matters — **no guard on `Azure/static-web-apps-deploy`**.

That action publishes `v1` as both a 2021 tag (`1a947af…`) and a 2024 branch head (`4d27395…`). Renovate's `github-tags` datasource resolves the tag. This repo references it **nine times across four acceptance and production deploy pipelines**, so an unguarded Renovate can propose reverting all nine to 3.5-year-old code in a PR that reads like routine maintenance. `minimumReleaseAge` offers no protection, because the target commit is years old.

## `dependencyDashboardApproval: true` is temporary

With it, Renovate installs, reads this config and builds its dependency dashboard, but raises **no PRs** until each is ticked. That keeps it from opening digest-pinning PRs against `acc`'s workflows while the same files are being pinned on `feat/pa-cockpit-duplication-guards` — two agents editing the same `uses:` lines would conflict on merge.

Remove the key once the pinning work lands on `acc`.

## Also required, as GitHub settings

- **Dependabot alerts: on** — `vulnerabilityAlerts` consumes that feed; without it the no-cooldown security lane never fires.
- **Dependabot security updates: off** (currently correct) — otherwise it opens competing PRs that ignore the cooldown.

Companion to `.github/zizmor.yml` and the `Supply-chain audit` workflow, both arriving with the pinning work. Pattern and rationale: `ttl-editor`'s `docs/the-gate-has-teeth.md`.