### PR TITLE
fix(ci): key the concurrency group on the event, not just the ref

### DIFF
--- a/.github/workflows/azure-frontend-acc.yml
+++ b/.github/workflows/azure-frontend-acc.yml
@@ -34,8 +34,14 @@ on:
 # 2026-08-29, two acc deploys 20 seconds apart. The group includes the ref,
 # so pull requests never cancel each other's previews, only their own
 # superseded runs.
+#
+# The key must distinguish the EVENT, not just the ref. Keyed on github.ref
+# alone, the pull_request(closed) teardown and the push deploy that a merge
+# fires simultaneously landed in the same group and cancelled each other —
+# one of each pair died, at random. Seen on 2026-08-29 merging #25: two acc
+# deploys skipped and one preview left un-torn-down.
 concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: true
 
 # Default to read-only; jobs opt into more only where required.

--- a/.github/workflows/azure-frontend-prod.yml
+++ b/.github/workflows/azure-frontend-prod.yml
@@ -16,7 +16,7 @@ on:
 # is worse than waiting for it. Production deploys are rare enough that
 # the wait costs nothing.
 concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: false
 
 # Default to read-only; jobs opt into more only where required.

--- a/.github/workflows/azure-pa-demo-acc.yml
+++ b/.github/workflows/azure-pa-demo-acc.yml
@@ -40,8 +40,14 @@ on:
 # 2026-08-29, two acc deploys 20 seconds apart. The group includes the ref,
 # so pull requests never cancel each other's previews, only their own
 # superseded runs.
+#
+# The key must distinguish the EVENT, not just the ref. Keyed on github.ref
+# alone, the pull_request(closed) teardown and the push deploy that a merge
+# fires simultaneously landed in the same group and cancelled each other —
+# one of each pair died, at random. Seen on 2026-08-29 merging #25: two acc
+# deploys skipped and one preview left un-torn-down.
 concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: true
 
 # Default to read-only; jobs opt into more only where required.

--- a/.github/workflows/azure-pa-demo-prod.yml
+++ b/.github/workflows/azure-pa-demo-prod.yml
@@ -22,7 +22,7 @@ on:
 # is worse than waiting for it. Production deploys are rare enough that
 # the wait costs nothing.
 concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: false
 
 # Default to read-only; jobs opt into more only where required.

--- a/.github/workflows/azure-publicsite-acc.yml
+++ b/.github/workflows/azure-publicsite-acc.yml
@@ -30,8 +30,14 @@ on:
 # 2026-08-29, two acc deploys 20 seconds apart. The group includes the ref,
 # so pull requests never cancel each other's previews, only their own
 # superseded runs.
+#
+# The key must distinguish the EVENT, not just the ref. Keyed on github.ref
+# alone, the pull_request(closed) teardown and the push deploy that a merge
+# fires simultaneously landed in the same group and cancelled each other —
+# one of each pair died, at random. Seen on 2026-08-29 merging #25: two acc
+# deploys skipped and one preview left un-torn-down.
 concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: true
 
 # Default to read-only; jobs opt into more only where required.

--- a/.github/workflows/azure-publicsite-prod.yml
+++ b/.github/workflows/azure-publicsite-prod.yml
@@ -14,7 +14,7 @@ on:
 # is worse than waiting for it. Production deploys are rare enough that
 # the wait costs nothing.
 concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: false
 
 # Default to read-only; jobs opt into more only where required.

--- a/docs/superpowers/plans/2026-08-28-ci-follow-ups.md
+++ b/docs/superpowers/plans/2026-08-28-ci-follow-ups.md
@@ -209,6 +209,16 @@ than justify its own.
 >
 > The backend workflows are untouched — they build and upload an artifact and
 > never reach Azure, so no race exists there.
+>
+> **Corrected the same day.** The first key was
+> `${{ github.workflow }}-${{ github.ref }}`, which looked like it separated a
+> pull request from a push but did not: merging #25 fired the
+> `pull_request(closed)` teardown and the `push` deploy simultaneously, they
+> landed in one group, and each pair cancelled one of its two members at random —
+> two acc deploys skipped and one preview left standing. The key now reads
+> `${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}`,
+> which keys pull requests on their number and pushes on the ref, so the two can
+> never collide.
 
 None of the deploy workflows declares one, so two merges within a few minutes send
 two deployments at the same Azure Static Web Apps environment and **Azure picks a


### PR DESCRIPTION
A regression from #25, caught on the merge that landed it. Corrects item 9 in `docs/superpowers/plans/2026-08-28-ci-follow-ups.md`, which records the correction rather than quietly rewriting the original entry.

## What went wrong

#25 added `concurrency` keyed `${{ github.workflow }}-${{ github.ref }}`. That looks like it separates a pull request from a push, since the two carry different refs. It does not.

Merging #25 fired the `pull_request(closed)` teardown and the `push` deploy at the same instant. Both landed in one group and each pair cancelled one of its two members — at random:

| App | `pull_request` (teardown) | `push` (deploy) |
| --- | --- | --- |
| Frontend | success | **cancelled** |
| PA Demo | success | **cancelled** |
| Public Site | **cancelled** | success |

All three died in the same two-second window, `07:25:43 → 07:25:45`.

**Consequences:** frontend and pa-demo never deployed `e8e4d2a` to acc, and public-site's preview environment was left standing — a slot against the three-environment ceiling this work exists to protect. All three runs have since been re-run successfully, so acc is correctly deployed and nothing is stranded.

It was harmless that time only because #25 changed workflow files and a doc, so the undeployed bytes were identical. On a release carrying real source changes it would have skipped a deploy silently.

## The fix

```yaml
group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
```

Pull requests key on their number, pushes on the ref. The two cannot collide.

`cancel-in-progress` is unchanged and still deliberate: `true` on the three acc workflows, `false` on the three prod ones so production deploys queue rather than being interrupted.

## Honest limitation

**This PR's checks cannot prove the fix**, for the same reason they did not catch the bug: the collision happens *at merge*, after the checks are done. The merge is the test.

What to look for when this merges — all runs should complete, with **no cancellations**: three `pull_request` teardowns and however many `push` deploys the paths filters allow.

If you want belt and braces, job-level `concurrency` on `build_and_deploy_job` alone — leaving `close_pull_request_job` ungoverned so a teardown can never be cancelled — is strictly safer. That is a larger change and belongs in its own PR.