### PR TITLE
fix(operaton): let the untenanted fallback see a text-typed error body

### DIFF
--- a/packages/backend/src/services/operaton.service.test.ts
+++ b/packages/backend/src/services/operaton.service.test.ts
@@ -847,6 +847,34 @@ describe('deployed forms', () => {
     );
   });
 
+  it('getDeployedStartForm falls back when the error body is still a raw string', async () => {
+    // `responseType: 'text'` switches axios's JSON parsing off for the *error*
+    // body too, so Operaton's 404 arrives as an unparsed string and
+    // `response.data.message` is undefined. Every other tenant-scoped lookup
+    // parses its error body, which is why only the start form regressed:
+    // untenanted processes (AwbShellProcess and friends) 404'd for any citizen.
+    mockClient.get
+      .mockResolvedValueOnce({ data: [{ tenantId: null }] }) // resolveDeployedTenant
+      .mockRejectedValueOnce({
+        isAxiosError: true,
+        response: {
+          status: 404,
+          data: '{"type":"RestException","message":"No matching process definition with key: AwbShellProcess and tenant-id: flevoland","code":null}',
+        },
+      })
+      .mockResolvedValueOnce({ data: '{}', headers: { 'content-type': 'application/json' } });
+
+    await expect(svc.getDeployedStartForm('AwbShellProcess', 'flevoland')).resolves.toMatchObject({
+      contentType: 'application/json',
+    });
+
+    expect(mockClient.get).toHaveBeenNthCalledWith(
+      3,
+      '/process-definition/key/AwbShellProcess/deployed-start-form',
+      { responseType: 'text' }
+    );
+  });
+
   it('getDeployedTaskForm fetches the task deployed-form', async () => {
     mockClient.get.mockResolvedValue({
       data: '{}',

--- a/packages/backend/src/services/operaton.service.ts
+++ b/packages/backend/src/services/operaton.service.ts
@@ -1070,7 +1070,13 @@ export class OperatonService {
         return result as { data: T; headers: Record<string, string> };
       } catch (scopedError) {
         const scopedBody = axios.isAxiosError(scopedError) ? scopedError.response?.data : null;
-        const scopedMessage: string = scopedBody?.message ?? '';
+        // `responseType: 'text'` switches axios's JSON parsing off for the
+        // *error* body too, so callers that ask for text (the deployed start
+        // form) get Operaton's 404 as an unparsed string with no `.message`.
+        // Match the raw body in that case, or the fallback never fires and
+        // every untenanted process 404s for any caller carrying a tenant.
+        const scopedMessage: string =
+          typeof scopedBody === 'string' ? scopedBody : (scopedBody?.message ?? '');
         if (!scopedMessage.includes('No matching process definition with key')) {
           throw scopedError;
         }


### PR DESCRIPTION
Logging in as `test-citizen-flevoland` on ACC, the Kapvergunning form would not
load: `GET /v1/process/AwbShellProcess/start-form` answered **404**.

## Root cause

`getByKeyWithTenantFallback` tries a tenant-scoped Operaton lookup first and
falls back to the untenanted one when the engine reports *"No matching process
definition with key…"*. It recognises that by reading `error.response.data.message`.

`getDeployedStartForm` is the only caller that passes `{ responseType: 'text' }`,
and axios disables JSON parsing of the **error** body when `responseType` is set.
Verified against the live ACC engine:

```
responseType=(default)  status=404  typeof data=object  data.message="No matching process definition with key: …"
responseType=text       status=404  typeof data=string  data.message=undefined
```

So `scopedMessage` is `''`, the guard rethrows, and the fallback **cannot fire
under any input**. Every process deployed without a tenant answers 404
`FORM_NOT_FOUND` to any caller carrying one — and the citizen's `tenantId` comes
straight from the `municipality` claim (`jwt.middleware.ts:102`).

On ACC that was **21 of 23** latest-version definitions: only `RipR21Process` and
`processAanvraagInfoBezwaar` are tenant-scoped. Zorgtoeslag, Thuisbatterij,
Bezwaar, TreeFelling and the rest were failing the same way.

`getBoardOwner` uses the same helper without `responseType`, so its error body is
parsed and its fallback works. That asymmetry is why only start forms broke.

## The change

Match the raw body when it has not been parsed:

```ts
const scopedMessage: string =
  typeof scopedBody === 'string' ? scopedBody : (scopedBody?.message ?? '');
```

No change to tenant policy — this only makes the existing fallback able to
recognise the error it was written to catch.

## Why the suite stayed green

The existing fallback test mocked the error body as an already-parsed object,
which the real code path never produces. The added test uses the shape axios
actually delivers, and fails without the fix:

```
Received promise rejected instead of resolved
Rejected to value: {"isAxiosError": true, "response": {"data": "{\"type\":\"RestException\", …
```

## Verification

| | |
| --- | --- |
| `operaton.service.test.ts` + `process.routes.test.ts` | **203 passed** (`--runInBand`) |
| `npm test --workspace=packages/backend` | green |
| `tsc --noEmit` (backend) | clean |
| Prettier · ESLint | clean |

## Not covered by this PR

Deploying `AwbShellProcess` under tenant `flevoland` resolves the process key but
then hits `ENGINE-03109 Cannot resolve a unique Operaton Form definition for key
'kapvergunning-start' because it exists for multiple tenants` — the forms bind
`camunda:formRefBinding="latest"`, which resolves by key across the repository,
and the key now exists under both `null` and `flevoland`.

That fix belongs in LDE: rebind to `deployment` in `AwbShellProcess.bpmn`
(`kapvergunning-start`, `awb-notify-applicant`) and `TreeFellingPermitSubProcess.bpmn`
(`tree-felling-review`), then redeploy. All 128 `formRefBinding` occurrences across
LDE's BPMN sources are `latest`, so every process still to be tenanted will hit
this. This PR is what keeps the untenanted ones working meanwhile.
