### PR TITLE
docs: reconcile the supply-chain register, and settle item 2

### DIFF
--- a/SECURITY-PIPELINE.md
+++ b/SECURITY-PIPELINE.md
@@ -23,14 +23,18 @@ These are GitHub settings, not files. Without them parts of the policy are inert
 
 ## Pinned
 
+**30 `uses:` references across 9 workflows, all 30 digest-pinned.** Verified on
+`acc` at `570f973`, 29 August 2026.
+
 | Dependency                          | Pin                                                 | Version           | Maintained by                                                                        |
 | ----------------------------------- | --------------------------------------------------- | ----------------- | ------------------------------------------------------------------------------------ |
-| `actions/checkout` (×9)             | `11d5960a326750d5838078e36cf38b85af677262`          | v4.4.0            | Renovate                                                                             |
-| `actions/setup-node` (×8)           | `49933ea5288caeca8642d1e84afbd3f7d6820020`          | v4.4.0            | Renovate                                                                             |
+| `actions/checkout` (×9)             | `3d3c42e5aac5ba805825da76410c181273ba90b1`          | v7.0.1            | Renovate                                                                             |
+| `actions/setup-node` (×9)           | `820762786026740c76f36085b0efc47a31fe5020`          | v7.0.0            | Renovate                                                                             |
 | `Azure/static-web-apps-deploy` (×9) | `4d27395796ac319302594769cfe812bd207490b1`          | v1                | **manual** — Renovate updates are disabled for it, see below                         |
-| `actions/upload-artifact` (×2)      | `ea165f8d65b6e75b540449e92b4886f43607fa02`          | v4.6.2            | Renovate                                                                             |
+| `actions/upload-artifact` (×2)      | `043fb46d1a93c77aae656e7c1c64a875d1fc6a0a`          | v7.0.1            | Renovate                                                                             |
 | `zizmorcore/zizmor-action`          | `3dc1ecc9bcb9e94e9b2c709687979e1298497054`          | v0.6.2            | Renovate                                                                             |
 | zizmor itself                       | `version: '1.29.0'` input, not `latest`             | 1.29.0            | **manual** — an action input, which Renovate's github-actions manager does not parse |
+| `renovate-config-validator`         | `npx --package renovate@44.50.3`                    | 44.50.3           | **manual** — an inline npx argument, not a manifest entry                            |
 | npm dependencies                    | `package-lock.json`, `sha512` integrity per package | lockfileVersion 3 | Renovate                                                                             |
 
 The zizmor pin is stronger than it looks: `zizmor-action` resolves the requested
@@ -94,11 +98,17 @@ open a routine-looking digest update reverting **all nine** references to
 old. Updates for this dependency are therefore disabled in `renovate.json`, with
 the reasoning recorded inline there too.
 
-### `node-version: '20'` floats — and disagrees with `.nvmrc`
+### `node-version` floats — and three sources disagree
 
-The workflows request `node-version: '20'`, which resolves to whatever 20.x
-`actions/setup-node` downloads at run time. Under a policy of "nothing a pipeline
-downloads may float", that is an exception.
+Eight of the nine workflows request `node-version: '20'`, which resolves to
+whatever 20.x `actions/setup-node` downloads at run time. Under a policy of
+"nothing a pipeline downloads may float", that is an exception.
+
+The ninth is deliberate and pinned differently: the `renovate-config-validator`
+step in `zizmor.yml` sets `node-version: '24'`, because `renovate@44.50.3`
+declares `engines.node ^24.11.0` and npm accepts a mismatch with an
+`EBADENGINE` **warning** rather than refusing — so the validator had been
+running unsupported and green.
 
 Worth recording alongside it: **`.nvmrc` says `22`** while CI builds on 20, and
 `package.json` declares `engines.node >= 20.13.0`. Developers therefore work on a
@@ -114,9 +124,19 @@ to agree.
 gates; nothing consumes the artifact they produce.
 
 The backend actually reaches acceptance and production through
