### PR TITLE
R2.2 in the Faseladder, and phase-parameterised RIP endpoints

### DIFF
--- a/packages/backend/src/routes/rip.routes.test.ts
+++ b/packages/backend/src/routes/rip.routes.test.ts
@@ -1,6 +1,8 @@
 /**
- * Route tests for /v1/rip/phase1 (jwt + tenant) — active/completed lists and the
- * documents endpoint with tenant-isolation. operatonService is mocked.
+ * Route tests for /v1/rip (jwt + tenant) — the phase-parameterised
+ * active/completed lists, the instance documents endpoint with
+ * tenant-isolation, and the catalogue-driven phase endpoints.
+ * operatonService is mocked.
  */
 
 import type { Request, Response, NextFunction } from 'express';
@@ -21,9 +23,9 @@ jest.mock('@middleware/tenant.middleware', () => ({
 }));
 jest.mock('@services/operaton.service', () => ({
   operatonService: {
-    getRipPhase1ActiveList: jest.fn(),
-    getRipPhase1CompletedList: jest.fn(),
-    getRipPhase1Documents: jest.fn(),
+    getRipPhaseActiveList: jest.fn(),
+    getRipPhaseCompletedList: jest.fn(),
+    getRipInstanceDocuments: jest.fn(),
     getDeployedProcessKeys: jest.fn(),
     getPhaseInstanceCounts: jest.fn(),
   },
@@ -42,9 +44,9 @@ import { RIP_PHASE_KEYS } from '@ronl/shared';
 const MODELLED_KEYS = RIP_PHASE_KEYS.map((p) => p.processDefinitionKey).filter(Boolean);
 
 const svc = operatonService as unknown as {
-  getRipPhase1ActiveList: jest.Mock;
-  getRipPhase1CompletedList: jest.Mock;
-  getRipPhase1Documents: jest.Mock;
+  getRipPhaseActiveList: jest.Mock;
+  getRipPhaseCompletedList: jest.Mock;
+  getRipInstanceDocuments: jest.Mock;
   getDeployedProcessKeys: jest.Mock;
   getPhaseInstanceCounts: jest.Mock;
 };
@@ -57,35 +59,79 @@ beforeEach(() => jest.clearAllMocks());
 
 describe('lists', () => {
   it('401 without a token', async () => {
-    const res = await request(app).get('/v1/rip/phase1/active');
+    const res = await request(app).get('/v1/rip/phases/R2.1/active');
     expect(res.status).toBe(401);
   });
 
-  it('GET /phase1/active returns the tenant list', async () => {
-    svc.getRipPhase1ActiveList.mockResolvedValue([{ id: 'i1' }]);
-    const res = await auth(request(app).get('/v1/rip/phase1/active'));
+  it('GET /phases/:code/active returns the tenant list', async () => {
+    svc.getRipPhaseActiveList.mockResolvedValue([{ id: 'i1' }]);
+    const res = await auth(request(app).get('/v1/rip/phases/R2.1/active'));
     expect(res.status).toBe(200);
     expect(res.body.data).toEqual([{ id: 'i1' }]);
-    expect(svc.getRipPhase1ActiveList).toHaveBeenCalledWith('flevoland');
+    expect(svc.getRipPhaseActiveList).toHaveBeenCalledWith('RipR21Process', 'flevoland');
   });
 
-  it('GET /phase1/active → 500 on service failure', async () => {
-    svc.getRipPhase1ActiveList.mockRejectedValue(new Error('boom'));
-    const res = await auth(request(app).get('/v1/rip/phase1/active'));
+  it('GET /phases/:code/active resolves each modelled phase to its own key', async () => {
+    svc.getRipPhaseActiveList.mockResolvedValue([]);
+    await auth(request(app).get('/v1/rip/phases/R2.2/active'));
+    expect(svc.getRipPhaseActiveList).toHaveBeenCalledWith('RipR22Process', 'flevoland');
+  });
+
+  it('GET /phases/:code/active answers 404 for a phase code the catalogue has never heard of', async () => {
+    const res = await auth(request(app).get('/v1/rip/phases/R9.9/active'));
+    expect(res.status).toBe(404);
+    expect(res.body.error.code).toBe('UNKNOWN_PHASE');
+    expect(svc.getRipPhaseActiveList).not.toHaveBeenCalled();
+  });
+
+  it('GET /phases/:code/active answers 409, not an empty list, for a known but unmodelled phase', async () => {
+    // The distinction that matters: a caller must be able to tell "this phase
+    // has no process yet" from "this phase is deployed and currently idle".
+    const res = await auth(request(app).get('/v1/rip/phases/R2.3/active'));
+    expect(res.status).toBe(409);
+    expect(res.body.error.code).toBe('PHASE_NOT_MODELLED');
+    expect(svc.getRipPhaseActiveList).not.toHaveBeenCalled();
+  });
+
+  it('GET /phases/:code/active → 500 on service failure', async () => {
+    svc.getRipPhaseActiveList.mockRejectedValue(new Error('boom'));
+    const res = await auth(request(app).get('/v1/rip/phases/R2.1/active'));
     expect(res.status).toBe(500);
     expect(res.body.error.code).toBe('RIP_LIST_FAILED');
   });
 
-  it('GET /phase1/completed returns the tenant list', async () => {
-    svc.getRipPhase1CompletedList.mockResolvedValue([{ id: 'c1' }]);
-    const res = await auth(request(app).get('/v1/rip/phase1/completed'));
+  it('GET /phases/:code/completed returns the tenant list', async () => {
+    svc.getRipPhaseCompletedList.mockResolvedValue([{ id: 'c1' }]);
+    const res = await auth(request(app).get('/v1/rip/phases/R2.1/completed'));
     expect(res.status).toBe(200);
-    expect(svc.getRipPhase1CompletedList).toHaveBeenCalledWith('flevoland');
+    expect(svc.getRipPhaseCompletedList).toHaveBeenCalledWith('RipR21Process', 'flevoland');
   });
 
-  it('GET /phase1/completed → 500 on service failure', async () => {
-    svc.getRipPhase1CompletedList.mockRejectedValue(new Error('boom'));
-    const res = await auth(request(app).get('/v1/rip/phase1/completed'));
+  it('GET /phases/:code/completed answers 404 for an unknown phase', async () => {
+    const res = await auth(request(app).get('/v1/rip/phases/R9.9/completed'));
+    expect(res.status).toBe(404);
+    expect(res.body.error.code).toBe('UNKNOWN_PHASE');
+  });
+
+  it('GET /phases/:code/completed answers 409 for a known but unmodelled phase', async () => {
+    const res = await auth(request(app).get('/v1/rip/phases/R2.3/completed'));
+    expect(res.status).toBe(409);
+    expect(res.body.error.code).toBe('PHASE_NOT_MODELLED');
+  });
+
+  it('the fixed /phases routes are not swallowed by /phases/:code', async () => {
+    // deployment-status and counts sit one path segment shorter than
+    // /phases/:code/active so they cannot collide, but the arrangement is
+    // load-bearing enough to pin.
+    svc.getDeployedProcessKeys.mockResolvedValue([]);
+    svc.getPhaseInstanceCounts.mockResolvedValue({});
+    expect((await auth(request(app).get('/v1/rip/phases/deployment-status'))).status).toBe(200);
+    expect((await auth(request(app).get('/v1/rip/phases/counts'))).status).toBe(200);
+  });
+
+  it('GET /phases/:code/completed → 500 on service failure', async () => {
+    svc.getRipPhaseCompletedList.mockRejectedValue(new Error('boom'));
+    const res = await auth(request(app).get('/v1/rip/phases/R2.1/completed'));
     expect(res.status).toBe(500);
     expect(res.body.error.code).toBe('RIP_COMPLETED_LIST_FAILED');
   });
@@ -139,34 +185,34 @@ describe('GET /phases/counts', () => {
   });
 });
 
-describe('GET /phase1/:instanceId/documents', () => {
+describe('GET /instances/:instanceId/documents', () => {
   it('returns documents when the instance belongs to the tenant', async () => {
-    svc.getRipPhase1Documents.mockResolvedValue({
+    svc.getRipInstanceDocuments.mockResolvedValue({
       variables: { municipality: 'flevoland' },
       intakeReport: { t: 'intake' },
       psuReport: null,
       pdp: null,
     });
-    const res = await auth(request(app).get('/v1/rip/phase1/pi-1/documents'));
+    const res = await auth(request(app).get('/v1/rip/instances/pi-1/documents'));
     expect(res.status).toBe(200);
     expect(res.body.data.intakeReport).toEqual({ t: 'intake' });
   });
 
   it('403 when the instance belongs to another tenant', async () => {
-    svc.getRipPhase1Documents.mockResolvedValue({
+    svc.getRipInstanceDocuments.mockResolvedValue({
       variables: { municipality: 'utrecht' },
       intakeReport: null,
       psuReport: null,
       pdp: null,
     });
-    const res = await auth(request(app).get('/v1/rip/phase1/pi-1/documents'));
+    const res = await auth(request(app).get('/v1/rip/instances/pi-1/documents'));
     expect(res.status).toBe(403);
     expect(res.body.error.code).toBe('FORBIDDEN');
   });
 
   it('500 on service failure', async () => {
-    svc.getRipPhase1Documents.mockRejectedValue(new Error('boom'));
-    const res = await auth(request(app).get('/v1/rip/phase1/pi-1/documents'));
+    svc.getRipInstanceDocuments.mockRejectedValue(new Error('boom'));
+    const res = await auth(request(app).get('/v1/rip/instances/pi-1/documents'));
     expect(res.status).toBe(500);
     expect(res.body.error.code).toBe('RIP_DOCUMENTS_FAILED');
   });
@@ -178,11 +224,11 @@ describe('handler guards for an authenticated request without a user', () => {
   const noUser = (r: request.Test) => r.set('x-test-no-user', '1');
 
   it.each([
-    ['/v1/rip/phase1/active'],
+    ['/v1/rip/phases/R2.1/active'],
     ['/v1/rip/phases/deployment-status'],
     ['/v1/rip/phases/counts'],
-    ['/v1/rip/phase1/pi-1/documents'],
-    ['/v1/rip/phase1/completed'],
+    ['/v1/rip/instances/pi-1/documents'],
+    ['/v1/rip/phases/R2.1/completed'],
   ])('%s → 401 UNAUTHORIZED', async (path) => {
     const res = await noUser(request(app).get(path));
     expect(res.status).toBe(401);
@@ -193,9 +239,9 @@ describe('handler guards for an authenticated request without a user', () => {
 describe('non-Error rejections', () => {
   // Operaton failures surface as strings often enough that the ternary's
   // 'Unknown error' fallback is a real path, not a formality.
-  it('GET /phase1/active still answers 500', async () => {
-    svc.getRipPhase1ActiveList.mockRejectedValue('socket hang up');
-    const res = await auth(request(app).get('/v1/rip/phase1/active'));
+  it('GET /phases/:code/active still answers 500', async () => {
+    svc.getRipPhaseActiveList.mockRejectedValue('socket hang up');
+    const res = await auth(request(app).get('/v1/rip/phases/R2.1/active'));
     expect(res.status).toBe(500);
     expect(res.body.error.code).toBe('RIP_LIST_FAILED');
   });
@@ -215,16 +261,16 @@ describe('non-Error rejections', () => {
     expect(res.body.error.code).toBe('PHASE_COUNTS_FAILED');
   });
 
-  it('GET /phase1/:instanceId/documents still answers 500', async () => {
-    svc.getRipPhase1Documents.mockRejectedValue('socket hang up');
-    const res = await auth(request(app).get('/v1/rip/phase1/pi-1/documents'));
+  it('GET /instances/:instanceId/documents still answers 500', async () => {
+    svc.getRipInstanceDocuments.mockRejectedValue('socket hang up');
+    const res = await auth(request(app).get('/v1/rip/instances/pi-1/documents'));
     expect(res.status).toBe(500);
     expect(res.body.error.code).toBe('RIP_DOCUMENTS_FAILED');
   });
 
-  it('GET /phase1/completed still answers 500', async () => {
-    svc.getRipPhase1CompletedList.mockRejectedValue('socket hang up');
-    const res = await auth(request(app).get('/v1/rip/phase1/completed'));
+  it('GET /phases/:code/completed still answers 500', async () => {
+    svc.getRipPhaseCompletedList.mockRejectedValue('socket hang up');
+    const res = await auth(request(app).get('/v1/rip/phases/R2.1/completed'));
     expect(res.status).toBe(500);
     expect(res.body.error.code).toBe('RIP_COMPLETED_LIST_FAILED');
   });
@@ -232,13 +278,13 @@ describe('non-Error rejections', () => {
 
 describe('tenant isolation when the instance has no municipality', () => {
   it('serves the documents rather than 403, since there is nothing to mismatch', async () => {
-    svc.getRipPhase1Documents.mockResolvedValue({
+    svc.getRipInstanceDocuments.mockResolvedValue({
       variables: {},
       intakeReport: { t: 'intake' },
       psuReport: null,
       pdp: null,
     });
-    const res = await auth(request(app).get('/v1/rip/phase1/pi-1/documents'));
+    const res = await auth(request(app).get('/v1/rip/instances/pi-1/documents'));
     expect(res.status).toBe(200);
     expect(res.body.data.intakeReport).toEqual({ t: 'intake' });
   });

--- a/packages/backend/src/routes/rip.routes.test.ts
+++ b/packages/backend/src/routes/rip.routes.test.ts
@@ -36,6 +36,10 @@ import express from 'express';
 import request from 'supertest';
 import ripRouter from './rip.routes';
 import { operatonService } from '@services/operaton.service';
+import { RIP_PHASE_KEYS } from '@ronl/shared';
+
+/** Every phase modelled as BPMN — the exact list both phase endpoints query. */
+const MODELLED_KEYS = RIP_PHASE_KEYS.map((p) => p.processDefinitionKey).filter(Boolean);
 
 const svc = operatonService as unknown as {
   getRipPhase1ActiveList: jest.Mock;
@@ -98,7 +102,7 @@ describe('GET /phases/deployment-status', () => {
     const res = await auth(request(app).get('/v1/rip/phases/deployment-status'));
     expect(res.status).toBe(200);
     expect(res.body.data).toEqual({ deployedKeys: ['RipR21Process'] });
-    expect(svc.getDeployedProcessKeys).toHaveBeenCalledWith(['RipR21Process'], 'flevoland');
+    expect(svc.getDeployedProcessKeys).toHaveBeenCalledWith(MODELLED_KEYS, 'flevoland');
   });
 
   it('500 with DEPLOYMENT_STATUS_FAILED on service failure', async () => {

--- a/packages/backend/src/routes/rip.routes.ts
+++ b/packages/backend/src/routes/rip.routes.ts
@@ -1,4 +1,5 @@
 import express from 'express';
+import type { Response } from 'express';
 import { jwtMiddleware } from '@auth/jwt.middleware';
 import { tenantMiddleware } from '@middleware/tenant.middleware';
 import { operatonService } from '@services/operaton.service';
@@ -11,22 +12,63 @@ const logger = createLogger('rip-routes');
 router.use(jwtMiddleware);
 router.use(tenantMiddleware);
 
+/** Every RIP phase modelled as BPMN, in ladder order. */
+const modelledKeys = () =>
+  RIP_PHASE_KEYS.map((p) => p.processDefinitionKey).filter((k): k is string => !!k);
+
 /**
- * GET /v1/rip/phase1/active
- * List active RipR21Process instances for the caseworker's municipality.
+ * Resolve a `:code` path param to its process-definition key, answering on
+ * `res` and returning null when it cannot.
+ *
+ * The two failure modes are deliberately distinct. An unknown code is a
+ * client error — a typo or a stale link — and 404s. A known code with no
+ * process model yet (R2.3 today) is a state of the world, not a bad request,
+ * and 409s with the phase echoed back. Neither returns an empty list: a phase
+ * that has no deployed process must not be indistinguishable from a deployed
+ * one that happens to have no instances.
  */
-router.get('/phase1/active', async (req, res) => {
+function resolvePhaseKey(code: string, res: Response): string | null {
+  const phase = RIP_PHASE_KEYS.find((p) => p.code === code);
+  if (!phase) {
+    res.status(404).json({
+      success: false,
+      error: { code: 'UNKNOWN_PHASE', message: `Unknown RIP phase '${code}'` },
+    });
+    return null;
+  }
+  if (!phase.processDefinitionKey) {
+    res.status(409).json({
+      success: false,
+      error: {
+        code: 'PHASE_NOT_MODELLED',
+        message: `RIP phase '${code}' has no process model deployed yet`,
+      },
+    });
+    return null;
+  }
+  return phase.processDefinitionKey;
+}
+
+/**
+ * GET /v1/rip/phases/:code/active
+ * List active instances of one RIP phase for the caseworker's municipality.
+ */
+router.get('/phases/:code/active', async (req, res) => {
   if (!req.user) {
     return res.status(401).json({
       success: false,
       error: { code: 'UNAUTHORIZED', message: 'Authentication required' },
     });
   }
+  const { code } = req.params;
+  const key = resolvePhaseKey(code, res);
+  if (!key) return;
   try {
-    const list = await operatonService.getRipPhase1ActiveList(req.user.tenantId);
+    const list = await operatonService.getRipPhaseActiveList(key, req.user.tenantId);
     res.json({ success: true, data: list });
   } catch (error) {
-    logger.error('Failed to list active RIP Phase 1 instances', {
+    logger.error('Failed to list active RIP phase instances', {
+      phaseCode: code,
       tenantId: req.user.tenantId,
       error: error instanceof Error ? error.message : 'Unknown error',
     });
@@ -34,7 +76,40 @@ router.get('/phase1/active', async (req, res) => {
       success: false,
       error: {
         code: 'RIP_LIST_FAILED',
-        message: 'Failed to retrieve active RIP Phase 1 instances',
+        message: 'Failed to retrieve active RIP phase instances',
+      },
+    });
+  }
+});
+
+/**
+ * GET /v1/rip/phases/:code/completed
+ * List completed instances of one RIP phase for the caseworker's municipality.
+ */
+router.get('/phases/:code/completed', async (req, res) => {
+  if (!req.user) {
+    return res.status(401).json({
+      success: false,
+      error: { code: 'UNAUTHORIZED', message: 'Authentication required' },
+    });
+  }
+  const { code } = req.params;
+  const key = resolvePhaseKey(code, res);
+  if (!key) return;
+  try {
+    const list = await operatonService.getRipPhaseCompletedList(key, req.user.tenantId);
+    res.json({ success: true, data: list });
+  } catch (error) {
+    logger.error('Failed to list completed RIP phase instances', {
+      phaseCode: code,
+      tenantId: req.user.tenantId,
+      error: error instanceof Error ? error.message : 'Unknown error',
+    });
+    res.status(500).json({
+      success: false,
+      error: {
+        code: 'RIP_COMPLETED_LIST_FAILED',
+        message: 'Failed to retrieve completed RIP phase instances',
       },
     });
   }
@@ -53,8 +128,10 @@ router.get('/phases/deployment-status', async (req, res) => {
     });
   }
   try {
-    const keys = RIP_PHASE_KEYS.map((p) => p.processDefinitionKey).filter((k): k is string => !!k);
-    const deployedKeys = await operatonService.getDeployedProcessKeys(keys, req.user.tenantId);
+    const deployedKeys = await operatonService.getDeployedProcessKeys(
+      modelledKeys(),
+      req.user.tenantId
+    );
     res.json({ success: true, data: { deployedKeys } });
   } catch (error) {
     logger.error('Failed to fetch RIP phase deployment status', {
@@ -83,8 +160,10 @@ router.get('/phases/counts', async (req, res) => {
     });
   }
   try {
-    const keys = RIP_PHASE_KEYS.map((p) => p.processDefinitionKey).filter((k): k is string => !!k);
-    const deployedKeys = await operatonService.getDeployedProcessKeys(keys, req.user.tenantId);
+    const deployedKeys = await operatonService.getDeployedProcessKeys(
+      modelledKeys(),
+      req.user.tenantId
+    );
     const counts = await operatonService.getPhaseInstanceCounts(deployedKeys, req.user.tenantId);
     res.json({ success: true, data: { counts } });
   } catch (error) {
@@ -103,10 +182,13 @@ router.get('/phases/counts', async (req, res) => {
 });
 
 /**
- * GET /v1/rip/phase1/:instanceId/documents
- * Fetch all three document templates + current process variables for a RIP Phase 1 instance.
+ * GET /v1/rip/instances/:instanceId/documents
+ * Fetch an instance's document templates + current process variables.
+ *
+ * Keyed by instance rather than by phase: the deployment is resolved from the
+ * instance itself, so no phase code is needed and none is asked for.
  */
-router.get('/phase1/:instanceId/documents', async (req, res) => {
+router.get('/instances/:instanceId/documents', async (req, res) => {
   if (!req.user) {
     return res.status(401).json({
       success: false,
@@ -115,7 +197,7 @@ router.get('/phase1/:instanceId/documents', async (req, res) => {
   }
   const { instanceId } = req.params;
   try {
-    const result = await operatonService.getRipPhase1Documents(instanceId);
+    const result = await operatonService.getRipInstanceDocuments(instanceId);
 
     // Tenant isolation
     if (result.variables.municipality && result.variables.municipality !== req.user.tenantId) {
@@ -127,7 +209,7 @@ router.get('/phase1/:instanceId/documents', async (req, res) => {
 
     res.json({ success: true, data: result });
   } catch (error) {
-    logger.error('Failed to fetch RIP Phase 1 documents', {
+    logger.error('Failed to fetch RIP instance documents', {
       instanceId,
       error: error instanceof Error ? error.message : 'Unknown error',
     });
@@ -135,36 +217,7 @@ router.get('/phase1/:instanceId/documents', async (req, res) => {
       success: false,
       error: {
         code: 'RIP_DOCUMENTS_FAILED',
-        message: 'Failed to retrieve RIP Phase 1 documents',
-      },
-    });
-  }
-});
-
-/**
- * GET /v1/rip/phase1/completed
- * List completed RipR21Process instances for the caseworker's municipality.
- */
-router.get('/phase1/completed', async (req, res) => {
-  if (!req.user) {
-    return res.status(401).json({
-      success: false,
-      error: { code: 'UNAUTHORIZED', message: 'Authentication required' },
-    });
-  }
-  try {
-    const list = await operatonService.getRipPhase1CompletedList(req.user.tenantId);
-    res.json({ success: true, data: list });
-  } catch (error) {
-    logger.error('Failed to list completed RIP Phase 1 instances', {
-      tenantId: req.user.tenantId,
-      error: error instanceof Error ? error.message : 'Unknown error',
-    });
-    res.status(500).json({
-      success: false,
-      error: {
-        code: 'RIP_COMPLETED_LIST_FAILED',
-        message: 'Failed to retrieve completed RIP Phase 1 instances',
+        message: 'Failed to retrieve RIP instance documents',
       },
     });
   }

--- a/packages/backend/src/services/operaton.service.test.ts
+++ b/packages/backend/src/services/operaton.service.test.ts
@@ -215,22 +215,27 @@ describe('startProcess', () => {
   });
 });
 
-describe('getRipPhase1ActiveList / getRipPhase1CompletedList', () => {
-  it('getRipPhase1ActiveList filters by the RipR21Process key', async () => {
+describe('getRipPhaseActiveList / getRipPhaseCompletedList', () => {
+  // A key the catalogue does not carry, on purpose: if either method ever
+  // reverts to a hardcoded RipR21Process these assertions fail, which the
+  // old R2.1-keyed versions of these tests could not detect.
+  const KEY = 'RipSomeOtherPhaseProcess';
+
+  it('getRipPhaseActiveList filters by the key it is given', async () => {
     mockClient.post.mockResolvedValue({ data: [] });
-    await svc.getRipPhase1ActiveList('flevoland');
+    await svc.getRipPhaseActiveList(KEY, 'flevoland');
     expect(mockClient.post).toHaveBeenCalledWith(
       '/history/process-instance',
-      expect.objectContaining({ processDefinitionKey: 'RipR21Process' })
+      expect.objectContaining({ processDefinitionKey: KEY, unfinished: true })
     );
   });
 
-  it('getRipPhase1CompletedList filters by the RipR21Process key', async () => {
+  it('getRipPhaseCompletedList filters by the key it is given', async () => {
     mockClient.post.mockResolvedValue({ data: [] });
-    await svc.getRipPhase1CompletedList('flevoland');
+    await svc.getRipPhaseCompletedList(KEY, 'flevoland');
     expect(mockClient.post).toHaveBeenCalledWith(
       '/history/process-instance',
-      expect.objectContaining({ processDefinitionKey: 'RipR21Process' })
+      expect.objectContaining({ processDefinitionKey: KEY, finished: true })
     );
   });
 });
@@ -1133,7 +1138,7 @@ describe('setProcessVariables', () => {
 });
 
 describe('document bundles', () => {
-  it('getRipPhase1Documents returns variables plus present templates (null for absent)', async () => {
+  it('getRipInstanceDocuments returns variables plus present templates (null for absent)', async () => {
     routeGet([
       [/\/history\/variable-instance$/, { data: [{ name: 'projectNumber', value: 'P1' }] }],
       [/\/history\/process-instance\/pi1$/, { data: { processDefinitionId: 'pd1' } }],
@@ -1142,7 +1147,7 @@ describe('document bundles', () => {
       [/\/deployment\/dep1\/resources\/r1\/data$/, { data: '{"t":"intake"}' }],
     ]);
 
-    const res = await svc.getRipPhase1Documents('pi1');
+    const res = await svc.getRipInstanceDocuments('pi1');
     expect(res.variables).toEqual({ projectNumber: 'P1' });
     expect(res.intakeReport).toEqual({ t: 'intake' });
     expect(res.psuReport).toBeNull();
@@ -1175,7 +1180,7 @@ describe('document bundles', () => {
 });
 
 describe('archive list builders', () => {
-  it('getRipPhase1ActiveList maps project variables with fallbacks', async () => {
+  it('getRipPhaseActiveList maps project variables with fallbacks', async () => {
     mockClient.post.mockResolvedValue({ data: [{ id: 'i1', startTime: 's' }] });
     mockClient.get.mockResolvedValue({
       data: [
@@ -1184,7 +1189,7 @@ describe('archive list builders', () => {
       ],
     });
 
-    const res = await svc.getRipPhase1ActiveList('flevoland');
+    const res = await svc.getRipPhaseActiveList('RipR21Process', 'flevoland');
     expect(res[0]).toEqual({
       id: 'i1',
       startTime: 's',
@@ -1199,13 +1204,13 @@ describe('archive list builders', () => {
     );
   });
 
-  it('getRipPhase1CompletedList maps completed instances', async () => {
+  it('getRipPhaseCompletedList maps completed instances', async () => {
     mockClient.post.mockResolvedValue({ data: [{ id: 'i1', startTime: 's', endTime: 'e' }] });
     mockClient.get.mockResolvedValue({
       data: [{ processInstanceId: 'i1', name: 'projectNumber', value: 'P1' }],
     });
 
-    const res = await svc.getRipPhase1CompletedList('flevoland');
+    const res = await svc.getRipPhaseCompletedList('RipR21Process', 'flevoland');
     expect(res[0]).toMatchObject({ id: 'i1', endTime: 'e', projectNumber: 'P1', projectName: '—' });
     expect(mockClient.post).toHaveBeenCalledWith(
       '/history/process-instance',
@@ -1242,7 +1247,7 @@ describe('archive list builders', () => {
 
   it('list builders return [] when there are no instances', async () => {
     mockClient.post.mockResolvedValue({ data: [] });
-    await expect(svc.getRipPhase1ActiveList('t')).resolves.toEqual([]);
+    await expect(svc.getRipPhaseActiveList('RipR21Process', 't')).resolves.toEqual([]);
     await expect(svc.getCapacityClaimActiveList('t')).resolves.toEqual([]);
   });
 });
@@ -1430,10 +1435,15 @@ describe('list mappers when the history variables are sparse', () => {
   // mappers have to skip variables they do not care about, tolerate a null
   // value, and fall back for an instance that contributed no variables at all.
   const LISTS: Array<[string, () => Promise<Array<Record<string, unknown>>>, string, string]> = [
-    ['getRipPhase1ActiveList', () => svc.getRipPhase1ActiveList('flevoland'), 'projectNumber', '—'],
     [
-      'getRipPhase1CompletedList',
-      () => svc.getRipPhase1CompletedList('flevoland'),
+      'getRipPhaseActiveList',
+      () => svc.getRipPhaseActiveList('RipR21Process', 'flevoland'),
+      'projectNumber',
+      '—',
+    ],
+    [
+      'getRipPhaseCompletedList',
+      () => svc.getRipPhaseCompletedList('RipR21Process', 'flevoland'),
       'projectNumber',
       '—',
     ],

--- a/packages/backend/src/services/operaton.service.ts
+++ b/packages/backend/src/services/operaton.service.ts
@@ -1323,10 +1323,15 @@ export class OperatonService {
   }
 
   /**
-   * List active (unfinished) RipR21Process instances for a municipality,
-   * enriched with projectNumber, projectName, edocsWorkspaceId.
+   * List active (unfinished) instances of one RIP phase process for a
+   * municipality, enriched with projectNumber, projectName, edocsWorkspaceId.
+   * The caller resolves the phase code to its process-definition key via
+   * RIP_PHASE_KEYS -- this method takes the key, not the code.
    */
-  async getRipPhase1ActiveList(tenantId: string): Promise<
+  async getRipPhaseActiveList(
+    processDefinitionKey: string,
+    tenantId: string
+  ): Promise<
     {
       id: string;
       startTime: string;
@@ -1337,7 +1342,7 @@ export class OperatonService {
     }[]
   > {
     const instancesRes = await this.client.post('/history/process-instance', {
-      processDefinitionKey: 'RipR21Process',
+      processDefinitionKey,
       unfinished: true,
       variables: [{ name: 'municipality', operator: 'eq', value: tenantId }],
       sorting: [{ sortBy: 'startTime', sortOrder: 'desc' }],
@@ -1372,11 +1377,18 @@ export class OperatonService {
   }
 
   /**
-   * Fetch all three RIP Phase 1 document templates from the deployment bundle,
-   * together with the current process variables (via history API — works for active instances).
-   * Documents not yet present in the deployment return null.
+   * Fetch an instance's document templates from its own deployment bundle,
+   * together with the current process variables (via history API — works for
+   * active instances). Documents not present in the deployment return null.
+   *
+   * Instance-keyed rather than phase-keyed on purpose: the deployment is
+   * resolved from the instance itself, so this works for any RIP process.
+   * The three resource names below (intakeReport, psuReport, pdp) are R2.1's
+   * document set, not a general RIP convention — when a later phase ships
+   * documents of its own, this returns null for all three rather than
+   * guessing. Generalising the set is a design question for that moment.
    */
-  async getRipPhase1Documents(processInstanceId: string): Promise<{
+  async getRipInstanceDocuments(processInstanceId: string): Promise<{
     variables: Record<string, unknown>;
     intakeReport: Record<string, unknown> | null;
     psuReport: Record<string, unknown> | null;
@@ -1422,9 +1434,13 @@ export class OperatonService {
   }
 
   /**
-   * Fetch all three RIP Phase 1 documents from the deployment bundle for finished instances.
+   * List completed (finished) instances of one RIP phase process for a
+   * municipality. Takes the process-definition key, not the phase code.
    */
-  async getRipPhase1CompletedList(tenantId: string): Promise<
+  async getRipPhaseCompletedList(
+    processDefinitionKey: string,
+    tenantId: string
+  ): Promise<
     {
       id: string;
       startTime: string;
@@ -1435,7 +1451,7 @@ export class OperatonService {
     }[]
   > {
     const instancesRes = await this.client.post('/history/process-instance', {
-      processDefinitionKey: 'RipR21Process',
+      processDefinitionKey,
       finished: true,
       variables: [{ name: 'municipality', operator: 'eq', value: tenantId }],
       sorting: [{ sortBy: 'endTime', sortOrder: 'desc' }],

--- a/packages/frontend/src/components/CaseworkerDashboard/RipFase1WipViewer.test.tsx
+++ b/packages/frontend/src/components/CaseworkerDashboard/RipFase1WipViewer.test.tsx
@@ -5,7 +5,7 @@ import userEvent from '@testing-library/user-event';
 import RipFase1WipViewer from './RipFase1WipViewer';
 
 const mockBusinessApi = vi.hoisted(() => ({
-  rip: { phase1Documents: vi.fn() },
+  rip: { instanceDocuments: vi.fn() },
 }));
 vi.mock('../../services/api', () => ({ businessApi: mockBusinessApi }));
 
@@ -27,7 +27,7 @@ const intakeTemplate = {
 };
 
 beforeEach(() => {
-  mockBusinessApi.rip.phase1Documents.mockResolvedValue({
+  mockBusinessApi.rip.instanceDocuments.mockResolvedValue({
     success: true,
     data: {
       variables: { projectName: 'Rondweg Noord' },
@@ -44,13 +44,13 @@ afterEach(() => {
 
 describe('RipFase1WipViewer', () => {
   it('shows a loading message before the documents resolve', () => {
-    mockBusinessApi.rip.phase1Documents.mockReturnValue(new Promise(() => {}));
+    mockBusinessApi.rip.instanceDocuments.mockReturnValue(new Promise(() => {}));
     render(<RipFase1WipViewer instanceId="pi-1" />);
     expect(screen.getByText('Documenten laden…')).toBeInTheDocument();
   });
 
   it('shows an error message when loading fails', async () => {
-    mockBusinessApi.rip.phase1Documents.mockResolvedValue({ success: false });
+    mockBusinessApi.rip.instanceDocuments.mockResolvedValue({ success: false });
     render(<RipFase1WipViewer instanceId="pi-1" />);
     expect(await screen.findByText('Documenten konden niet worden geladen.')).toBeInTheDocument();
   });

--- a/packages/frontend/src/components/CaseworkerDashboard/RipFase1WipViewer.tsx
+++ b/packages/frontend/src/components/CaseworkerDashboard/RipFase1WipViewer.tsx
@@ -244,7 +244,7 @@ export default function RipFase1WipViewer({ instanceId }: RipFase1WipViewerProps
     setLoading(true);
     setError(false);
     businessApi.rip
-      .phase1Documents(instanceId)
+      .instanceDocuments(instanceId)
       .then((res) => {
         if (res.success && res.data) setData(res.data);
         else setError(true);

--- a/packages/frontend/src/components/InfraBoardDashboard/InfraCommandPalette.test.tsx
+++ b/packages/frontend/src/components/InfraBoardDashboard/InfraCommandPalette.test.tsx
@@ -5,14 +5,14 @@ import userEvent from '@testing-library/user-event';
 import InfraCommandPalette from './InfraCommandPalette';
 import { getMockPortfolio } from '../../pages/infra-board/infra-board.data';
 
-const mockUseActivePhase1 = vi.hoisted(() => vi.fn());
+const mockUseRipActiveAcrossPhases = vi.hoisted(() => vi.fn());
 vi.mock('../../services/infra.api', async (importOriginal) => {
   const actual = await importOriginal<typeof import('../../services/infra.api')>();
-  return { ...actual, useActivePhase1: mockUseActivePhase1 };
+  return { ...actual, useRipActiveAcrossPhases: mockUseRipActiveAcrossPhases };
 });
 
 beforeEach(() => {
-  mockUseActivePhase1.mockReturnValue({
+  mockUseRipActiveAcrossPhases.mockReturnValue({
     data: null,
     loading: false,
     error: false,
@@ -55,7 +55,7 @@ describe('InfraCommandPalette', () => {
   });
 
   it('includes live RIP Fase 1 instances tagged "live"', () => {
-    mockUseActivePhase1.mockReturnValue({
+    mockUseRipActiveAcrossPhases.mockReturnValue({
       data: [
         {
           id: 'i1',

--- a/packages/frontend/src/components/InfraBoardDashboard/InfraCommandPalette.tsx
+++ b/packages/frontend/src/components/InfraBoardDashboard/InfraCommandPalette.tsx
@@ -1,6 +1,6 @@
 import { useEffect, useMemo, useRef, useState } from 'react';
 import { getMockPortfolio } from '../../pages/infra-board/infra-board.data';
-import { useActivePhase1 } from '../../services/infra.api';
+import { useRipActiveAcrossPhases } from '../../services/infra.api';
 import type { InfraModeId } from '../../pages/infra-board/modes.config';
 import type { ProjectRef } from '../../pages/InfraBoardDashboard';
 
@@ -24,7 +24,7 @@ export default function InfraCommandPalette({
   const [q, setQ] = useState('');
   const [hi, setHi] = useState(0);
   const ref = useRef<HTMLInputElement>(null);
-  const { data: live } = useActivePhase1();
+  const { data: live } = useRipActiveAcrossPhases();
 
   const items: Hit[] = useMemo(() => {
     const views: Hit[] = [

--- a/packages/frontend/src/components/InfraBoardDashboard/PhaseDetail.test.tsx
+++ b/packages/frontend/src/components/InfraBoardDashboard/PhaseDetail.test.tsx
@@ -35,17 +35,17 @@ vi.mock('../../pages/infra-board/rip-phases.catalog', async (importOriginal) => 
 });
 
 const mockStart = vi.hoisted(() => vi.fn());
-const mockPhase1Active = vi.hoisted(() => vi.fn());
+const mockPhaseActive = vi.hoisted(() => vi.fn());
 const mockActivityHistory = vi.hoisted(() => vi.fn());
-const mockPhase1Completed = vi.hoisted(() => vi.fn());
-const mockPhase1Documents = vi.hoisted(() => vi.fn());
+const mockPhaseCompleted = vi.hoisted(() => vi.fn());
+const mockInstanceDocuments = vi.hoisted(() => vi.fn());
 vi.mock('../../services/api', () => ({
   businessApi: {
     process: { start: mockStart, activityHistory: mockActivityHistory },
     rip: {
-      phase1Active: mockPhase1Active,
-      phase1Completed: mockPhase1Completed,
-      phase1Documents: mockPhase1Documents,
+      phaseActive: mockPhaseActive,
+      phaseCompleted: mockPhaseCompleted,
+      instanceDocuments: mockInstanceDocuments,
     },
   },
 }));
@@ -67,10 +67,10 @@ beforeEach(() => {
     phase.code === 'R2.1' ? 'gedeployed' : 'ontwerp'
   );
   mockStart.mockResolvedValue({ success: true, data: { processInstanceId: 'pi-1' } });
-  mockPhase1Active.mockResolvedValue({ success: true, data: [] });
+  mockPhaseActive.mockResolvedValue({ success: true, data: [] });
   mockActivityHistory.mockResolvedValue({ success: true, data: [] });
-  mockPhase1Completed.mockResolvedValue({ success: true, data: [] });
-  mockPhase1Documents.mockResolvedValue({
+  mockPhaseCompleted.mockResolvedValue({ success: true, data: [] });
+  mockInstanceDocuments.mockResolvedValue({
     success: true,
     data: { variables: {}, intakeReport: null, psuReport: null, pdp: null },
   });
@@ -187,12 +187,12 @@ describe('PhaseDetail — Starten tab, R2.1 fallback', () => {
     const user = userEvent.setup();
     render(<PhaseDetail phaseCode="R2.1" onBack={vi.fn()} />);
     await screen.findByRole('button', { name: 'R2.1 starten' });
-    mockPhase1Active.mockClear();
+    mockPhaseActive.mockClear();
 
     await user.click(screen.getByRole('button', { name: 'R2.1 starten' }));
     await screen.findByText('R2.1 gestart', { exact: false });
 
-    expect(mockPhase1Active).toHaveBeenCalled();
+    expect(mockPhaseActive).toHaveBeenCalled();
   });
 });
 
@@ -266,7 +266,7 @@ describe('PhaseDetail — Starten tab, deployed phase with ready projects', () =
 
 describe('PhaseDetail — WIP tab', () => {
   it('renders a real R2.1 row with a LIVE badge, using the live activity history', async () => {
-    mockPhase1Active.mockResolvedValue({
+    mockPhaseActive.mockResolvedValue({
       success: true,
       data: [
         {
@@ -322,7 +322,7 @@ describe('PhaseDetail — WIP tab', () => {
   });
 
   it('shows a loading indicator while live WIP data is in flight', async () => {
-    mockPhase1Active.mockImplementation(() => new Promise(() => {})); // never resolves
+    mockPhaseActive.mockImplementation(() => new Promise(() => {})); // never resolves
     const user = userEvent.setup();
     render(<PhaseDetail phaseCode="R2.1" onBack={vi.fn()} />);
 
@@ -332,7 +332,7 @@ describe('PhaseDetail — WIP tab', () => {
   });
 
   it('shows an error banner with a retry button when live WIP data fails to load', async () => {
-    mockPhase1Active.mockResolvedValue({ success: false });
+    mockPhaseActive.mockResolvedValue({ success: false });
     const user = userEvent.setup();
     render(<PhaseDetail phaseCode="R2.1" onBack={vi.fn()} />);
 
@@ -341,13 +341,13 @@ describe('PhaseDetail — WIP tab', () => {
     expect(
       await screen.findByText('Live WIP-gegevens konden niet worden geladen.', { exact: false })
     ).toBeInTheDocument();
-    mockPhase1Active.mockClear();
+    mockPhaseActive.mockClear();
     await user.click(screen.getByRole('button', { name: 'Opnieuw proberen' }));
-    expect(mockPhase1Active).toHaveBeenCalledTimes(1);
+    expect(mockPhaseActive).toHaveBeenCalledTimes(1);
   });
 
   it('computes Producten (docsDone/docsTotal) for a live WIP row from its activity history', async () => {
-    mockPhase1Active.mockResolvedValue({
+    mockPhaseActive.mockResolvedValue({
       success: true,
       data: [
         {
@@ -410,7 +410,7 @@ describe('PhaseDetail — WIP tab', () => {
   });
 
   it('renders a dash for Gezondheid, not a false "Op schema", when a live row has no derivable step info', async () => {
-    mockPhase1Active.mockResolvedValue({
+    mockPhaseActive.mockResolvedValue({
       success: true,
       data: [
         {
@@ -439,7 +439,7 @@ describe('PhaseDetail — WIP tab', () => {
 
 describe('PhaseDetail — Gereed tab', () => {
   it('renders the summary line and a real R2.1 row with a LIVE badge', async () => {
-    mockPhase1Completed.mockResolvedValue({
+    mockPhaseCompleted.mockResolvedValue({
       success: true,
       data: [
         {
@@ -474,7 +474,7 @@ describe('PhaseDetail — Gereed tab', () => {
   });
 
   it('reveals the document viewer when Openen is clicked on a real row', async () => {
-    mockPhase1Completed.mockResolvedValue({
+    mockPhaseCompleted.mockResolvedValue({
       success: true,
       data: [
         {
@@ -494,11 +494,11 @@ describe('PhaseDetail — Gereed tab', () => {
     await user.click(screen.getByRole('button', { name: /Gereed/ }));
     await user.click(await screen.findByRole('button', { name: 'Openen' }));
 
-    expect(mockPhase1Documents).toHaveBeenCalledWith('done-1');
+    expect(mockInstanceDocuments).toHaveBeenCalledWith('done-1');
   });
 
   it('shows the computed rework-loop count for a real completed row', async () => {
-    mockPhase1Completed.mockResolvedValue({
+    mockPhaseCompleted.mockResolvedValue({
       success: true,
       data: [
         {
@@ -574,7 +574,7 @@ describe('PhaseDetail — Gereed tab', () => {
   });
 
   it('shows a loading indicator while live Gereed data is in flight', async () => {
-    mockPhase1Completed.mockImplementation(() => new Promise(() => {})); // never resolves
+    mockPhaseCompleted.mockImplementation(() => new Promise(() => {})); // never resolves
     const user = userEvent.setup();
     render(<PhaseDetail phaseCode="R2.1" onBack={vi.fn()} />);
 
@@ -584,7 +584,7 @@ describe('PhaseDetail — Gereed tab', () => {
   });
 
   it('shows an error banner with a retry button when live Gereed data fails to load', async () => {
-    mockPhase1Completed.mockResolvedValue({ success: false });
+    mockPhaseCompleted.mockResolvedValue({ success: false });
     const user = userEvent.setup();
     render(<PhaseDetail phaseCode="R2.1" onBack={vi.fn()} />);
 
@@ -593,13 +593,13 @@ describe('PhaseDetail — Gereed tab', () => {
     expect(
       await screen.findByText('Live Gereed-gegevens konden niet worden geladen.', { exact: false })
     ).toBeInTheDocument();
-    mockPhase1Completed.mockClear();
+    mockPhaseCompleted.mockClear();
     await user.click(screen.getByRole('button', { name: 'Opnieuw proberen' }));
-    expect(mockPhase1Completed).toHaveBeenCalledTimes(1);
+    expect(mockPhaseCompleted).toHaveBeenCalledTimes(1);
   });
 
   it('renders the full Gereed summary line with average doorlooptijd, norm, and review-loop count', async () => {
-    mockPhase1Completed.mockResolvedValue({
+    mockPhaseCompleted.mockResolvedValue({
       success: true,
       data: [
         {

--- a/packages/frontend/src/components/InfraBoardDashboard/PhaseDetail.tsx
+++ b/packages/frontend/src/components/InfraBoardDashboard/PhaseDetail.tsx
@@ -23,8 +23,8 @@ import {
 import {
   useDeployedProcessKeys,
   useLivePhaseCounts,
-  useActivePhase1,
-  usePhase1Completed,
+  useRipPhaseActive,
+  useRipPhaseCompleted,
 } from '../../services/infra.api';
 import { businessApi } from '../../services/api';
 import {
@@ -58,6 +58,9 @@ function computeHealth(blocked: string | null, daysInStep: number): HealthKey {
 
 export default function PhaseDetail({ phaseCode, onBack }: Props) {
   const phase = ripPhaseByCode(phaseCode);
+  // Null for a phase with no process model: there are no instances to ask
+  // for, and the phase endpoints answer 409 rather than an empty list.
+  const livePhaseCode = phase?.processDefinitionKey ? phaseCode : null;
   const { data: deployment } = useDeployedProcessKeys();
   const { data: liveCountsRaw } = useLivePhaseCounts();
   const [tab, setTab] = useState<'starten' | 'wip' | 'gereed'>('starten');
@@ -75,13 +78,13 @@ export default function PhaseDetail({ phaseCode, onBack }: Props) {
     loading: wipLoading,
     error: wipError,
     reload: reloadWip,
-  } = useActivePhase1();
+  } = useRipPhaseActive(livePhaseCode);
   const {
     data: completedInstances,
     loading: gereedLoading,
     error: gereedError,
     reload: reloadGereed,
-  } = usePhase1Completed();
+  } = useRipPhaseCompleted(livePhaseCode);
 
   const [wipDerived, setWipDerived] = useState<
     Record<string, { info: WipStepInfo | null; docs: DocProgress }>
@@ -89,7 +92,7 @@ export default function PhaseDetail({ phaseCode, onBack }: Props) {
   const [gereedDerived, setGereedDerived] = useState<Record<string, { loops: number }>>({});
 
   useEffect(() => {
-    if (phaseCode !== 'R2.1' || !activeInstances) return;
+    if (!livePhaseCode || !activeInstances) return;
     let alive = true;
     Promise.all(
       activeInstances.map(async (inst) => {
@@ -103,10 +106,10 @@ export default function PhaseDetail({ phaseCode, onBack }: Props) {
     return () => {
       alive = false;
     };
-  }, [phaseCode, activeInstances]);
+  }, [livePhaseCode, activeInstances]);
 
   useEffect(() => {
-    if (phaseCode !== 'R2.1' || !completedInstances) return;
+    if (!livePhaseCode || !completedInstances) return;
     let alive = true;
     Promise.all(
       completedInstances.map(async (inst) => {
@@ -120,7 +123,7 @@ export default function PhaseDetail({ phaseCode, onBack }: Props) {
     return () => {
       alive = false;
     };
-  }, [phaseCode, completedInstances]);
+  }, [livePhaseCode, completedInstances]);
 
   if (!phase) return null;
 
@@ -230,7 +233,7 @@ export default function PhaseDetail({ phaseCode, onBack }: Props) {
     setSubmitting(true);
     setFallbackError(null);
     try {
-      const res = await businessApi.process.start('RipR21Process', {});
+      const res = await businessApi.process.start(phase!.processDefinitionKey!, {});
       if (res.success) {
         setFallbackStarted(true);
         reloadWip();
@@ -268,13 +271,15 @@ export default function PhaseDetail({ phaseCode, onBack }: Props) {
     }
   }
 
-  const isR21 = phaseCode === 'R2.1';
-  const liveActive = isR21 ? (activeInstances ?? []) : [];
-  const liveCompleted = isR21 ? (completedInstances ?? []) : [];
-  const showWipLoading = isR21 && wipLoading && !activeInstances;
-  const showWipError = isR21 && wipError;
-  const showGereedLoading = isR21 && gereedLoading && !completedInstances;
-  const showGereedError = isR21 && gereedError;
+  // Every modelled phase now serves live rows; an unmodelled one has none
+  // and must not render a loading or error state for a request never made.
+  const isLive = Boolean(livePhaseCode);
+  const liveActive = isLive ? (activeInstances ?? []) : [];
+  const liveCompleted = isLive ? (completedInstances ?? []) : [];
+  const showWipLoading = isLive && wipLoading && !activeInstances;
+  const showWipError = isLive && wipError;
+  const showGereedLoading = isLive && gereedLoading && !completedInstances;
+  const showGereedError = isLive && gereedError;
 
   const mockWipRows = getMockWipRows(phase);
   const mockGereedRows = getMockGereedRows(phase);

--- a/packages/frontend/src/components/InfraBoardDashboard/Portfolio.test.tsx
+++ b/packages/frontend/src/components/InfraBoardDashboard/Portfolio.test.tsx
@@ -6,14 +6,14 @@ import Portfolio from './Portfolio';
 import { getMockPortfolio, MIJN_PROJECT_NRS } from '../../pages/infra-board/infra-board.data';
 import { RIP_PHASES, RIP_STAGES } from '../../pages/infra-board/rip-phases.catalog';
 
-const mockUseActivePhase1 = vi.hoisted(() => vi.fn());
+const mockUseRipActiveAcrossPhases = vi.hoisted(() => vi.fn());
 vi.mock('../../services/infra.api', async (importOriginal) => {
   const actual = await importOriginal<typeof import('../../services/infra.api')>();
-  return { ...actual, useActivePhase1: mockUseActivePhase1 };
+  return { ...actual, useRipActiveAcrossPhases: mockUseRipActiveAcrossPhases };
 });
 
 beforeEach(() => {
-  mockUseActivePhase1.mockReturnValue({
+  mockUseRipActiveAcrossPhases.mockReturnValue({
     data: null,
     loading: false,
     error: false,
@@ -67,8 +67,8 @@ describe('Portfolio', () => {
     expect(onOpenProject).toHaveBeenCalledWith({ nr: first.nr, instanceId: first.instanceId });
   });
 
-  it('mentions the live RIP Fase 1 instance count when there are live instances', () => {
-    mockUseActivePhase1.mockReturnValue({
+  it('mentions the live RIP instance count when there are live instances', () => {
+    mockUseRipActiveAcrossPhases.mockReturnValue({
       data: [
         {
           id: 'i1',
@@ -77,6 +77,7 @@ describe('Portfolio', () => {
           projectName: 'Live project',
           edocsWorkspaceId: 'w1',
           leadRole: 'projectleider',
+          phaseCode: 'R2.1',
         },
       ],
       loading: false,
@@ -86,7 +87,7 @@ describe('Portfolio', () => {
 
     render(<Portfolio onOpenProject={vi.fn()} />);
 
-    expect(screen.getByText(/actieve RIP Fase 1 instanties/)).toBeInTheDocument();
+    expect(screen.getByText(/actieve RIP-instanties/)).toBeInTheDocument();
     expect(screen.getByText('Live project')).toBeInTheDocument();
   });
 

--- a/packages/frontend/src/components/InfraBoardDashboard/Portfolio.tsx
+++ b/packages/frontend/src/components/InfraBoardDashboard/Portfolio.tsx
@@ -1,14 +1,14 @@
 import { useState } from 'react';
 import {
   getMockPortfolio,
-  makePhase1Row,
+  makeLivePhaseRow,
   MIJN_PROJECT_NRS,
   TL,
   type PortfolioProject,
 } from '../../pages/infra-board/infra-board.data';
 import { STATUS, roleByKey, type StatusKey } from '../../pages/infra-board/rip-model';
 import { RIP_PHASES, RIP_STAGES, ripPhaseByCode } from '../../pages/infra-board/rip-phases.catalog';
-import { useActivePhase1 } from '../../services/infra.api';
+import { useRipActiveAcrossPhases } from '../../services/infra.api';
 import type { ProjectRef } from '../../pages/InfraBoardDashboard';
 
 interface Props {
@@ -189,11 +189,13 @@ export default function Portfolio({ onOpenProject }: Props) {
   const [scope, setScope] = useState<'alle' | 'mijn' | 'risico'>('alle');
   const [role, setRole] = useState('alle');
 
-  const { data: liveInstances } = useActivePhase1();
+  const { data: liveInstances } = useRipActiveAcrossPhases();
 
   // Convert live instances to portfolio rows and prepend them.
   // Remove any mock row whose project number matches a live instance (avoid duplicates).
-  const liveRows: PortfolioProject[] = (liveInstances ?? []).map(makePhase1Row);
+  const liveRows: PortfolioProject[] = (liveInstances ?? []).map((i) =>
+    makeLivePhaseRow(i, i.phaseCode)
+  );
   const liveNrs = new Set(liveRows.map((r) => r.nr));
   const all = [...liveRows, ...getMockPortfolio().filter((p) => !liveNrs.has(p.nr))];
   const mijn = new Set(MIJN_PROJECT_NRS);
@@ -229,8 +231,8 @@ export default function Portfolio({ onOpenProject }: Props) {
       <h1 className="pb-h1">Projectenportfolio</h1>
       <p className="pb-lead">
         {counts.total} projecten over de RIP-fasen (venster 2022–2027)
-        {liveInstances ? ` · ${liveInstances.length} actieve RIP Fase 1 instanties` : ''}. Bekijk
-        als tijdlijn of per fase. Klik een project om in te zoomen.
+        {liveInstances ? ` · ${liveInstances.length} actieve RIP-instanties` : ''}. Bekijk als
+        tijdlijn of per fase. Klik een project om in te zoomen.
       </p>
 
       <div className="pb-port-toolbar">

--- a/packages/frontend/src/components/InfraBoardDashboard/ProjectDetail.test.tsx
+++ b/packages/frontend/src/components/InfraBoardDashboard/ProjectDetail.test.tsx
@@ -7,14 +7,14 @@ import { getMockPortfolio } from '../../pages/infra-board/infra-board.data';
 import { RIP_PHASES } from '../../pages/infra-board/rip-phases.catalog';
 
 const mockUseActivityHistory = vi.hoisted(() => vi.fn());
-const mockUsePhase1Documents = vi.hoisted(() => vi.fn());
+const mockUseInstanceDocuments = vi.hoisted(() => vi.fn());
 const mockUseOpenTasks = vi.hoisted(() => vi.fn());
 vi.mock('../../services/infra.api', async (importOriginal) => {
   const actual = await importOriginal<typeof import('../../services/infra.api')>();
   return {
     ...actual,
     useActivityHistory: mockUseActivityHistory,
-    usePhase1Documents: mockUsePhase1Documents,
+    useInstanceDocuments: mockUseInstanceDocuments,
     useOpenTasks: mockUseOpenTasks,
   };
 });
@@ -50,7 +50,7 @@ beforeEach(() => {
     error: false,
     reload: vi.fn(),
   });
-  mockUsePhase1Documents.mockReturnValue({
+  mockUseInstanceDocuments.mockReturnValue({
     data: null,
     loading: false,
     error: false,

--- a/packages/frontend/src/components/InfraBoardDashboard/ProjectDetail.tsx
+++ b/packages/frontend/src/components/InfraBoardDashboard/ProjectDetail.tsx
@@ -8,7 +8,7 @@ import {
 } from '../../pages/infra-board/rip-model';
 import { RIP_PHASES, ripPhaseByCode } from '../../pages/infra-board/rip-phases.catalog';
 import { getMockPortfolio, type PortfolioProject } from '../../pages/infra-board/infra-board.data';
-import { useActivityHistory, usePhase1Documents, useOpenTasks } from '../../services/infra.api';
+import { useActivityHistory, useInstanceDocuments, useOpenTasks } from '../../services/infra.api';
 import { businessApi } from '../../services/api';
 import type { SignatureSpec } from '../../services/api';
 import type { Task } from '@ronl/shared';
@@ -175,7 +175,7 @@ export default function ProjectDetail({ projectRef, onBack }: Props) {
   const { data: history, reload: reloadHistory } = useActivityHistory(
     projectRef.instanceId ?? null
   );
-  const { data: docs } = usePhase1Documents(projectRef.instanceId ?? null);
+  const { data: docs } = useInstanceDocuments(projectRef.instanceId ?? null);
   const { data: allTasks, reload: reloadTasks } = useOpenTasks();
 
   // Tasks belonging to this process instance.

--- a/packages/frontend/src/pages/InfraBoardDashboard.test.tsx
+++ b/packages/frontend/src/pages/InfraBoardDashboard.test.tsx
@@ -43,7 +43,7 @@ vi.mock('../components/SessionExpiryWarning', () => ({ default: () => null }));
 vi.mock('./ChangelogPanel', () => ({ default: () => null }));
 
 const mockUseOpenTasks = vi.hoisted(() => vi.fn());
-const mockUseActivePhase1 = vi.hoisted(() => vi.fn());
+const mockUseRipActiveAcrossPhases = vi.hoisted(() => vi.fn());
 const mockUseDeployedProcessKeys = vi.hoisted(() => vi.fn());
 const mockUseLivePhaseCounts = vi.hoisted(() => vi.fn());
 vi.mock('../services/infra.api', async (importOriginal) => {
@@ -51,7 +51,7 @@ vi.mock('../services/infra.api', async (importOriginal) => {
   return {
     ...actual,
     useOpenTasks: mockUseOpenTasks,
-    useActivePhase1: mockUseActivePhase1,
+    useRipActiveAcrossPhases: mockUseRipActiveAcrossPhases,
     useDeployedProcessKeys: mockUseDeployedProcessKeys,
     useLivePhaseCounts: mockUseLivePhaseCounts,
   };
@@ -63,7 +63,7 @@ describe('InfraBoardDashboard', () => {
     mockGetUser.mockReturnValue(null);
     window.sessionStorage.clear();
     mockUseOpenTasks.mockReturnValue({ data: null, loading: false, error: false, reload: vi.fn() });
-    mockUseActivePhase1.mockReturnValue({
+    mockUseRipActiveAcrossPhases.mockReturnValue({
       data: null,
       loading: false,
       error: false,

--- a/packages/frontend/src/pages/InfraBoardDashboard.tsx
+++ b/packages/frontend/src/pages/InfraBoardDashboard.tsx
@@ -37,7 +37,7 @@ import SessionExpiryWarning from '../components/SessionExpiryWarning';
 import ChangelogPanel from './ChangelogPanel';
 import {
   useOpenTasks,
-  useActivePhase1,
+  useRipActiveAcrossPhases,
   useDeployedProcessKeys,
   useLivePhaseCounts,
 } from '../services/infra.api';
@@ -45,7 +45,7 @@ import {
   getMockPortfolio,
   getMockTodos,
   getMockPhaseCounts,
-  makePhase1Row,
+  makeLivePhaseRow,
   type PortfolioProject,
 } from './infra-board/infra-board.data';
 import { RIP_PHASES } from './infra-board/rip-phases.catalog';
@@ -152,11 +152,13 @@ export default function InfraBoardDashboard() {
   // Portfolio.tsx/FaseladderOverview.tsx already source their own live data
   // rather than lifting it here and threading it down as props.
   const { data: liveTasks } = useOpenTasks();
-  const { data: liveInstances } = useActivePhase1();
+  const { data: liveInstances } = useRipActiveAcrossPhases();
   const { data: deployment } = useDeployedProcessKeys();
   const { data: liveCountsRaw } = useLivePhaseCounts();
 
-  const liveRows: PortfolioProject[] = (liveInstances ?? []).map(makePhase1Row);
+  const liveRows: PortfolioProject[] = (liveInstances ?? []).map((i) =>
+    makeLivePhaseRow(i, i.phaseCode)
+  );
   const liveNrs = new Set(liveRows.map((r) => r.nr));
   const allProjects = [...liveRows, ...getMockPortfolio().filter((p) => !liveNrs.has(p.nr))];
 

--- a/packages/frontend/src/pages/caseworker-v2/dashboard-v2.css
+++ b/packages/frontend/src/pages/caseworker-v2/dashboard-v2.css
@@ -569,6 +569,10 @@
   cursor: pointer;
   font-family: inherit;
 }
+.cwd-v2 .v2-btn:disabled {
+  opacity: 0.4;
+  cursor: not-allowed;
+}
 .cwd-v2 .v2-btn.v2-btn-ghost {
   background: #fff;
   color: var(--v2-chrome);

--- a/packages/frontend/src/pages/infra-board/infra-board.data.test.ts
+++ b/packages/frontend/src/pages/infra-board/infra-board.data.test.ts
@@ -10,7 +10,7 @@ import {
   getMockWipRows,
   getOutOfSequenceProjects,
   getReadyProjects,
-  makePhase1Row,
+  makeLivePhaseRow,
   normalizeLeadRole,
   TL,
 } from './infra-board.data';
@@ -30,15 +30,18 @@ describe('normalizeLeadRole', () => {
   });
 });
 
-describe('makePhase1Row', () => {
+describe('makeLivePhaseRow', () => {
   it('builds a live portfolio row anchored on the instance start quarter', () => {
-    const row = makePhase1Row({
-      id: 'abcdefgh-1234',
-      startTime: '2024-04-15T00:00:00Z',
-      projectNumber: '24099',
-      projectName: 'Test project',
-      leadRole: 'manager-pb',
-    });
+    const row = makeLivePhaseRow(
+      {
+        id: 'abcdefgh-1234',
+        startTime: '2024-04-15T00:00:00Z',
+        projectNumber: '24099',
+        projectName: 'Test project',
+        leadRole: 'manager-pb',
+      },
+      'R2.1'
+    );
 
     const expectedStart = (2024 - TL.startYear) * 4 + (2 - 1); // April = Q2
 
@@ -58,16 +61,40 @@ describe('makePhase1Row', () => {
   });
 
   it('falls back to the instance id and a default name when nr/naam are blank', () => {
-    const row = makePhase1Row({
-      id: 'abcdefgh-1234',
-      startTime: '2024-01-01T00:00:00Z',
-      projectNumber: '',
-      projectName: '',
-    });
+    const row = makeLivePhaseRow(
+      {
+        id: 'abcdefgh-1234',
+        startTime: '2024-01-01T00:00:00Z',
+        projectNumber: '',
+        projectName: '',
+      },
+      'R2.1'
+    );
 
     expect(row.nr).toBe('abcdefgh'); // first 8 chars of id
-    expect(row.naam).toBe('RIP Fase 1 project');
+    expect(row.naam).toBe('RIP R2.1 project');
     expect(row.role).toBe('projectleider'); // normalizeLeadRole(undefined)
+  });
+
+  it('marks earlier phases done and later ones todo for a mid-ladder phase', () => {
+    // A live R2.2 instance means R2.1 is behind it -- the row must not claim
+    // the project is still sitting in the first phase.
+    const row = makeLivePhaseRow(
+      {
+        id: 'i-1',
+        startTime: '2024-04-15T00:00:00Z',
+        projectNumber: '24100',
+        projectName: 'VO project',
+      },
+      'R2.2'
+    );
+
+    expect(row.ripPhaseCode).toBe('R2.2');
+    expect(row.naam).toBe('VO project');
+    expect(row.milestone).toBe('R2.2 lopend');
+    expect(row.segments[0].status).toBe('done');
+    expect(row.segments[1].status).toBe('active');
+    expect(row.segments.slice(2).every((seg) => seg.status === 'todo')).toBe(true);
   });
 });
 

--- a/packages/frontend/src/pages/infra-board/infra-board.data.ts
+++ b/packages/frontend/src/pages/infra-board/infra-board.data.ts
@@ -626,33 +626,40 @@ const RAW: Raw[] = [
 ];
 
 /** Build a PortfolioProject row from a live RIP Fase 1 process instance. */
-export function makePhase1Row(inst: {
-  id: string;
-  startTime: string;
-  projectNumber: string;
-  projectName: string;
-  leadRole?: string;
-}): PortfolioProject {
+export function makeLivePhaseRow(
+  inst: {
+    id: string;
+    startTime: string;
+    projectNumber: string;
+    projectName: string;
+    leadRole?: string;
+  },
+  phaseCode: string
+): PortfolioProject {
   const d = new Date(inst.startTime);
   const q = Math.floor(d.getMonth() / 3) + 1;
   const fromIdx = qIdx(d.getFullYear(), q);
-  const statuses: StatusKey[] = RIP_PHASES.map((p) => (p.code === 'R2.1' ? 'active' : 'todo'));
+  // Phases before this one are done, this one is running, later ones are todo.
+  const activeIdx = RIP_PHASES.findIndex((p) => p.code === phaseCode);
+  const statuses: StatusKey[] = RIP_PHASES.map((_, i) =>
+    i < activeIdx ? 'done' : i === activeIdx ? 'active' : 'todo'
+  );
   const segments = buildRipSegments(fromIdx, statuses);
   const last = segments[segments.length - 1];
   return {
     id: 'live-' + inst.id,
     nr: inst.projectNumber || inst.id.slice(0, 8),
-    naam: inst.projectName || 'RIP Fase 1 project',
+    naam: inst.projectName || `RIP ${phaseCode} project`,
     role: normalizeLeadRole(inst.leadRole),
     health: 'groen',
-    milestone: 'Fase 1 lopend',
+    milestone: `${phaseCode} lopend`,
     budget: '—',
     startYear: d.getFullYear(),
     start: fromIdx,
     end: last.from + last.len,
     segments,
     instanceId: inst.id,
-    ripPhaseCode: RIP_PHASES[0].code,
+    ripPhaseCode: phaseCode,
     ripPhaseState: 'wip',
   };
 }

--- a/packages/frontend/src/pages/infra-board/rip-phases.catalog.test.ts
+++ b/packages/frontend/src/pages/infra-board/rip-phases.catalog.test.ts
@@ -7,8 +7,7 @@ import {
   type RipPhase,
 } from './rip-phases.catalog';
 
-const NON_R21_CODES = [
-  'R2.2',
+const UNMODELLED_CODES = [
   'R2.3',
   'R2.4',
   'R3.1',
@@ -43,9 +42,10 @@ describe('RIP_PHASES catalogue', () => {
     expect(RIP_STAGES.map((s) => s.code)).toEqual(['R2', 'R3', 'R4', 'R5', 'R6']);
   });
 
-  it('only R2.1 carries a processDefinitionKey', () => {
+  it('only the modelled phases carry a processDefinitionKey', () => {
     expect(ripPhaseByCode('R2.1')?.processDefinitionKey).toBe('RipR21Process');
-    for (const code of NON_R21_CODES) {
+    expect(ripPhaseByCode('R2.2')?.processDefinitionKey).toBe('RipR22Process');
+    for (const code of UNMODELLED_CODES) {
       expect(ripPhaseByCode(code)?.processDefinitionKey).toBeUndefined();
     }
   });
@@ -80,7 +80,7 @@ describe('RIP_PHASES catalogue', () => {
 
 describe('getPhaseDeployStatus', () => {
   const withKey: RipPhase = { ...ripPhaseByCode('R2.1')! };
-  const withoutKey: RipPhase = { ...ripPhaseByCode('R2.2')! };
+  const withoutKey: RipPhase = { ...ripPhaseByCode('R2.3')! };
   const beyond: RipPhase = { ...ripPhaseByCode('R5.3')! };
 
   it('is gedeployed when the phase has a key and it is in the deployed set', () => {

--- a/packages/frontend/src/services/api.test.ts
+++ b/packages/frontend/src/services/api.test.ts
@@ -431,23 +431,28 @@ describe('businessApi.hr', () => {
 });
 
 describe('businessApi.rip', () => {
-  it('phase1Active fetches the active Fase 1 instances', async () => {
+  it('phaseActive fetches the active instances of the phase it is given', async () => {
+    let seen = '';
     server.use(
-      http.get('*/rip/phase1/active', () => HttpResponse.json({ success: true, data: [] }))
+      http.get('*/rip/phases/:code/active', ({ request }) => {
+        seen = new URL(request.url).pathname;
+        return HttpResponse.json({ success: true, data: [] });
+      })
     );
-    expect(await businessApi.rip.phase1Active()).toEqual({ success: true, data: [] });
+    expect(await businessApi.rip.phaseActive('R2.2')).toEqual({ success: true, data: [] });
+    expect(seen).toContain('/rip/phases/R2.2/active');
   });
 
-  it('phase1Documents fetches the Fase 1 document bundle', async () => {
+  it('instanceDocuments fetches an instance document bundle', async () => {
     server.use(
-      http.get('*/rip/phase1/pi-1/documents', () =>
+      http.get('*/rip/instances/pi-1/documents', () =>
         HttpResponse.json({
           success: true,
           data: { variables: {}, intakeReport: null, psuReport: null, pdp: null },
         })
       )
     );
-    expect(await businessApi.rip.phase1Documents('pi-1')).toEqual({
+    expect(await businessApi.rip.instanceDocuments('pi-1')).toEqual({
       success: true,
       data: { variables: {}, intakeReport: null, psuReport: null, pdp: null },
     });
@@ -480,11 +485,16 @@ describe('businessApi.rip', () => {
     });
   });
 
-  it('phase1Completed fetches the completed Fase 1 instances', async () => {
+  it('phaseCompleted fetches the completed instances of the phase it is given', async () => {
+    let seen = '';
     server.use(
-      http.get('*/rip/phase1/completed', () => HttpResponse.json({ success: true, data: [] }))
+      http.get('*/rip/phases/:code/completed', ({ request }) => {
+        seen = new URL(request.url).pathname;
+        return HttpResponse.json({ success: true, data: [] });
+      })
     );
-    expect(await businessApi.rip.phase1Completed()).toEqual({ success: true, data: [] });
+    expect(await businessApi.rip.phaseCompleted('R2.1')).toEqual({ success: true, data: [] });
+    expect(seen).toContain('/rip/phases/R2.1/completed');
   });
 });
 

--- a/packages/frontend/src/services/api.ts
+++ b/packages/frontend/src/services/api.ts
@@ -309,7 +309,9 @@ export const businessApi = {
   },
 
   rip: {
-    phase1Active: async (): Promise<
+    phaseActive: async (
+      phaseCode: string
+    ): Promise<
       ApiResponse<
         Array<{
           id: string;
@@ -321,11 +323,11 @@ export const businessApi = {
         }>
       >
     > => {
-      const response = await api.get('/rip/phase1/active');
+      const response = await api.get(`/rip/phases/${encodeURIComponent(phaseCode)}/active`);
       return response.data;
     },
 
-    phase1Documents: async (
+    instanceDocuments: async (
       instanceId: string
     ): Promise<
       ApiResponse<{
@@ -335,7 +337,7 @@ export const businessApi = {
         pdp: Record<string, unknown> | null;
       }>
     > => {
-      const response = await api.get(`/rip/phase1/${instanceId}/documents`);
+      const response = await api.get(`/rip/instances/${instanceId}/documents`);
       return response.data;
     },
 
@@ -351,7 +353,9 @@ export const businessApi = {
       return response.data;
     },
 
-    phase1Completed: async (): Promise<
+    phaseCompleted: async (
+      phaseCode: string
+    ): Promise<
       ApiResponse<
         Array<{
           id: string;
@@ -363,7 +367,7 @@ export const businessApi = {
         }>
       >
     > => {
-      const response = await api.get('/rip/phase1/completed');
+      const response = await api.get(`/rip/phases/${encodeURIComponent(phaseCode)}/completed`);
       return response.data;
     },
   },

--- a/packages/frontend/src/services/infra.api.test.ts
+++ b/packages/frontend/src/services/infra.api.test.ts
@@ -8,15 +8,16 @@ import {
   useDeployedProcessKeys,
   useLivePhaseCounts,
   useOpenTasks,
-  usePhase1Completed,
+  useRipActiveAcrossPhases,
+  useRipPhaseCompleted,
 } from './infra.api';
 
 const mockBusinessApi = vi.hoisted(() => ({
   task: { list: vi.fn() },
   rip: {
-    phase1Active: vi.fn(),
-    phase1Completed: vi.fn(),
-    phase1Documents: vi.fn(),
+    phaseActive: vi.fn(),
+    phaseCompleted: vi.fn(),
+    instanceDocuments: vi.fn(),
     deploymentStatus: vi.fn(),
     phasesCounts: vi.fn(),
   },
@@ -115,7 +116,7 @@ describe('groupTasksByHorizon', () => {
       makeTask({ id: 'titled-1', due: localDateTime(2026, 0, 8) }),
     ]);
 
-    expect(result.vandaag[0].titel).toBe('RIP Fase 1 — R2.1 Projectplan Planvoorbereiding');
+    expect(result.vandaag[0].titel).toBe('RIP R2.1 — Projectplan planvoorbereiding');
   });
 });
 
@@ -247,7 +248,70 @@ describe('useActivityHistory', () => {
   });
 });
 
-describe('usePhase1Completed', () => {
+describe('useRipActiveAcrossPhases', () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  const inst = (id: string) => ({
+    id,
+    startTime: '2026-01-01T00:00:00Z',
+    projectNumber: '11111',
+    projectName: 'Live',
+    edocsWorkspaceId: 'w1',
+    leadRole: 'projectleider',
+  });
+
+  it('tags each instance with the phase it came from', async () => {
+    mockBusinessApi.rip.phaseActive.mockClear();
+    mockBusinessApi.rip.phaseActive.mockImplementation((code: string) =>
+      Promise.resolve({ success: true, data: [inst(`i-${code}`)] })
+    );
+
+    const { result } = renderHook(() => useRipActiveAcrossPhases());
+    await waitFor(() => expect(result.current.loading).toBe(false));
+
+    expect(result.current.data).toEqual([
+      expect.objectContaining({ id: 'i-R2.1', phaseCode: 'R2.1' }),
+      expect.objectContaining({ id: 'i-R2.2', phaseCode: 'R2.2' }),
+    ]);
+    expect(result.current.error).toBe(false);
+  });
+
+  it('keeps the phases that answered when another one rejects', async () => {
+    // A non-2xx rejects the axios promise, it does not resolve
+    // { success: false } -- so an unguarded Promise.all would reject here and
+    // the portfolio would show no live rows at all. This is the regression
+    // that made R2.1's live project vanish while the backend still served
+    // the old routes.
+    mockBusinessApi.rip.phaseActive.mockClear();
+    mockBusinessApi.rip.phaseActive.mockImplementation((code: string) =>
+      code === 'R2.1'
+        ? Promise.resolve({ success: true, data: [inst('i-1')] })
+        : Promise.reject(new Error('404'))
+    );
+
+    const { result } = renderHook(() => useRipActiveAcrossPhases());
+    await waitFor(() => expect(result.current.loading).toBe(false));
+
+    expect(result.current.data).toEqual([
+      expect.objectContaining({ id: 'i-1', phaseCode: 'R2.1' }),
+    ]);
+    expect(result.current.error).toBe(false);
+  });
+
+  it('reports an error only when every phase fails', async () => {
+    mockBusinessApi.rip.phaseActive.mockClear();
+    mockBusinessApi.rip.phaseActive.mockRejectedValue(new Error('backend down'));
+
+    const { result } = renderHook(() => useRipActiveAcrossPhases());
+    await waitFor(() => expect(result.current.loading).toBe(false));
+
+    expect(result.current.error).toBe(true);
+  });
+});
+
+describe('useRipPhaseCompleted', () => {
   afterEach(() => {
     vi.restoreAllMocks();
   });
@@ -263,21 +327,36 @@ describe('usePhase1Completed', () => {
         edocsWorkspaceId: 'w2',
       },
     ];
-    mockBusinessApi.rip.phase1Completed.mockResolvedValue({ success: true, data: completed });
+    mockBusinessApi.rip.phaseCompleted.mockResolvedValue({ success: true, data: completed });
 
-    const { result } = renderHook(() => usePhase1Completed());
+    const { result } = renderHook(() => useRipPhaseCompleted('R2.1'));
 
     expect(result.current.loading).toBe(true);
     await waitFor(() => expect(result.current.loading).toBe(false));
 
     expect(result.current.data).toEqual(completed);
     expect(result.current.error).toBe(false);
+    expect(mockBusinessApi.rip.phaseCompleted).toHaveBeenCalledWith('R2.1');
+  });
+
+  it('makes no request at all for a null phase code', async () => {
+    // vi.restoreAllMocks() does not reset a vi.hoisted() vi.fn(), so the
+    // previous test's call would otherwise still be on the record here.
+    mockBusinessApi.rip.phaseCompleted.mockClear();
+
+    const { result } = renderHook(() => useRipPhaseCompleted(null));
+
+    await waitFor(() => expect(result.current.loading).toBe(false));
+
+    expect(mockBusinessApi.rip.phaseCompleted).not.toHaveBeenCalled();
+    expect(result.current.data).toEqual([]);
+    expect(result.current.error).toBe(false);
   });
 
   it('sets error state when the call rejects', async () => {
-    mockBusinessApi.rip.phase1Completed.mockRejectedValue(new Error('network down'));
+    mockBusinessApi.rip.phaseCompleted.mockRejectedValue(new Error('network down'));
 
-    const { result } = renderHook(() => usePhase1Completed());
+    const { result } = renderHook(() => useRipPhaseCompleted('R2.1'));
 
     await waitFor(() => expect(result.current.loading).toBe(false));
 

--- a/packages/frontend/src/services/infra.api.ts
+++ b/packages/frontend/src/services/infra.api.ts
@@ -10,9 +10,11 @@
 import { useEffect, useState } from 'react';
 import { businessApi } from './api';
 import type { Task, ActivityHistoryItem } from '@ronl/shared';
+import { RIP_PHASE_KEYS } from '@ronl/shared';
 import type { StatusKey } from '../pages/infra-board/rip-model';
+import { RIP_PHASES } from '../pages/infra-board/rip-phases.catalog';
 
-export interface Phase1Instance {
+export interface RipPhaseInstance {
   id: string;
   startTime: string;
   projectNumber: string;
@@ -20,6 +22,12 @@ export interface Phase1Instance {
   edocsWorkspaceId: string;
   /** Declared portfolio lead role (rip-model key); '' when the instance predates the contract. */
   leadRole: string;
+}
+
+/** A running instance carrying the phase it belongs to — the shape the
+ *  portfolio and command palette need, since their rows span phases. */
+export interface RipPhaseInstanceRow extends RipPhaseInstance {
+  phaseCode: string;
 }
 
 interface AsyncState<T> {
@@ -71,11 +79,24 @@ export const useLivePhaseCounts = () =>
     []
   );
 
-/** Running RIP Fase 1 instances (portfolio — live Fase-1 rows). */
-export const useActivePhase1 = () =>
-  useAsync<Phase1Instance[]>(() => businessApi.rip.phase1Active(), []);
+/** Phase codes whose process is modelled as BPMN — the only ones the
+ *  phase endpoints accept. An unmodelled code answers 409, deliberately:
+ *  callers must not confuse "not deployed" with "deployed, no instances". */
+const modelledPhaseCodes = () =>
+  RIP_PHASE_KEYS.filter((p) => p.processDefinitionKey).map((p) => p.code);
 
-export interface Phase1CompletedInstance {
+/** Running instances of one RIP phase. Pass null to skip the request —
+ *  for a phase with no process model there is nothing to ask for. */
+export const useRipPhaseActive = (phaseCode: string | null) =>
+  useAsync<RipPhaseInstance[]>(
+    () =>
+      phaseCode
+        ? businessApi.rip.phaseActive(phaseCode)
+        : Promise.resolve({ success: true, data: [] }),
+    [phaseCode]
+  );
+
+export interface RipPhaseCompletedInstance {
   id: string;
   startTime: string;
   endTime: string;
@@ -84,9 +105,47 @@ export interface Phase1CompletedInstance {
   edocsWorkspaceId: string;
 }
 
-/** Completed RIP Fase 1 instances (Gereed tab — live Fase-1 rows). */
-export const usePhase1Completed = () =>
-  useAsync<Phase1CompletedInstance[]>(() => businessApi.rip.phase1Completed(), []);
+/** Completed instances of one RIP phase (Gereed tab). Null skips, as above. */
+export const useRipPhaseCompleted = (phaseCode: string | null) =>
+  useAsync<RipPhaseCompletedInstance[]>(
+    () =>
+      phaseCode
+        ? businessApi.rip.phaseCompleted(phaseCode)
+        : Promise.resolve({ success: true, data: [] }),
+    [phaseCode]
+  );
+
+/**
+ * Running instances across every modelled phase, flattened and tagged.
+ *
+ * One phase failing does not blank the others — the portfolio showing R2.1's
+ * projects is strictly better than showing none because R2.2's request
+ * timed out. Only an across-the-board failure is reported as an error.
+ */
+async function fetchActiveAcrossPhases(): Promise<{
+  success: boolean;
+  data?: RipPhaseInstanceRow[];
+}> {
+  const codes = modelledPhaseCodes();
+  if (codes.length === 0) return { success: true, data: [] };
+  const results = await Promise.all(
+    codes.map((code) =>
+      // The per-request catch is what actually makes one phase survivable:
+      // a non-2xx rejects the axios promise rather than resolving
+      // { success: false }, so without it a single failing phase rejects the
+      // whole Promise.all and the portfolio renders no live rows at all.
+      businessApi.rip.phaseActive(code).catch(() => ({ success: false as const, data: undefined }))
+    )
+  );
+  const rows = results.flatMap((res, i) =>
+    res.success && res.data ? res.data.map((inst) => ({ ...inst, phaseCode: codes[i] })) : []
+  );
+  return { success: results.some((r) => r.success), data: rows };
+}
+
+/** Running instances portfolio-wide, across every deployed phase. */
+export const useRipActiveAcrossPhases = () =>
+  useAsync<RipPhaseInstanceRow[]>(fetchActiveAcrossPhases, []);
 
 /** Activity-history for a process instance — drives swimlane node status. */
 export const useActivityHistory = (instanceId: string | null) =>
@@ -98,8 +157,9 @@ export const useActivityHistory = (instanceId: string | null) =>
     [instanceId]
   );
 
-/** The three Projectplan documents + variables for a Fase-1 instance. */
-export const usePhase1Documents = (instanceId: string | null) =>
+/** An instance's documents + variables. The three names are R2.1's document
+ *  set; instances of a phase that ships none get null for all three. */
+export const useInstanceDocuments = (instanceId: string | null) =>
   useAsync<{
     variables: Record<string, unknown>;
     intakeReport: Record<string, unknown> | null;
@@ -108,7 +168,7 @@ export const usePhase1Documents = (instanceId: string | null) =>
   }>(
     () =>
       instanceId
-        ? businessApi.rip.phase1Documents(instanceId)
+        ? businessApi.rip.instanceDocuments(instanceId)
         : Promise.resolve({
             success: true,
             data: { variables: {}, intakeReport: null, psuReport: null, pdp: null },
@@ -132,9 +192,20 @@ function startOfDay(d: Date) {
   return x;
 }
 
-const PROCESS_DISPLAY_NAMES: Record<string, string> = {
-  RipR21Process: 'RIP Fase 1 — R2.1 Projectplan Planvoorbereiding',
-};
+/**
+ * Human label per infra process-definition key, derived from the phase
+ * catalogue rather than listed by hand: a phase that gains a
+ * processDefinitionKey becomes an infra process in the same edit, with no
+ * second place to remember. Hand-listing it is what previously left an
+ * R2.2 task nameless and, worse, filtered out of the infra task list
+ * entirely by INFRA_PROCESS_KEYS below.
+ */
+const PROCESS_DISPLAY_NAMES: Record<string, string> = Object.fromEntries(
+  RIP_PHASES.filter((p) => p.processDefinitionKey).map((p) => [
+    p.processDefinitionKey as string,
+    `RIP ${p.code} — ${p.name}`,
+  ])
+);
 
 /**
  * Process-definition keys owned by the Infra-board. Single source of truth for

--- a/packages/shared/src/rip-phases.ts
+++ b/packages/shared/src/rip-phases.ts
@@ -14,7 +14,7 @@ export interface RipPhaseKey {
 
 export const RIP_PHASE_KEYS: RipPhaseKey[] = [
   { code: 'R2.1', stage: 'R2', processDefinitionKey: 'RipR21Process' },
-  { code: 'R2.2', stage: 'R2' },
+  { code: 'R2.2', stage: 'R2', processDefinitionKey: 'RipR22Process' },
   { code: 'R2.3', stage: 'R2' },
   { code: 'R2.4', stage: 'R2' },
   { code: 'R3.1', stage: 'R3' },


### PR DESCRIPTION
Deploying `RipR22Process` via LDE surfaced how much of the Infra-board's live data path was pinned to R2.1 by a literal. Three commits: the catalogue entry that started it, the generalisation it exposed, and a UX fix found while testing.

## 1. `R2.2` → `RipR22Process` in the phase catalogue

`RIP_PHASE_KEYS` carried R2.2 with no `processDefinitionKey`, which broke the chain at both ends: `/v1/rip/phases/deployment-status` builds its `keysIn` query from that list, so the engine was never asked about `RipR22Process`; and `getPhaseDeployStatus` requires the field to be set before it can match a returned key. R2.2 rendered as *In ontwerp* and the Faseladder read `1 / 12`.

The catalogue's own header comment names this as the step to take when a phase is deployed — it was simply missed.

## 2. Phase endpoints parameterised by phase code

The badge and the per-phase counts generalised for free from the catalogue, but the WIP/Gereed lists, the portfolio's live rows and the command palette read `'RipR21Process'` or `'R2.1'` directly — so R2.2 showed mock data beside a *Gedeployed* badge.

| Before | After |
|---|---|
| `GET /v1/rip/phase1/active` | `GET /v1/rip/phases/:code/active` |
| `GET /v1/rip/phase1/completed` | `GET /v1/rip/phases/:code/completed` |
| `GET /v1/rip/phase1/:instanceId/documents` | `GET /v1/rip/instances/:instanceId/documents` |

Documents moves sideways rather than gaining a `:code`: it resolves the deployment from the instance itself and fetches three fixed resource names that are R2.1's document set, not a general RIP convention.

`resolvePhaseKey` separates two failure modes an empty list would have conflated — **404 `UNKNOWN_PHASE`** for a code the catalogue doesn't carry, **409 `PHASE_NOT_MODELLED`** for a known phase with no process yet (R2.3 today). A caller must be able to tell "no process deployed" from "deployed and idle".

Frontend: `useRipPhaseActive(code | null)` / `useRipPhaseCompleted(code | null)`, plus `useRipActiveAcrossPhases()` which fans out over every modelled phase and tags each row with its `phaseCode`. `PROCESS_DISPLAY_NAMES` now derives from the catalogue — it feeds `INFRA_PROCESS_KEYS`, so the hand-written map would have silently dropped every R2.2 task from Mijn dag.

### One bug fixed during review

The cross-phase fetch originally used plain `Promise.all`. A non-2xx **rejects** the axios promise rather than resolving `{ success: false }`, so one failing phase discarded every phase's rows — observed in the browser as the live project vanishing from the portfolio. Now caught per request; only an across-the-board failure reports an error.

## 3. Disabled buttons look disabled

`.cwd-v2 .v2-btn` set `cursor: pointer` unconditionally with no `:disabled` rule anywhere, so a disabled button rendered in full accent pink with a hand cursor. Found on Beheer → R2.2 → Starten, where the start button is correctly disabled with nothing selected but read as broken.

## Behaviour worth knowing

`resolvePhaseKey` does not consult the engine, so a phase modelled in the catalogue but absent from the target environment — **R2.2 on ACC today** — answers `200` with an empty list rather than 409. Only `deployment-status` speaks to what is actually deployed where, which is why R2.2 correctly shows *In ontwerp* on ACC and *Gedeployed* locally.

## Testing

`type-check`, `lint`, `prettier --check` clean. Full suite and Playwright E2E green locally against a freshly reset Operaton with both processes deployed tenant-scoped to `flevoland`.

New coverage: six route tests for the 404/409 split and route-shadowing order; three hook tests for the fan-out including the one-phase-fails case that fails against plain `Promise.all`. The service tests now assert pass-through with a key the catalogue does not carry — the previous R2.1-keyed assertions would have passed unchanged had either method reverted to hardcoding.

Verified in the browser: Faseladder reads `2 / 12`, R2.1's live instance lists in Portfolio and its WIP tab, R2.2 answers with empty lists rather than an error.

## Known gap, not addressed here

"Finish R2.1 → R2.2 becomes startable" does not work yet, and this PR doesn't change that. `getReadyProjects` reads only the mock portfolio, so a completed live instance never enters it; and in the mock data a project at ladder position 1 can never be `wachtend`, so R2.2's ready list is structurally always empty. Wiring completed live instances into the next phase's ready list is the follow-up.
