### PR TITLE
docs: move the CI follow-ups where follow-ups live

### DIFF
--- a/SECURITY-PIPELINE.md
+++ b/SECURITY-PIPELINE.md
@@ -154,45 +154,13 @@ change, but GitHub Actions runs the workflow file _from the branch being pushed_
 `main` still carries unpinned copies and will keep using them until `acc` is
 promoted. Pinning the file is not the same as pinning the branch that runs it.
 
-## Queued CI improvements
+## Pending work
 
-Deliberately left out of the pinning work, which was kept behaviour-preserving so
-that a broken deploy would be attributable. Roughly in order of what they buy.
+This document records what _is_. Pending work lives in
+[`docs/superpowers/plans/2026-08-28-ci-follow-ups.md`](docs/superpowers/plans/2026-08-28-ci-follow-ups.md),
+following the same convention as the other follow-up lists in that directory.
 
-1. **Pin the backend deploy bundle's dependencies.** Copy the lockfile into
-   `packages/backend/deploy/` and use `npm ci --omit=dev` rather than
-   `npm install --production --omit=dev`. Closes the widest floating surface in
-   the repo. Note the wrinkle: `@ronl/shared` is deleted from `package.json`
-   before the install and copied in afterwards, because it is a workspace
-   dependency npm cannot fetch from the registry — a lockfile-based install needs
-   the same treatment, so this is not a one-word change.
-
-2. **Move the backend deploy into a workflow.** The blocker was authentication,
-   not YAML: `az webapp deploy` works locally under `az login`, while
-   `azure/webapps-deploy` authenticates over SCM basic auth, which Azure now
-   disables by default. The likely route is OIDC — an app registration with a
-   federated credential for this repo, `azure/login`, `permissions: id-token:
-write`, then the same `az webapp deploy` the scripts already use. **Confirm
-   against a real failed run before committing to that diagnosis.**
-
-3. **Pin the Node runtime.** The workflows request `node-version: '20'`, which
-   floats across every 20.x release. `.nvmrc` says `22` and `engines.node` says
-   `>= 20.13.0` — three different answers to the same question. Once they are
-   meant to agree, `node-version-file: .nvmrc` settles it in one place.
-
-4. **Make PR previews worth opening.** A preview frontend gets an ephemeral
-   `*.azurestaticapps.net` origin that is not in the backend's `CORS_ORIGIN`
-   allowlist, and `VITE_API_URL` is baked in at build time, so anything touching
-   the API fails. Today a preview only demonstrates that static pages render.
-   Allowing the preview origin (and matching Keycloak redirect URIs) would change
-   that.
-
-5. **Consider `paths:` filters on the frontend workflows.** `frontend-acc`,
-   `pa-demo-acc` and `publicsite-acc` trigger on every PR to `acc` regardless of
-   what changed — a one-file config PR redeploys three sites. The backend
-   workflows already do this correctly.
-
-6. **Action major upgrades.** Renovate offers `checkout`, `setup-node` and
-   `upload-artifact` v7 on the dependency dashboard. Kept separate from pinning
-   on purpose: pinning is behaviour-preserving, upgrading is not, and bundling
-   them would make a failure ambiguous.
+Highest value there, and the only item on this page's exceptions list that is
+fixable from our side: **pin the backend deploy bundle's dependencies**, which
+today are resolved by an `npm install` with no lockfile, on a developer machine,
+for the artifact that ships to production.

--- a/docs/superpowers/plans/2026-08-28-ci-follow-ups.md
+++ b/docs/superpowers/plans/2026-08-28-ci-follow-ups.md
@@ -94,14 +94,43 @@ Today a preview only demonstrates that static pages render. Allowing the preview
 origin, and adding matching Keycloak redirect URIs where auth is involved, would
 make preview deployments worth the three deploys each PR already costs.
 
-## 5. Consider `paths:` filters on the frontend workflows
+## 5. The `pull_request` trigger has no `paths:` filter
 
 `frontend-acc`, `pa-demo-acc` and `publicsite-acc` trigger on every pull request to
-`acc` regardless of what changed — a one-file config PR redeploys three sites. The
-backend workflows already filter correctly.
+`acc` regardless of what changed — a one-file config PR redeploys three sites, and
+each preview holds a Static Web Apps staging environment. With three apps and a
+three-environment ceiling, five open PRs exhausted the quota on 2026-08-28 and two
+Renovate PRs failed on `BadRequest … maximum number of staging environments`.
 
