### PR TITLE
docs: point each open follow-up at its tracking issue

### DIFF
--- a/docs/superpowers/plans/2026-08-28-ci-follow-ups.md
+++ b/docs/superpowers/plans/2026-08-28-ci-follow-ups.md
@@ -18,6 +18,8 @@ file is the pending work.
 
 ## 1. Pin the backend deploy bundle's dependencies
 
+> Tracked as [#34](https://github.com/sgort/ronl-business-api/issues/34).
+
 The widest floating surface in the repository, and the only one on this list that
 is both reachable from our side and about what actually ships.
 
@@ -43,6 +45,8 @@ same treatment, or it will fail resolving a package that does not exist on the
 registry.
 
 ## 2. Move the backend deploy into a workflow
+
+> Tracked as [#35](https://github.com/sgort/ronl-business-api/issues/35).
 
 `azure-backend-{acc,prod}.yml` build, test, package a zip and call
 `upload-artifact`. **Neither has a deploy step**; nothing consumes the artifact.
@@ -82,6 +86,8 @@ since a workflow-based deploy would install from the lockfile in CI.
 
 ## 3. Pin the Node runtime
 
+> Tracked as [#36](https://github.com/sgort/ronl-business-api/issues/36).
+
 The workflows request `node-version: '20'`, which resolves to whatever 20.x
 `actions/setup-node` downloads at run time. Under a policy of "nothing a pipeline
 downloads may float", that is an exception.
@@ -99,6 +105,8 @@ artifact. `node-version-file: .nvmrc` would settle it in one place — once the
 three are meant to agree, which is the question to answer first.
 
 ## 4. Make PR previews worth opening
+
+> Tracked as [#37](https://github.com/sgort/ronl-business-api/issues/37).
 
 A preview frontend gets an ephemeral `*.azurestaticapps.net` origin that is not in
 the backend's `CORS_ORIGIN` allowlist, and `VITE_API_URL` is baked in at build
@@ -159,6 +167,8 @@ possible, so the answer may be narrower filters rather than simply more of them.
 
 ## 6. A `package.json`-only change triggers the backend build
 
+> Tracked as [#38](https://github.com/sgort/ronl-business-api/issues/38).
+
 `azure-backend-acc.yml` is path-filtered on `packages/backend/**`, which matches
 `package.json`. Adding a script or bumping `engines` fires a full backend build
 even though no source changed, and — because the habit is to run the deploy script
@@ -197,6 +207,8 @@ what closes the Node-runtime deprecation path — the pilot repo hit a warning t
 its pinned actions target a Node version the runner now force-upgrades.
 
 ## 8. Remove `dependencyDashboardApproval` from `renovate.json`
+
+> Tracked as draft PR [#20](https://github.com/sgort/ronl-business-api/pull/20), open since 2026-08-28.
 
 Set during adoption so Renovate raised nothing while the same workflow files were
 being pinned on a branch — two agents editing the same `uses:` lines would have


### PR DESCRIPTION
The follow-ups plan was the only record of this work, so learning what was still
outstanding meant opening and reading a planning document. The five open items now
have GitHub issues; the plan should say so rather than quietly duplicating them.

| Item | Tracked as |
| --- | --- |
| 1. Pin the backend deploy bundle's dependencies | #34 |
| 2. Move the backend deploy into a workflow | #35 |
| 3. Pin the Node runtime | #36 |
| 4. Make PR previews worth opening | #37 |
| 6. A `package.json`-only change triggers the backend build | #38 |
| 8. Remove `dependencyDashboardApproval` | draft PR #20, open since 2026-08-28 |

Items **5, 7 and 9** are already marked `Done` in place and get no link — there is
nothing left to track.

## Two judgement calls worth surfacing

**Item 8 got no issue.** PR #20 has covered it since 28 August. A second tracker
entry would only be something else to keep in sync.

**The issues repeat the plan's reasoning rather than linking back to it.** That
duplication is deliberate: an issue nobody can act on without first opening a
planning document in another repository folder is not much of an issue. Either can
now be read alone.

## Related context from today

Two of these items moved on substance, not just location:

- **#35 (item 2)** — its central hypothesis, that `azure/webapps-deploy` fails
  because Azure disables SCM basic auth by default, is **disproved**.
  `linked-data-explorer` runs exactly that action with a publish-profile secret
  against the same subscription and deployed green today. The blocker here is
  per-App-Service, and the fix is a publish profile rather than the OIDC app
  registration the item originally proposed.
- **#34 (item 1)** is now the widest floating surface left that is reachable from
  our side. Today's acceptance deploy resolved production dependencies fresh,
  lockfile-less, immediately after three dependency merges.