### PR TITLE
fix(deploy): make both backend deploy scripts runnable, and fail fast on a dead session

### DIFF
--- a/SECURITY-PIPELINE.md
+++ b/SECURITY-PIPELINE.md
@@ -127,19 +127,35 @@ The backend actually reaches acceptance and production through
 `deploy-backend-to-{acc,prod}.sh`, run from a developer machine. They exist
 because a workflow-based App Service deploy could not be made to work.
 
-**`.gitignore` lists them, but two of the three are tracked anyway.**
-`.gitignore` carries `deploy-backend-to-*.sh`, which reads as though none of them
-is in the repository. In fact `deploy-backend-to-acc.sh` and
-`deploy-backend-to-prod.sh` are both **tracked** — an ignore rule does not
-untrack a file that was already committed. Only
-`deploy-backend-to-acc-portable.sh` is genuinely ignored. This matters for the
-register's purpose: the deployed dependency tree is resolved by a script whose
-contents are reviewable in git, not by a local file nobody else can see. That is
-better than the ignore rule implies, and worth stating accurately rather than
-repeating the tidier claim. A
-`-portable` variant exists alongside them: the original targets Ubuntu, while the
-portable one falls back to the bsdtar Windows bundles at `System32\tar.exe`,
-because Info-ZIP's `zip` cannot be installed on a managed Windows laptop.
+**Both scripts are tracked and reviewable in git.** `.gitignore` carries a broad
+`deploy-backend-to-*.sh` followed by an explicit `!` negation for each script that
+belongs in the repository. The pattern exists so an ad-hoc local variant is not
+committed by accident; it was never hiding the real ones. That matters for this
+register's purpose - the deployed dependency tree is resolved by these scripts, so
+their contents have to be readable by someone other than the person who runs them.
+
+Until 29 August 2026 that was only half true. An untracked
+`deploy-backend-to-acc-portable.sh` carried an archiver fallback the tracked script
+lacked, and on a managed Windows laptop it was the one that actually ran - so the
+script really performing acceptance deploys was the single one nobody could
+review. It has now replaced `deploy-backend-to-acc.sh` outright. The merged script
+prefers Info-ZIP's `zip` when it is present, leaving Ubuntu behaviour unchanged,
+and falls back to the bsdtar that Windows bundles at `System32	ar.exe` when it is
+not, because `zip` cannot be installed on a managed Windows laptop.
+
+`deploy-backend-to-prod.sh` carries the identical archiver logic, so both scripts
+run from either platform. It was Ubuntu-only until the same day, for no reason
+other than that nobody had needed it from Windows yet - which would have been an
+unwelcome discovery during a production release.
+
+Both scripts now open with an Azure-session preflight. `az account show` is not
+sufficient for this and was the original trap: it reads cached local state and
+succeeds against a refresh token that expired days earlier, so the deploy failed
+only after both builds, the production install and the zip. Only a real ARM call
+proves the session works, so the preflight asks for the target App Service itself
+
+- covering an expired session, the wrong subscription, and a missing app in one
+  request, before the builds rather than after them.
 
 What that means for this document's scope:
 

--- a/deploy-backend-to-acc.sh
+++ b/deploy-backend-to-acc.sh
@@ -12,6 +12,79 @@ ZIP_FILE="$BACKEND_DIR/deployment-acc.zip"
 APP_NAME="ronl-business-api-acc"
 RESOURCE_GROUP="rg-ronl-acc"
 