-Weigh this against the fact that a path filter is what makes item 6 possible; the
-answer may be narrower filters rather than more of them.
+**This is smaller than it looks.** The `paths:` blocks already exist and are
+correct — on the `push` trigger, including the `packages/pa-cockpit/**` dependency
+that a naive filter would have missed:
+
+```yaml
+on:
+  push:
+    branches: [acc]
+    paths: # ← already here, already right
+      - 'packages/frontend/**'
+      - 'packages/shared/**'
+      - 'packages/pa-cockpit/**'
+      - '.github/workflows/azure-frontend-acc.yml'
+  pull_request:
+    types: [opened, synchronize, reopened, closed]
+    branches: [acc] # ← no paths: at all
+```
+
+So the work is **mirroring an existing correct filter onto `pull_request`**, not
+designing one.
+
+One wrinkle to think through rather than copy blindly: `close_pull_request_job`
+fires on the `closed` type. Once `pull_request` is filtered, a PR touching no
+frontend files will not run the close job either — which is right, since it never
+created a preview. But a PR that _did_ touch frontend files and then reverted them
+before merging could leave an environment stranded.
+
+Weigh this against item 6: a path filter is what makes that false positive
+possible, so the answer may be narrower filters rather than simply more of them.
 
 ## 6. A `package.json`-only change triggers the backend build
 
@@ -124,6 +153,16 @@ making "did it run" and "was it deployed" the same question.
 
 ## 7. Action major upgrades
 
