### PR TITLE
ci: filter pull_request triggers and serialise Azure deployments

### DIFF
--- a/.github/workflows/azure-frontend-acc.yml
+++ b/.github/workflows/azure-frontend-acc.yml
@@ -13,7 +13,30 @@ on:
     types: [opened, synchronize, reopened, closed]
     branches:
       - acc
+    # Mirrors the push filter above. Without it every pull request to acc
+    # deployed all three sites, each holding a Static Web Apps staging
+    # environment — three apps against a three-environment ceiling, which
+    # five open pull requests exhausted on 2026-08-28.
+    #
+    # Note this also gates close_pull_request_job, which fires on 'closed'.
+    # A pull request touching none of these paths never created a preview,
+    # so there is nothing for it to tear down.
+    paths:
+      - 'packages/frontend/**'
+      - 'packages/shared/**'
+      - 'packages/pa-cockpit/**'
+      - '.github/workflows/azure-frontend-acc.yml'
   workflow_dispatch:
+
+# Serialise deployments to one Azure Static Web Apps environment. Two
+# deployments at the same environment make Azure cancel one and report
+# "Deployment Canceled" on a job that did nothing wrong — seen on
+# 2026-08-29, two acc deploys 20 seconds apart. The group includes the ref,
+# so pull requests never cancel each other's previews, only their own
+# superseded runs.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
 
 # Default to read-only; jobs opt into more only where required.
 permissions:

--- a/.github/workflows/azure-frontend-prod.yml
+++ b/.github/workflows/azure-frontend-prod.yml
@@ -11,6 +11,14 @@ on:
       - '.github/workflows/azure-frontend-prod.yml'
   workflow_dispatch:
 
+# Same serialisation as the acc workflow, but production runs QUEUE rather
+# than cancel: interrupting a live production deployment to start another
+# is worse than waiting for it. Production deploys are rare enough that
+# the wait costs nothing.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: false
+
 # Default to read-only; jobs opt into more only where required.
 permissions:
   contents: read

--- a/.github/workflows/azure-pa-demo-acc.yml
+++ b/.github/workflows/azure-pa-demo-acc.yml
@@ -19,7 +19,30 @@ on:
     types: [opened, synchronize, reopened, closed]
     branches:
       - acc
+    # Mirrors the push filter above. Without it every pull request to acc
+    # deployed all three sites, each holding a Static Web Apps staging
+    # environment — three apps against a three-environment ceiling, which
+    # five open pull requests exhausted on 2026-08-28.
+    #
+    # Note this also gates close_pull_request_job, which fires on 'closed'.
+    # A pull request touching none of these paths never created a preview,
+    # so there is nothing for it to tear down.
+    paths:
+      - 'packages/pa-demo/**'
+      - 'packages/shared/**'
+      - 'packages/pa-cockpit/**'
+      - '.github/workflows/azure-pa-demo-acc.yml'
   workflow_dispatch:
+
+# Serialise deployments to one Azure Static Web Apps environment. Two
+# deployments at the same environment make Azure cancel one and report
+# "Deployment Canceled" on a job that did nothing wrong — seen on
+# 2026-08-29, two acc deploys 20 seconds apart. The group includes the ref,
+# so pull requests never cancel each other's previews, only their own
+# superseded runs.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
 
 # Default to read-only; jobs opt into more only where required.
 permissions:

--- a/.github/workflows/azure-pa-demo-prod.yml
+++ b/.github/workflows/azure-pa-demo-prod.yml
@@ -17,6 +17,14 @@ on:
       - '.github/workflows/azure-pa-demo-prod.yml'
   workflow_dispatch:
 
+# Same serialisation as the acc workflow, but production runs QUEUE rather
+# than cancel: interrupting a live production deployment to start another
+# is worse than waiting for it. Production deploys are rare enough that
+# the wait costs nothing.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: false
+
 # Default to read-only; jobs opt into more only where required.
 permissions:
   contents: read

--- a/.github/workflows/azure-publicsite-acc.yml
+++ b/.github/workflows/azure-publicsite-acc.yml
@@ -11,7 +11,28 @@ on:
     types: [opened, synchronize, reopened, closed]
     branches:
       - acc
+    # Mirrors the push filter above. Without it every pull request to acc
+    # deployed all three sites, each holding a Static Web Apps staging
+    # environment — three apps against a three-environment ceiling, which
+    # five open pull requests exhausted on 2026-08-28.
+    #
+    # Note this also gates close_pull_request_job, which fires on 'closed'.
+    # A pull request touching none of these paths never created a preview,
+    # so there is nothing for it to tear down.
+    paths:
+      - 'packages/public-site/**'
+      - '.github/workflows/azure-publicsite-acc.yml'
   workflow_dispatch:
+
+# Serialise deployments to one Azure Static Web Apps environment. Two
+# deployments at the same environment make Azure cancel one and report
+# "Deployment Canceled" on a job that did nothing wrong — seen on
+# 2026-08-29, two acc deploys 20 seconds apart. The group includes the ref,
+# so pull requests never cancel each other's previews, only their own
+# superseded runs.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
 
 # Default to read-only; jobs opt into more only where required.
 permissions:

