### PR TITLE
docs: bump-release verifies the branch is gone from the remote too

### DIFF
--- a/.claude/commands/bump-release.md
+++ b/.claude/commands/bump-release.md
@@ -412,6 +412,22 @@ gh pr create --base acc --title "chore: bump release to v<version>" --body "..."
   Use `-d`, not `-D` — it only succeeds when the branch is fully merged. If it
   refuses, stop and investigate rather than forcing it.
 
+- **Confirm the branch is gone from the remote too.** `gh pr merge --delete-branch`
+  removes both copies, and both repositories now have `delete_branch_on_merge`
+  enabled so a merge through the GitHub UI does the same. But a release merged some
+  other way leaves the remote branch behind — `chore/release-2026-08-33` survived
+  exactly that way, and was only noticed later:
+
+  ```bash
+  git fetch origin --prune
+  git ls-remote --heads origin '<working-branch>'   # expect no output
+  git push origin --delete <working-branch>          # only if it survived
+  ```
+
+  A stale merged branch is harmless on its own. They accumulate, and every one of
+  them makes it harder to see which branches are genuinely in flight — which is the
+  question step 0 has to answer at the next release.
+
 ### Why this changed
 
 Through v2026.08.x this step fast-forwarded `acc` locally and asked separately


### PR DESCRIPTION
One file: `.claude/commands/bump-release.md`. Adds a housekeeping check to step 8.

## Why

`gh pr merge --delete-branch` removes both copies of a branch, and both repositories now have `delete_branch_on_merge` enabled so a merge through the GitHub UI does the same. But a release merged some other way leaves the remote branch behind — `chore/release-2026-08-33` survived exactly that way and was only noticed later, by eye.

The step is written as a **check, not an action**, since with the setting enabled there is normally nothing to delete:

```bash
git fetch origin --prune
git ls-remote --heads origin '<working-branch>'   # expect no output
git push origin --delete <working-branch>          # only if it survived
```

A stale merged branch is harmless on its own. They accumulate, and each one makes it harder to see which branches are genuinely in flight — which is the question step 0 has to answer at the next release.

The same patch is applied in `ttl-editor`, whose command had the identical omission.

## Incidentally, this is item 5's first real test

This PR touches only `.claude/`, which matches none of the deploy workflows' `paths:` filters. **Expect `audit` alone and no deploys** — no Static Web Apps staging environments consumed. Before item 5, a one-file change like this deployed all three sites and held three environments.