+> **Done.** Shipped in `2026.08.33` (#21, #22, #23). `actions/checkout` →
+> `3d3c42e5` v7.0.1, `actions/setup-node` → `820762786` v7.0.0,
+> `actions/upload-artifact` → `043fb46d` v7.0.1. The Node-runtime deprecation is
+> closed: v7 declares node24 natively, where the pinned v4 actions targeted a
+> version the runner had begun force-upgrading.
+>
+> The checkout upgrade also covers `zizmor.yml`, so the audit gate now runs on
+> v7 — the one change whose failure would have been self-obscuring. It passed on
+> all three merges, verifying the upgrade by the mechanism it upgrades.
+
 Renovate offers `actions/checkout` v7, `actions/setup-node` v7 and
 `actions/upload-artifact` v7 on its dependency dashboard.
 
@@ -145,6 +184,50 @@ this was all built for.
 
 One line. It needs a release to ship, so it should ride with the next one rather
 than justify its own.
+
+## 9. The deploy workflows need a `concurrency:` group
+
+None of the deploy workflows declares one, so two merges within a few minutes send
+two deployments at the same Azure Static Web Apps environment and **Azure picks a
+loser** — reporting `Deployment Canceled` on a job that did nothing wrong.
+
+Observed while merging #21, #22 and #23 for `2026.08.33`:
+
+```
+35a7b0c  success   start 05:41:41   end 05:45:26
+9fe004c  failure   start 05:42:01   end 05:45:22   ← cancelled by Azure
+```
+
+Twenty seconds apart, same environment. Nothing was actually broken — zero files
+differ in `packages/public-site` between those two commits, so the successful run
+had already published the correct bytes — but the run history carried a red mark
+that reads like a real deployment failure, and clearing it took a manual
+`workflow_dispatch`.
+
+**The fix** is a `concurrency:` block per deploy workflow, so GitHub serialises
+them and cancels the _superseded_ run cleanly rather than letting Azure arbitrate:
+
+```yaml
+concurrency:
+  group: publicsite-acc
+  cancel-in-progress: true
+```
+
+Two things to get right when writing it:
+
+- **The group must be per environment, not per workflow file.** `acc` and `prod`
+  deploy to different Static Web Apps and must not cancel each other.
+- **Think about PR previews.** Each pull request deploys to its own preview
+  environment, so a group keyed only on the workflow would make two PRs cancel
+  each other's previews. The group likely needs the ref or PR number in it —
+  something like `${{ github.workflow }}-${{ github.ref }}`.
+
+This will recur, and more often as the Renovate queue drains: any two PRs merged
+in quick succession can produce a spurious failure on any of the three sites.
+
+**Do this alongside item 5** — it touches exactly the same workflow files, and
+both are about the `pull_request` half of those triggers behaving differently
+from the `push` half.
 
 ---
 

--- a/docs/superpowers/plans/2026-08-28-ci-follow-ups.md
+++ b/docs/superpowers/plans/2026-08-28-ci-follow-ups.md
@@ -1,0 +1,168 @@
+# Supply-chain pinning — CI follow-ups
+
+Carried out of `chore/supply-chain-pinning` (released as `2026.08.31`), which
+pinned all 27 action references to commit digests, scoped `GITHUB_TOKEN` to least
+privilege, and added the blocking `Supply-chain audit` gate — taking zizmor from
+49 findings to 0.
+
+**None of these block anything.** They were surfaced while pinning and
+deliberately left out of it, because that change was kept behaviour-preserving:
+if a deploy had broken, the cause had to be attributable to pinning rather than to
+an improvement bundled alongside it.
+
+Ordered by value-for-effort, not severity. Nothing here leaks today. The current
+state of what is pinned, and what cannot be, lives in `SECURITY-PIPELINE.md`; this
+file is the pending work.
+
+---
+
+## 1. Pin the backend deploy bundle's dependencies
+
+The widest floating surface in the repository, and the only one on this list that
+is both reachable from our side and about what actually ships.
+
+`deploy-backend-to-{acc,prod}.sh` build a bundle in `packages/backend/deploy/`,
+then run:
+
+```
+npm pkg delete dependencies.@ronl/shared
+npm install --production --omit=dev
+```
+
+That directory has a `package.json` but **no lockfile**. The dependency tree
+deployed to the backend App Service is therefore resolved fresh against semver
+ranges, on a developer machine, with no integrity checking and no record of what
+was installed. The same pattern exists in the CI workflows' "Prepare deployment
+package" step, but that copy is never deployed.
+
+**The fix is `npm ci --omit=dev` against a copied lockfile**, and it is not a
+one-word change. `@ronl/shared` is a workspace dependency npm cannot fetch from
+the registry, which is why it is deleted from `package.json` before the install
+and copied into `node_modules` afterwards. A lockfile-based install needs the
+same treatment, or it will fail resolving a package that does not exist on the
+registry.
+
+## 2. Move the backend deploy into a workflow
+
+`azure-backend-{acc,prod}.yml` build, test, package a zip and call
+`upload-artifact`. **Neither has a deploy step**; nothing consumes the artifact.
+The deploy is the script in item 1, run by hand.
+
+The blocker was authentication, not workflow YAML. A previous attempt could not be
+made to work.
+
+**Hypothesis, unconfirmed:** `az webapp deploy` works locally because it uses the
+operator's `az login` identity, while `azure/webapps-deploy` authenticates over
+SCM basic auth — which Azure now disables by default. If that is the cause, the
+route is OIDC: an app registration with a federated credential for this repo,
+`azure/login`, `permissions: id-token: write`, then the same `az webapp deploy`
+the scripts already run.
+
+**Confirm against a real failed run before acting on this.** It is a plausible
+diagnosis reasoned from a symptom, not something observed.
+
+Doing this also dissolves item 6 and closes the gap in item 1 at the same time,
+since a workflow-based deploy would install from the lockfile in CI.
+
+## 3. Pin the Node runtime
+
+The workflows request `node-version: '20'`, which resolves to whatever 20.x
+`actions/setup-node` downloads at run time. Under a policy of "nothing a pipeline
+downloads may float", that is an exception.
+
+There are currently three answers to the same question:
+
+| Source         | Says         |
+| -------------- | ------------ |
+| workflows      | `20`         |
+| `.nvmrc`       | `22`         |
+| `engines.node` | `>= 20.13.0` |
+
+So developers work on a different Node major than the one producing the deployed
+artifact. `node-version-file: .nvmrc` would settle it in one place — once the
+three are meant to agree, which is the question to answer first.
+
+## 4. Make PR previews worth opening
+
+A preview frontend gets an ephemeral `*.azurestaticapps.net` origin that is not in
+the backend's `CORS_ORIGIN` allowlist, and `VITE_API_URL` is baked in at build
+time. The backend is not deployed per-PR at all — `azure-backend-acc.yml` has no
+`pull_request` trigger — so every preview talks to the one shared acc backend, and
+is refused.
+
+Today a preview only demonstrates that static pages render. Allowing the preview
+origin, and adding matching Keycloak redirect URIs where auth is involved, would
+make preview deployments worth the three deploys each PR already costs.
+
+## 5. Consider `paths:` filters on the frontend workflows
+
+`frontend-acc`, `pa-demo-acc` and `publicsite-acc` trigger on every pull request to
+`acc` regardless of what changed — a one-file config PR redeploys three sites. The
+backend workflows already filter correctly.
+
+Weigh this against the fact that a path filter is what makes item 6 possible; the
+answer may be narrower filters rather than more of them.
+
+## 6. A `package.json`-only change triggers the backend build
+
+`azure-backend-acc.yml` is path-filtered on `packages/backend/**`, which matches
+`package.json`. Adding a script or bumping `engines` fires a full backend build
+even though no source changed, and — because the habit is to run the deploy script
+whenever that workflow fires — invites a deploy of byte-identical code.
+
+Observed on the `2026.08.32` release merge: the only backend change was a
+`test:serial` script and an `engines` floor, and the workflow ran.
+
+The question to ask before deploying is not "did the workflow run" but:
+
+```bash
+git diff --name-only <last-deployed-sha>..HEAD -- packages/backend/src packages/shared/src
+```
+
+Empty output means there is nothing to deploy. Item 2 dissolves this properly, by
+making "did it run" and "was it deployed" the same question.
+
+## 7. Action major upgrades
+
+Renovate offers `actions/checkout` v7, `actions/setup-node` v7 and
+`actions/upload-artifact` v7 on its dependency dashboard.
+
+Kept separate from pinning deliberately: pinning is behaviour-preserving,
+upgrading is not, and bundling them would make any failure ambiguous. This is also
+what closes the Node-runtime deprecation path — the pilot repo hit a warning that
+its pinned actions target a Node version the runner now force-upgrades.
+
+## 8. Remove `dependencyDashboardApproval` from `renovate.json`
+
+Set during adoption so Renovate raised nothing while the same workflow files were
+being pinned on a branch — two agents editing the same `uses:` lines would have
+conflicted.
+
+That race is over: `renovate/pin-dependencies` has already dropped off the
+dashboard, which is Renovate confirming it has nothing left to pin. Removing the
+key lets it open PRs normally under the 14-day cooldown, which is the steady state
+this was all built for.
+
+One line. It needs a release to ship, so it should ride with the next one rather
+than justify its own.
+
+---
+
+## Not follow-ups — resolved, recorded so they are not re-raised
+
+**The `staticappsclient:stable` container cannot be pinned.** It is hardcoded
+inside a third-party action and unreachable from our side. Its exposure here is
+narrower than it first appears, because all six deploy steps set
+`skip_app_build: true` — the container uploads an artifact this pipeline built
+rather than building it. (The other three references to that action are
+`action: 'close'` steps, which build nothing.) Recorded in `SECURITY-PIPELINE.md`.
+
+**The `@v1` ambiguity is settled.** `Azure/static-web-apps-deploy` publishes `v1`
+as both a 2021 tag and a 2024 branch head. The pinned digest is the branch commit,
+chosen on evidence: the executed surface is byte-identical at both, GitHub's API
+resolves the ref to the branch, and the branch declares a superset of inputs.
+Renovate is blocked from "updating" it back to the tag by a `packageRules` entry.
+
+**The zizmor version pin is manual, by necessity.** It lives in a `with:` input,
+which Renovate's github-actions manager does not parse. Not a defect to fix — a
+property to remember, recorded in the register's Maintained-by column.


### PR DESCRIPTION
**Draft — parked deliberately.** No urgency; intended to be swept up by `/bump-release` step 0 at the next release, so it appears in a changelog entry rather than landing unreleased.

## Why

The queued CI improvements were filed in `SECURITY-PIPELINE.md`, whose job is recording **current state**. Two consequences: completed items would accumulate in a document that no longer described them, and they sat outside `docs/superpowers/plans/`, which is the list actually reviewed and worked through.

They now follow the existing convention — numbered items, ordered by value-for-effort, `> **Done.**` blockquotes when closed, and a closing *"Not follow-ups — resolved, recorded so they are not re-raised"* section. The register keeps a short pointer.

## Eight items

The headline one: **the backend deploys from a gitignored laptop script whose `npm install` has no lockfile** — so the dependency tree that reaches production is resolved against semver ranges, on a developer machine, with no CI record. The audit gate never sees that path. It is the widest floating surface in the repo and the only one on the register's exceptions list fixable from our side.

Two items were added while moving:

- **#6** — a `package.json`-only change triggers the backend build, observed live on the `2026.08.32` merge. Since the habit is to deploy whenever that workflow fires, it invites deploying byte-identical code. Includes the one-liner for "is there actually anything to deploy".
- **#8** — remove `dependencyDashboardApproval`, now that Renovate has confirmed it has nothing left to pin.

Dependencies between items are recorded: **#2 dissolves #6 and closes #1**, and **#5 is in tension with #6**.

## Note

Item 8 is implemented on a sibling branch. If both land in the same release, mark item 8 `Done` in the same pass — otherwise this list claims pending work that has already shipped, which is exactly the failure mode that prompted the move.