### PR TITLE
chore: bump release to v2026.08.33

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "ronl-business-api",
-  "version": "2026.08.32",
+  "version": "2026.08.33",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "ronl-business-api",
-      "version": "2026.08.32",
+      "version": "2026.08.33",
       "hasInstallScript": true,
       "license": "EUPL-1.2",
       "workspaces": [

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ronl-business-api",
-  "version": "2026.08.32",
+  "version": "2026.08.33",
   "description": "Secure, multi-tenant Business API for Dutch municipality BPMN/DMN services",
   "private": true,
   "workspaces": [

--- a/packages/frontend/src/pages/changelog-data.ts
+++ b/packages/frontend/src/pages/changelog-data.ts
@@ -108,6 +108,44 @@ export const changelog: Changelog = {
   versions: [
     {
       format: 'commits',
+      version: '2026.08.33',
+      status: 'Released',
+      date: '29 aug 2026',
+      scope: ['ci'],
+      commits: [
+        {
+          sha: 'cfbc8e5',
+          author: 'renovate[bot]',
+          type: 'ci',
+          subject: 'actions/upload-artifact pinned to v7.0.1',
+          details: [
+            'Raised by Renovate and merged under the 14-day cooldown. Two backend workflows move from ea165f8d (v4.6.2) to 043fb46d (v7.0.1). The digest and its version comment move together, which is what the pin-digests helper maintains — a digest without an accurate comment is a pin nobody can read.',
+          ],
+        },
+        {
+          sha: '3355e95',
+          author: 'renovate[bot]',
+          type: 'ci',
+          subject: 'actions/setup-node pinned to v7.0.0',
+          details: [
+            'Eight workflows move from 49933ea5 (v4.4.0) to 820762786 (v7.0.0).',
+            'Together with the checkout upgrade this closes the Node-runtime deprecation: the pinned v4 actions targeted a Node version the runner had begun force-upgrading, and v7 declares node24 natively. Pinning deliberately froze those versions in place; upgrading them was kept as separate work so a broken deploy would be attributable to one change or the other.',
+          ],
+        },
+        {
+          sha: '488d6dd',
+          author: 'renovate[bot]',
+          type: 'ci',
+          subject: 'actions/checkout pinned to v7.0.1',
+          details: [
+            'Nine workflows move from 11d5960a (v4.4.0) to 3d3c42e5 (v7.0.1), including the supply-chain audit gate itself.',
+            'That made this the one upgrade whose failure would have been self-obscuring: a broken checkout inside the gate breaks the thing that would otherwise report it. The gate passed on all three merges, so the upgrade is verified by the mechanism it upgrades.',
+          ],
+        },
+      ],
+    },
+    {
+      format: 'commits',
       version: '2026.08.32',
       status: 'Released',
       date: '28 aug 2026',


### PR DESCRIPTION
One entry, `2026.08.33`, covering the three action major upgrades merged today (#21, #22, #23). Closes follow-up item 7.

## Scope is `['ci']` — and that matters here

These commits touch **only `.github/workflows/*.yml`**. Zero files under `packages/`, so no deployable changed and **no package version moves**: frontend stays `.32`, backend `.29`, public-site `.29`, pa-demo `.30`. Root goes to `2026.08.33`.

Under the old scope tags this release would have needed *some* deployable in scope, bumping a `package.json` and tripping that package's path-filtered workflow — redeploying an app whose code did not change. The `ci` tag exists for exactly this, and this is its second use.

## What the upgrades did

| Action | From | To |
| --- | --- | --- |
| `actions/checkout` | `11d5960a…` v4.4.0 | `3d3c42e5…` **v7.0.1** |
| `actions/setup-node` | `49933ea5…` v4.4.0 | `820762786…` **v7.0.0** |
| `actions/upload-artifact` | `ea165f8d…` v4.6.2 | `043fb46d…` **v7.0.1** |

This closes the Node-runtime deprecation. The pinned v4 actions targeted a Node version the runner had begun force-upgrading; v7 declares node24 natively. Pinning deliberately froze those versions so the pinning change stayed behaviour-preserving — upgrading them was always separate work, so a broken deploy would be attributable to one or the other.

The checkout upgrade also covers `zizmor.yml`, making it the one change whose failure would have been self-obscuring: a broken checkout inside the audit gate breaks the thing that would report it. The gate passed on all three merges, so the upgrade is verified by the mechanism it upgrades.

## Known, already resolved

Merging all three within minutes produced one spurious failure: two public-site deploys raced into the same Azure Static Web Apps environment 20 seconds apart, and Azure cancelled one. Content was identical — zero files differ in `packages/public-site` between the two commits — and a `workflow_dispatch` re-deploy on current `acc` succeeded. GitHub `concurrency:` groups on the deploy workflows would prevent the recurrence; that is going into the CI follow-ups list.

## Merge

Merge commit, not squash: the entry names `cfbc8e5`, `3355e95` and `488d6dd` by SHA. Squash and rebase are disabled repo-wide, so the button can only do the right thing.