### PR TITLE
chore: let Renovate raise PRs without dashboard approval

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -3,13 +3,11 @@
   "description": [
     "Supply-chain policy for ronl-business-api. Companion to .github/zizmor.yml",
     "and the Supply-chain audit workflow: zizmor enforces that every action",
-    "reference is a commit digest, Renovate keeps those digests current.",
-    "dependencyDashboardApproval is TEMPORARY - see the note on that key."
+    "reference is a commit digest, Renovate keeps those digests current."
   ],
   "extends": ["config:recommended", "helpers:pinGitHubActionDigests"],
   "minimumReleaseAge": "14 days",
   "internalChecksFilter": "strict",
-  "dependencyDashboardApproval": true,
   "vulnerabilityAlerts": {
     "description": [
       "Security advisories bypass the cooldown. Without this override the",


### PR DESCRIPTION
**Draft — parked deliberately.** Closes item 8 of `docs/superpowers/plans/2026-08-28-ci-follow-ups.md` (PR #19). One line, plus the description line that called the key temporary.

## Why it was set

`dependencyDashboardApproval` was added so Renovate raised **nothing** while the same workflow files were being pinned on a branch. Without it, Renovate would have opened digest-pinning PRs against `acc`'s workflows while we pinned the same `uses:` lines on `chore/supply-chain-pinning` — two agents editing the same lines, guaranteed conflicts on merge.

## Why it can go

That race is over, and Renovate said so itself: **`renovate/pin-dependencies` has dropped off the dependency dashboard**, the pending count falling 38 → 37. It has nothing left to pin, because the workflows are already at digests — which it now reads correctly as `actions/checkout v4.4.0@11d5960a…`, digest *and* version, confirming the `# vX.Y.Z` comments parse as intended.

With pinning done, the key only suppresses the cooldown-governed flow it was written around. The `vulnerabilityAlerts` fast-lane in particular is pointless behind a dashboard nobody has to visit: a security advisory would bypass the 14-day cooldown and then sit unraised.

## Before merging — read this

**37 updates are queued**, including three action majors (`checkout`, `setup-node`, `upload-artifact` → v7) and several package majors. Merging releases them into normal flow, and **each PR to `acc` costs three preview deploys**, since `frontend-acc`, `pa-demo-acc` and `publicsite-acc` have no `paths:` filter.

Thinning the majors from the dashboard first would make that arrival considerably quieter. Nothing in the queue is a security advisory — those carry a `security` label and bypass the cooldown regardless of this key.

## If both land together

Mark item 8 `Done` in PR #19's list in the same pass, or that list will claim pending work that has already shipped.