-`deploy-backend-to-{acc,prod}.sh`, run from a developer machine. Those scripts
-are deliberately gitignored (`.gitignore`: `deploy-backend-to-*.sh`) and exist
-because a workflow-based App Service deploy could not be made to work. A
+`deploy-backend-to-{acc,prod}.sh`, run from a developer machine. They exist
+because a workflow-based App Service deploy could not be made to work.
+
+**`.gitignore` lists them, but two of the three are tracked anyway.**
+`.gitignore` carries `deploy-backend-to-*.sh`, which reads as though none of them
+is in the repository. In fact `deploy-backend-to-acc.sh` and
+`deploy-backend-to-prod.sh` are both **tracked** — an ignore rule does not
+untrack a file that was already committed. Only
+`deploy-backend-to-acc-portable.sh` is genuinely ignored. This matters for the
+register's purpose: the deployed dependency tree is resolved by a script whose
+contents are reviewable in git, not by a local file nobody else can see. That is
+better than the ignore rule implies, and worth stating accurately rather than
+repeating the tidier claim. A
 `-portable` variant exists alongside them: the original targets Ubuntu, while the
 portable one falls back to the bsdtar Windows bundles at `System32\tar.exe`,
 because Info-ZIP's `zip` cannot be installed on a managed Windows laptop.
@@ -149,10 +169,28 @@ nothing checks that this document still matches the workflows — Renovate updat
 pins and never touches it. A `scripts/check-supply-chain.mjs` preflight covering
 both is planned.
 
+**That second gap is not hypothetical — it already bit.** Between the v7 action
+upgrades (`2026.08.33`) and 29 August 2026, this document's Pinned table still
+listed the superseded v4 digests for `actions/checkout`, `actions/setup-node` and
+`actions/upload-artifact`. The workflows had moved; the register had not, and
+every gate stayed green throughout — which is exactly the failure mode described
+above.
+
+A second, quieter drift came with it: `setup-node` had gone from ×8 to ×9 when
+the `renovate-config-validator` step was added, and the `renovate@44.50.3` pin
+that step introduced was absent from the table entirely. A count is as easy to
+falsify as a digest, and neither the audit nor review catches it.
+
+The reconciliation was manual, prompted by a documentation review rather than by
+any check in this repository. Until the planned preflight exists, **treat "the
+register matches the workflows" as an assumption, not a guarantee** — and
+re-derive the table from the workflow files whenever a pin changes.
+
 **Production is not yet protected.** The `*-prod.yml` files are pinned by this
 change, but GitHub Actions runs the workflow file _from the branch being pushed_.
-`main` still carries unpinned copies and will keep using them until `acc` is
-promoted. Pinning the file is not the same as pinning the branch that runs it.
+Measured on `origin/main`, 29 August 2026: **4 workflows, 13 `uses:` references,
+0 digest-pinned.** `main` will keep using those copies until `acc` is promoted.
+Pinning the file is not the same as pinning the branch that runs it.
 
 ## Pending work
 

--- a/docs/superpowers/plans/2026-08-28-ci-follow-ups.md
+++ b/docs/superpowers/plans/2026-08-28-ci-follow-ups.md
@@ -51,15 +51,31 @@ The deploy is the script in item 1, run by hand.
 The blocker was authentication, not workflow YAML. A previous attempt could not be
 made to work.
 
-**Hypothesis, unconfirmed:** `az webapp deploy` works locally because it uses the
-operator's `az login` identity, while `azure/webapps-deploy` authenticates over
-SCM basic auth — which Azure now disables by default. If that is the cause, the
-route is OIDC: an app registration with a federated credential for this repo,
-`azure/login`, `permissions: id-token: write`, then the same `az webapp deploy`
-the scripts already run.
+**The hypothesis this item carried has been disproved.** It read: `azure/webapps-deploy`
+fails because it authenticates over SCM basic auth, which Azure now disables by
+default.
 