+# ── Archiver ──────────────────────────────────────────────────────────────────
+# Info-ZIP's `zip` isn't installable on a managed Windows laptop, but Windows
+# bundles bsdtar (libarchive) at System32\tar.exe, which writes zip natively.
+# Git Bash also puts a `tar` on PATH — that one is GNU tar, which cannot write
+# zip at all, so a candidate is only accepted once it identifies itself as
+# bsdtar. Resolved up front so a missing archiver fails before the builds, not
+# after them.
+ARCHIVER=""
+BSDTAR=""
+
+resolve_archiver() {
+  if command -v zip >/dev/null 2>&1; then
+    ARCHIVER="zip"
+    return
+  fi
+
+  local candidates=() candidate
+  if command -v cygpath >/dev/null 2>&1 && [[ -n "${SYSTEMROOT:-}" ]]; then
+    candidates+=("$(cygpath -u "$SYSTEMROOT")/System32/tar.exe")
+  fi
+  candidates+=("/c/Windows/System32/tar.exe")
+  if command -v tar >/dev/null 2>&1; then
+    candidates+=("$(command -v tar)") # macOS ships bsdtar as plain `tar`
+  fi
+
+  for candidate in "${candidates[@]}"; do
+    if [[ -x "$candidate" ]] && "$candidate" --version 2>/dev/null | grep -qi bsdtar; then
+      ARCHIVER="bsdtar"
+      BSDTAR="$candidate"
+      return
+    fi
+  done
+
+  ARCHIVER="none"
+}
+
+# Archives the CURRENT directory into $1 (an absolute path).
+make_zip() {
+  local out="$1"
+
+  case "$ARCHIVER" in
+    zip)
+      zip -r "$out" .
+      ;;
+    bsdtar)
+      # Archiving '.' would write every entry with a './' prefix, and this
+      # Windows build has bsdtar's -s substitution compiled out, so name the
+      # top-level entries instead — that yields the same listing `zip -r .`
+      # does. The globs cover dotfiles too, which .deployment depends on.
+      local entries=() f
+      for f in * .[!.]* ..?*; do
+        if [[ -e "$f" ]]; then entries+=("$f"); fi
+      done
+      if [[ ${#entries[@]} -eq 0 ]]; then
+        echo "❌ Nothing to archive in $PWD — aborting"
+        exit 1
+      fi
+      # bsdtar is a native Windows binary and cannot read an MSYS-style path.
+      local win_out="$out"
+      if command -v cygpath >/dev/null 2>&1; then win_out="$(cygpath -w "$out")"; fi
+      # -v so the run scrolls file-by-file the way `zip -r` does. Without it
+      # bsdtar is completely silent, and a 126MB / ~17k-file deploy directory
+      # looks indistinguishable from a hang for a minute or more.
+      "$BSDTAR" --format zip -cvf "$win_out" "${entries[@]}"
+      ;;
+    *)
+      echo "❌ No archiver available — install Info-ZIP ('zip'), or run from a"
+      echo "   shell where Windows' System32\\tar.exe (bsdtar) is reachable."
+      exit 1
+      ;;
+  esac
+}
+
 # ── Safety: ACC deploy must come from a clean acc ─────────────────────────────
 CURRENT_BRANCH="$(git -C "$PROJECT_ROOT" rev-parse --abbrev-ref HEAD)"
 if [[ "$CURRENT_BRANCH" != "acc" ]]; then
@@ -23,6 +96,39 @@ if [[ -n "$(git -C "$PROJECT_ROOT" status --porcelain)" ]]; then
   exit 1
 fi
 echo "✅ On 'acc', clean working tree"
+
+resolve_archiver
+if [[ "$ARCHIVER" == "none" ]]; then
+  echo "❌ No archiver available — install Info-ZIP ('zip'), or run from a shell"
+  echo "   where Windows' System32\\tar.exe (bsdtar) is reachable."
+  exit 1
+fi
+echo "✅ Archiver: ${ARCHIVER}${BSDTAR:+ ($BSDTAR)}"
+
+# ── Preflight: a *working* Azure session ────────────────────────────────
+# `az account show` is NOT sufficient, however natural a check it looks. It
+# reads cached local state and succeeds happily against a refresh token that
+# expired days ago: on 2026-08-29 it reported a valid login whose token had in
+# fact expired on the 25th, and the deploy still died with AADSTS70043 after
+# both builds, the production install and the zip had run.
+#
+# Only a real ARM call proves the session works, so this asks for the target
+# app itself -- one request that covers three separate failures: an expired
+# session, the wrong subscription selected, and the app not existing in the
+# resource group this script names.
+#
+# Resolved up front for the same reason the archiver is: a one-command fix
+# should not cost several minutes of builds to discover.
+if ! az webapp show -n "$APP_NAME" -g "$RESOURCE_GROUP" -o none 2>/dev/null; then
+  echo "❌ Cannot reach $APP_NAME in $RESOURCE_GROUP."
+  echo "   Most often an expired session -- note that 'az account show' will"
+  echo "   still look perfectly fine. Re-authenticate:"
+  echo "     az logout && az login"
+  echo "   If the session is current, check the right subscription is selected:"
+  echo "     az account list -o table && az account set --subscription <name>"
+  exit 1
+fi
+echo "✅ Azure: $(az account show --query "join(' -- ', [user.name, name])" -o tsv 2>/dev/null)"
 
 echo "▶ Building shared package..."
 cd "$SHARED_DIR"
@@ -62,7 +168,7 @@ cp "$SHARED_DIR/package.json" "$DEPLOY_DIR/node_modules/@ronl/shared/"
 
 echo "▶ Creating zip..."
 cd "$DEPLOY_DIR"
-zip -r "$ZIP_FILE" .
+make_zip "$ZIP_FILE"
 echo "✅ $(du -sh "$ZIP_FILE" | cut -f1) — deployment-acc.zip"
 
 echo "▶ Deploying to Azure..."

--- a/deploy-backend-to-prod.sh
+++ b/deploy-backend-to-prod.sh
@@ -12,6 +12,79 @@ ZIP_FILE="$BACKEND_DIR/deployment-prod.zip"
 APP_NAME="ronl-business-api-prod"
 RESOURCE_GROUP="rg-ronl-prod"
 
+# ── Archiver ──────────────────────────────────────────────────────────────────
+# Info-ZIP's `zip` isn't installable on a managed Windows laptop, but Windows
+# bundles bsdtar (libarchive) at System32\tar.exe, which writes zip natively.
+# Git Bash also puts a `tar` on PATH — that one is GNU tar, which cannot write
+# zip at all, so a candidate is only accepted once it identifies itself as
+# bsdtar. Resolved up front so a missing archiver fails before the builds, not
+# after them.
+ARCHIVER=""
+BSDTAR=""
+
+resolve_archiver() {
+  if command -v zip >/dev/null 2>&1; then
+    ARCHIVER="zip"
+    return
+  fi
+
+  local candidates=() candidate
+  if command -v cygpath >/dev/null 2>&1 && [[ -n "${SYSTEMROOT:-}" ]]; then
+    candidates+=("$(cygpath -u "$SYSTEMROOT")/System32/tar.exe")
+  fi
+  candidates+=("/c/Windows/System32/tar.exe")
+  if command -v tar >/dev/null 2>&1; then
+    candidates+=("$(command -v tar)") # macOS ships bsdtar as plain `tar`
+  fi
+
+  for candidate in "${candidates[@]}"; do
+    if [[ -x "$candidate" ]] && "$candidate" --version 2>/dev/null | grep -qi bsdtar; then
+      ARCHIVER="bsdtar"
+      BSDTAR="$candidate"
+      return
+    fi
+  done
+
+  ARCHIVER="none"
+}
+
+# Archives the CURRENT directory into $1 (an absolute path).
+make_zip() {
+  local out="$1"
+
+  case "$ARCHIVER" in
+    zip)
+      zip -r "$out" .
+      ;;
+    bsdtar)
+      # Archiving '.' would write every entry with a './' prefix, and this
+      # Windows build has bsdtar's -s substitution compiled out, so name the
+      # top-level entries instead — that yields the same listing `zip -r .`
+      # does. The globs cover dotfiles too, which .deployment depends on.
+      local entries=() f
+      for f in * .[!.]* ..?*; do
+        if [[ -e "$f" ]]; then entries+=("$f"); fi
+      done
+      if [[ ${#entries[@]} -eq 0 ]]; then
+        echo "❌ Nothing to archive in $PWD — aborting"
+        exit 1
+      fi
+      # bsdtar is a native Windows binary and cannot read an MSYS-style path.
+      local win_out="$out"
+      if command -v cygpath >/dev/null 2>&1; then win_out="$(cygpath -w "$out")"; fi
+      # -v so the run scrolls file-by-file the way `zip -r` does. Without it
+      # bsdtar is completely silent, and a 126MB / ~17k-file deploy directory
+      # looks indistinguishable from a hang for a minute or more.
+      "$BSDTAR" --format zip -cvf "$win_out" "${entries[@]}"
+      ;;
+    *)
+      echo "❌ No archiver available — install Info-ZIP ('zip'), or run from a"
+      echo "   shell where Windows' System32\\tar.exe (bsdtar) is reachable."
+      exit 1
+      ;;
+  esac
+}
+
 # ── Safety: PROD deploy must come from a clean main ──────────────────────────
 CURRENT_BRANCH="$(git -C "$PROJECT_ROOT" rev-parse --abbrev-ref HEAD)"
 if [[ "$CURRENT_BRANCH" != "main" ]]; then
@@ -23,6 +96,39 @@ if [[ -n "$(git -C "$PROJECT_ROOT" status --porcelain)" ]]; then
   exit 1
 fi
 echo "✅ On 'main', clean working tree"
+
+resolve_archiver
+if [[ "$ARCHIVER" == "none" ]]; then
+  echo "❌ No archiver available — install Info-ZIP ('zip'), or run from a shell"
+  echo "   where Windows' System32\tar.exe (bsdtar) is reachable."
+  exit 1
+fi
+echo "✅ Archiver: ${ARCHIVER}${BSDTAR:+ ($BSDTAR)}"
+
+# ── Preflight: a *working* Azure session ────────────────────────────────
+# `az account show` is NOT sufficient, however natural a check it looks. It
+# reads cached local state and succeeds happily against a refresh token that
+# expired days ago: on 2026-08-29 it reported a valid login whose token had in
+# fact expired on the 25th, and the deploy still died with AADSTS70043 after
+# both builds, the production install and the zip had run.
+#
+# Only a real ARM call proves the session works, so this asks for the target
+# app itself -- one request that covers three separate failures: an expired
+# session, the wrong subscription selected, and the app not existing in the
+# resource group this script names.
+#
+# Resolved up front for the same reason the archiver is: a one-command fix
+# should not cost several minutes of builds to discover.
+if ! az webapp show -n "$APP_NAME" -g "$RESOURCE_GROUP" -o none 2>/dev/null; then
+  echo "❌ Cannot reach $APP_NAME in $RESOURCE_GROUP."
+  echo "   Most often an expired session -- note that 'az account show' will"
+  echo "   still look perfectly fine. Re-authenticate:"
+  echo "     az logout && az login"
+  echo "   If the session is current, check the right subscription is selected:"
+  echo "     az account list -o table && az account set --subscription <name>"
+  exit 1
+fi
+echo "✅ Azure: $(az account show --query "join(' -- ', [user.name, name])" -o tsv 2>/dev/null)"
 
 echo "▶ Building shared package..."
 cd "$SHARED_DIR"
@@ -62,7 +168,7 @@ cp "$SHARED_DIR/package.json" "$DEPLOY_DIR/node_modules/@ronl/shared/"
 
 echo "▶ Creating zip..."
 cd "$DEPLOY_DIR"
-zip -r "$ZIP_FILE" .
+make_zip "$ZIP_FILE"
 echo "✅ $(du -sh "$ZIP_FILE" | cut -f1) — deployment-prod.zip"
 
 echo "▶ Deploying to Azure..."


### PR DESCRIPTION
Three problems in the backend deploy scripts, each of which cost time before it
was understood.

## 1. The acceptance script that actually ran was untracked

`deploy-backend-to-acc.sh` called Info-ZIP's `zip` directly and therefore only
worked on Ubuntu. An untracked `deploy-backend-to-acc-portable.sh` carried a
bsdtar fallback and was the script really used on a managed Windows laptop, where
`zip` cannot be installed.

So **the script performing acceptance deploys was the one nobody else could read
or review** — while `SECURITY-PIPELINE.md` exists precisely to describe how the
deployed dependency tree is resolved.

The portable version now **replaces** the original outright. It prefers `zip`
when present, so Ubuntu behaviour is unchanged, and falls back to the bsdtar
Windows bundles at `System32\tar.exe` when it is not.

## 2. `deploy-backend-to-prod.sh` had the same limitation

Same archiver logic applied. Nobody had needed a production deploy from Windows
yet — an unwelcome thing to discover during a release.

## 3. Neither script checked the Azure session

An expired login surfaced only at `az webapp deploy`, the **last** step, after
both builds, the production install and the zip. Several minutes thrown away for
a one-command fix, repeatedly.

### The obvious check does not work

This is the part worth recording. **`az account show` reads cached local state**
and succeeds happily against a refresh token that expired days earlier. Observed
today:

```
$ az account show
Steven.Gort@ictu.nl — PDR - C1380          # looks fine

$ az webapp show -n ronl-business-api-acc -g rg-ronl-acc
AADSTS70043: The refresh token has expired ...
issued 2026-08-18, maximum allowed lifetime 604800
```

A preflight built on `az account show` would have sailed straight past that and
failed at exactly the same place as before.

### What it does instead

Both scripts ask for the **target App Service itself** — a real authenticated ARM
call covering three distinct failures in one request:

- an expired session
- the wrong subscription selected
- the app missing from the resource group the script names

It sits **before the builds**, matching the reasoning the archiver check already
states: a one-command fix should not cost several minutes of work to discover.

**Both failure modes were then confirmed live.** The expired token aborted it
first; after re-authenticating, `az login` defaulted to `Platform Regelbeheer 2025
- C1427` rather than `PDR - C1380`, and the preflight aborted again on the wrong
subscription — before any build ran, both times.

## Register updated, and one explanation corrected

`SECURITY-PIPELINE.md` attributed the two tracked scripts to an ignore rule being
unable to untrack an already-committed file. **That is not the mechanism** —
`.gitignore` carries explicit `!` negations for both, so they were never ignored.
Corrected, along with the portable merge, the preflight, and the closed prod gap.

## Verification

- `bash -n` clean on both scripts
- both now expose `resolve_archiver`, `make_zip` and the preflight; neither has a
  bare `zip -r` left
- `.gitignore` **unchanged** — its existing negations already cover both scripts
  once the portable variant stopped being a separate file

Not yet run end to end; the acceptance deploy follows once this lands, which is
the point of doing it in this order.