--- a/.github/workflows/azure-publicsite-prod.yml
+++ b/.github/workflows/azure-publicsite-prod.yml
@@ -9,6 +9,14 @@ on:
       - '.github/workflows/azure-publicsite-prod.yml'
   workflow_dispatch:
 
+# Same serialisation as the acc workflow, but production runs QUEUE rather
+# than cancel: interrupting a live production deployment to start another
+# is worse than waiting for it. Production deploys are rare enough that
+# the wait costs nothing.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: false
+
 # Default to read-only; jobs opt into more only where required.
 permissions:
   contents: read

--- a/docs/superpowers/plans/2026-08-28-ci-follow-ups.md
+++ b/docs/superpowers/plans/2026-08-28-ci-follow-ups.md
@@ -96,6 +96,15 @@ make preview deployments worth the three deploys each PR already costs.
 
 ## 5. The `pull_request` trigger has no `paths:` filter
 
+> **Done.** The push filter is mirrored onto `pull_request` in
+> `azure-frontend-acc.yml`, `azure-pa-demo-acc.yml` and
+> `azure-publicsite-acc.yml` — 4, 4 and 2 paths respectively, copied rather than
+> re-derived, so `packages/pa-cockpit/**` travels with them.
+>
+> `zizmor.yml` deliberately keeps **no** `paths:` filter: the audit must run on
+> every pull request regardless of what changed. The backend workflows have no
+> `pull_request` trigger at all.
+
 `frontend-acc`, `pa-demo-acc` and `publicsite-acc` trigger on every pull request to
 `acc` regardless of what changed — a one-file config PR redeploys three sites, and
 each preview holds a Static Web Apps staging environment. With three apps and a
@@ -186,6 +195,20 @@ One line. It needs a release to ship, so it should ride with the next one rather
 than justify its own.
 
 ## 9. The deploy workflows need a `concurrency:` group
+
+> **Done.** Added to all six workflows that deploy to Azure, keyed
+> `${{ github.workflow }}-${{ github.ref }}` — per workflow file, so acc and prod
+> never cancel each other, and per ref, so pull requests never cancel each other's
+> previews, only their own superseded runs.
+>
+> The three acc workflows use `cancel-in-progress: true`; a superseded acceptance
+> deploy is wasted work. The three prod workflows use **`false`** so runs queue
+> instead: interrupting a live production deployment to start another is worse
+> than waiting for it, and production deploys are rare enough that the wait costs
+> nothing.
+>
+> The backend workflows are untouched — they build and upload an artifact and
+> never reach Azure, so no race exists there.
 
 None of the deploy workflows declares one, so two merges within a few minutes send
 two deployments at the same Azure Static Web Apps environment and **Azure picks a


### PR DESCRIPTION
Closes items **5** and **9** of `docs/superpowers/plans/2026-08-28-ci-follow-ups.md`, both marked `Done` in this PR. Additions only — no line is removed.

## Item 5 — `pull_request` had no `paths:` filter

The `push` triggers already carried correct filters. `pull_request` had none, so **every** PR to `acc` deployed all three sites, each holding a Static Web Apps staging environment. Three apps against a three-environment ceiling: five open PRs exhausted the quota on 2026-08-28 and two Renovate PRs failed with `BadRequest … maximum number of staging environments`.

The filters are **copied from `push`, not re-derived** — which is what carries `packages/pa-cockpit/**` across, the dependency a hand-written filter would most likely have missed.

Also documented inline: this gates `close_pull_request_job` too, which fires on `closed`. A PR touching none of these paths never created a preview, so there is nothing to tear down.

## Item 9 — no workflow declared a `concurrency:` group

Two merges minutes apart sent two deployments at the same Azure environment, and Azure cancelled one — reporting `Deployment Canceled` on a job that did nothing wrong. Observed on 2026-08-29 while merging #21–#23:

```
35a7b0c  success   start 05:41:41   end 05:45:26
9fe004c  failure   start 05:42:01   end 05:45:22   ← cancelled by Azure
```

Groups are keyed `${{ github.workflow }}-${{ github.ref }}`:

- **per workflow file** → acc and prod never cancel each other
- **per ref** → pull requests never cancel each other's previews, only their own superseded runs

| Workflows | `cancel-in-progress` | Why |
| --- | --- | --- |
| 3 × `*-acc.yml` | `true` | a superseded acceptance deploy is wasted work |
| 3 × `*-prod.yml` | **`false`** | runs queue; interrupting a live production deployment to start another is worse than waiting, and prod deploys are rare enough that the wait costs nothing |

## Two deliberate non-changes

**`zizmor.yml` keeps no `paths:` filter.** The audit must run on every pull request regardless of what changed — filtering it would let a PR skip the gate by touching nothing it watches. Recorded so it is not "fixed" later.

**The backend workflows are untouched.** They have no `pull_request` trigger and never reach Azure — they build and upload an artifact. No race to serialise.

## Testing note

This PR still deploys all three sites, because it edits all three `*-acc.yml` files and each filter matches its own filename. That is correct, and is how the change gets exercised. The serialisation itself is only properly tested by the next pair of quick merges.

zizmor: 0 findings across all 9 workflows.