-**Confirm against a real failed run before acting on this.** It is a plausible
-diagnosis reasoned from a symptom, not something observed.
+`linked-data-explorer` runs exactly that action against the same subscription and
+deploys its backend successfully. Its `azure-backend-acc.yml` uses
+`azure/webapps-deploy@v3` with a `publish-profile` secret, and it ran green on
+2026-08-29, including a post-deploy health check and endpoint verification. So SCM
+basic auth is **not** disabled subscription-wide, and the blocker here is
+per-App-Service configuration rather than a platform default.
+
+That also changes the recommended route. This item proposed OIDC — an app
+registration with a federated credential, `azure/login`, `permissions: id-token:
+write`. LDE shows a **publish-profile secret is sufficient**, which is materially
+cheaper and needs no app registration at all. Try it in this order:
+
+1. Download the publish profile for the App Service and store it as a repository
+   secret, the way LDE stores `AZURE_WEBAPP_PUBLISH_PROFILE_ACC`.
+2. Add the deploy step: `azure/webapps-deploy` with `publish-profile:` and
+   `package:` pointing at the artifact these workflows already build.
+3. Only if that fails, check whether basic auth is disabled on **that specific App
+   Service** — and reach for OIDC only if it is and cannot be re-enabled.
+
+The original caution still stands for step 3: confirm against a real failed run
+rather than reasoning from a symptom.
 
 Doing this also dissolves item 6 and closes the gap in item 1 at the same time,
 since a workflow-based deploy would install from the lockfile in CI.


### PR DESCRIPTION
Two documentation commits, both correcting claims that had drifted from what the
pipeline actually does.

## `efe1ebd` — the supply-chain register had gone stale

The Pinned table in `SECURITY-PIPELINE.md` still listed the pre-upgrade v4
digests. The v7 upgrades landed in `2026.08.33`; the register did not move with
them, **and every gate stayed green throughout**. That is precisely the drift the
document's own "What the audit cannot see" section predicts — Renovate maintains
the pins and never touches the register, and nothing checks the two agree.

| | was | now |
| --- | --- | --- |
| `actions/checkout` ×9 | `11d5960a` v4.4.0 | `3d3c42e5` v7.0.1 |
| `actions/setup-node` | `49933ea5` v4.4.0 ×8 | `820762786` v7.0.0 ×9 |
| `actions/upload-artifact` ×2 | `ea165f8d` v4.6.2 | `043fb46d` v7.0.1 |

Also adds `renovate-config-validator` (`npx --package renovate@44.50.3`), which
was missing from the table entirely — recorded as **manually maintained**, since
an inline npx argument is not a manifest entry Renovate will follow.

Three further claims were found **wrong rather than merely stale**:

- *"the workflows request `node-version: '20'`"* — eight do; the ninth requests
  `24` deliberately, because `renovate@44.50.3` declares `engines.node ^24.11.0`.
- The `.gitignore` rule `deploy-backend-to-*.sh` reads as though none of the
  deploy scripts is in the repository. Two of the three are **tracked** — an
  ignore rule does not untrack an already-committed file. That is *better* than
  the tidier claim implied, and worth stating accurately.
- The register-drift gap is no longer hypothetical, and is now recorded as
  something that already happened.

### Verified

Every falsifiable claim was checked against `acc` at `570f973`, since the commit
message rightly notes a count is as easy to falsify as a digest and nothing
catches either:

```
workflows: 9      uses: refs: 30      digest-pinned: 30
checkout x9  setup-node x9  static-web-apps-deploy x9  upload-artifact x2  zizmor-action x1
node-version 20: 8 workflows    node-version 24: 1 workflow
deploy-backend-to-acc.sh TRACKED   -to-prod.sh TRACKED   -acc-portable.sh not tracked
```

All correct.

## `b06c6f6` — follow-up item 2's hypothesis is disproved

Item 2 recorded, correctly hedged, that `azure/webapps-deploy` might be failing
because it authenticates over SCM basic auth, which Azure disables by default. It
asked for confirmation against a real failed run before anyone acted.

**`linked-data-explorer` answers it.** That repository runs
`azure/webapps-deploy@v3` with a `publish-profile` secret against the same
subscription and deploys its backend successfully — verified green on 2026-08-29,
including its post-deploy health check and v1 endpoint verification.

So SCM basic auth is **not** disabled subscription-wide, and the blocker here is
**per-App-Service configuration**.

That changes the remedy as much as the diagnosis. Item 2 proposed OIDC: an app
registration with a federated credential, `azure/login`, `id-token: write`. A
publish-profile secret is evidently sufficient, needs no app registration, and is
one repository secret plus one step. The item is rewritten as an ordered
three-step, with the original caution kept and moved to step 3 where it still
applies.

---

Hedging the claim rather than acting on it is why item 2 was still open and still
honest when the evidence turned up.