### PR TITLE
Start a RIP phase from its finished predecessor

### DIFF
--- a/packages/backend/src/middleware/tenant.middleware.test.ts
+++ b/packages/backend/src/middleware/tenant.middleware.test.ts
@@ -127,6 +127,23 @@ describe('addTenantToProcessVariables', () => {
     expect((req.body as Record<string, unknown>).variables).toBeUndefined();
   });
 
+  it('keeps a caller-supplied business key so a phase can inherit it', () => {
+    const req = {
+      user: { tenantId: 'flevoland', organisationType: 'gemeente', userId: 'u1' },
+      body: { businessKey: 'flevoland-1788277164739', variables: {} },
+    } as unknown as Request;
+    const next = jest.fn();
+
+    addTenantToProcessVariables(req, makeRes(), next as NextFunction);
+
+    const body = req.body as { businessKey: string; variables: Record<string, unknown> };
+    expect(body.businessKey).toBe('flevoland-1788277164739');
+    // The tenant context is still applied -- honouring the key does not mean
+    // honouring anything else the caller sent.
+    expect(body.variables.municipality).toBe('flevoland');
+    expect(next).toHaveBeenCalled();
+  });
+
   it('injects businessKey and tenant-scoped variables', () => {
     const req = {
       user: {

--- a/packages/backend/src/middleware/tenant.middleware.ts
+++ b/packages/backend/src/middleware/tenant.middleware.ts
@@ -112,7 +112,21 @@ export const addTenantToProcessVariables = (req: Request, res: Response, next: N
       req.body.variables = {};
     }
 
-    req.body.businessKey = `${req.user.tenantId}-${Date.now()}`;
+    // Mint a business key only when the caller has none. A caller that
+    // supplies one is asserting a relationship the server cannot
+    // reconstruct: a RIP phase started for a project inherits the key its
+    // originating R2.1 run minted, so every phase instance of one project
+    // shares it and the board can tell which projects are already past a
+    // rung. Overwriting it unconditionally silently broke that -- each
+    // phase got a fresh key and no instance was ever recognisably related
+    // to another.
+    //
+    // Safe to honour: businessKey grants nothing. Tenant isolation runs on
+    // the municipality variable set immediately below, which is always
+    // taken from the token and never from the request body.
+    if (!req.body.businessKey) {
+      req.body.businessKey = `${req.user.tenantId}-${Date.now()}`;
+    }
 
     req.body.variables.municipality = req.user.tenantId;
     req.body.variables.organisationType = req.user.organisationType;

--- a/packages/backend/src/services/operaton.service.test.ts
+++ b/packages/backend/src/services/operaton.service.test.ts
@@ -1181,7 +1181,9 @@ describe('document bundles', () => {
 
 describe('archive list builders', () => {
   it('getRipPhaseActiveList maps project variables with fallbacks', async () => {
-    mockClient.post.mockResolvedValue({ data: [{ id: 'i1', startTime: 's' }] });
+    mockClient.post.mockResolvedValue({
+      data: [{ id: 'i1', businessKey: 'flevoland-123', startTime: 's' }],
+    });
     mockClient.get.mockResolvedValue({
       data: [
         { processInstanceId: 'i1', name: 'projectNumber', value: 'P1' },
@@ -1192,6 +1194,7 @@ describe('archive list builders', () => {
     const res = await svc.getRipPhaseActiveList('RipR21Process', 'flevoland');
     expect(res[0]).toEqual({
       id: 'i1',
+      businessKey: 'flevoland-123',
       startTime: 's',
       projectNumber: 'P1',
       projectName: 'Road',
@@ -1205,17 +1208,39 @@ describe('archive list builders', () => {
   });
 
   it('getRipPhaseCompletedList maps completed instances', async () => {
-    mockClient.post.mockResolvedValue({ data: [{ id: 'i1', startTime: 's', endTime: 'e' }] });
+    mockClient.post.mockResolvedValue({
+      data: [{ id: 'i1', businessKey: 'flevoland-123', startTime: 's', endTime: 'e' }],
+    });
     mockClient.get.mockResolvedValue({
       data: [{ processInstanceId: 'i1', name: 'projectNumber', value: 'P1' }],
     });
 
     const res = await svc.getRipPhaseCompletedList('RipR21Process', 'flevoland');
-    expect(res[0]).toMatchObject({ id: 'i1', endTime: 'e', projectNumber: 'P1', projectName: '—' });
+    expect(res[0]).toMatchObject({
+      id: 'i1',
+      businessKey: 'flevoland-123',
+      endTime: 'e',
+      projectNumber: 'P1',
+      projectName: '—',
+    });
     expect(mockClient.post).toHaveBeenCalledWith(
       '/history/process-instance',
       expect.objectContaining({ finished: true })
     );
+  });
+
+  it('maps a missing businessKey to null on both RIP list builders', async () => {
+    // Operaton omits businessKey rather than sending null when an instance
+    // was started without one. The readiness filter treats null as "no key,
+    // keep the candidate", so it must not arrive as undefined.
+    mockClient.post.mockResolvedValue({ data: [{ id: 'i1', startTime: 's', endTime: 'e' }] });
+    mockClient.get.mockResolvedValue({ data: [] });
+
+    const active = await svc.getRipPhaseActiveList('RipR21Process', 'flevoland');
+    expect(active[0].businessKey).toBeNull();
+
+    const completed = await svc.getRipPhaseCompletedList('RipR21Process', 'flevoland');
+    expect(completed[0].businessKey).toBeNull();
   });
 
   it('getCapacityClaimActiveList maps capacity variables', async () => {

--- a/packages/backend/src/services/operaton.service.ts
+++ b/packages/backend/src/services/operaton.service.ts
@@ -1325,6 +1325,11 @@ export class OperatonService {
   /**
    * List active (unfinished) instances of one RIP phase process for a
    * municipality, enriched with projectNumber, projectName, edocsWorkspaceId.
+   *
+   * businessKey identifies the project's whole journey rather than one
+   * instance: R2.1 mints it and every later phase started for that project
+   * inherits it. It is what lets the board tell whether a project has already
+   * started the next phase.
    * The caller resolves the phase code to its process-definition key via
    * RIP_PHASE_KEYS -- this method takes the key, not the code.
    */
@@ -1334,6 +1339,7 @@ export class OperatonService {
   ): Promise<
     {
       id: string;
+      businessKey: string | null;
       startTime: string;
       projectNumber: string;
       projectName: string;
@@ -1348,7 +1354,8 @@ export class OperatonService {
       sorting: [{ sortBy: 'startTime', sortOrder: 'desc' }],
     });
 
-    const instances: Array<{ id: string; startTime: string }> = instancesRes.data;
+    const instances: Array<{ id: string; businessKey: string | null; startTime: string }> =
+      instancesRes.data;
     if (instances.length === 0) return [];
 
     const ids = instances.map((i) => i.id).join(',');
@@ -1366,6 +1373,7 @@ export class OperatonService {
 
     return instances.map((i) => ({
       id: i.id,
+      businessKey: i.businessKey ?? null,
       startTime: i.startTime,
       projectNumber: varMap[i.id]?.projectNumber ?? '—',
       projectName: varMap[i.id]?.projectName ?? '—',
@@ -1443,6 +1451,7 @@ export class OperatonService {
   ): Promise<
     {
       id: string;
+      businessKey: string | null;
       startTime: string;
       endTime: string;
       projectNumber: string;
@@ -1457,7 +1466,12 @@ export class OperatonService {
       sorting: [{ sortBy: 'endTime', sortOrder: 'desc' }],
     });
 
-    const instances: Array<{ id: string; startTime: string; endTime: string }> = instancesRes.data;
+    const instances: Array<{
+      id: string;
+      businessKey: string | null;
+      startTime: string;
+      endTime: string;
+    }> = instancesRes.data;
     if (instances.length === 0) return [];
 
     const ids = instances.map((i) => i.id).join(',');
@@ -1474,6 +1488,7 @@ export class OperatonService {
 
     return instances.map((i) => ({
       id: i.id,
+      businessKey: i.businessKey ?? null,
       startTime: i.startTime,
       endTime: i.endTime,
       projectNumber: varMap[i.id]?.projectNumber ?? '—',

--- a/packages/frontend/src/components/InfraBoardDashboard/PhaseDetail.test.tsx
+++ b/packages/frontend/src/components/InfraBoardDashboard/PhaseDetail.test.tsx
@@ -1,6 +1,6 @@
 // @vitest-environment jsdom
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
-import { render, screen, within } from '@testing-library/react';
+import { render, screen, waitFor, within } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import PhaseDetail from './PhaseDetail';
 import { ripPhaseByCode, RIP_PHASES } from '../../pages/infra-board/rip-phases.catalog';
@@ -623,5 +623,146 @@ describe('PhaseDetail — Gereed tab', () => {
         /afgerond · Gemiddelde doorlooptijd \d+ wk · norm 10 wk · \d+ met review-loop/
       )
     ).toBeInTheDocument();
+  });
+});
+
+describe('PhaseDetail — starting the next phase from a finished predecessor', () => {
+  const completedR21 = {
+    id: 'pi-r21',
+    businessKey: 'flevoland-1788277164739',
+    startTime: '2026-01-05T09:00:00Z',
+    endTime: '2026-02-10T15:30:00Z',
+    projectNumber: '24011',
+    projectName: 'Larserweg — ongelijkvloerse aansluiting',
+    edocsWorkspaceId: 'w1',
+  };
+
+  function deployR22() {
+    mockGetPhaseDeployStatus.mockImplementation((phase: { code: string }) =>
+      phase.code === 'R2.1' || phase.code === 'R2.2' ? 'gedeployed' : 'ontwerp'
+    );
+    mockPhaseCompleted.mockImplementation((code: string) =>
+      Promise.resolve({ success: true, data: code === 'R2.1' ? [completedR21] : [] })
+    );
+    mockPhaseActive.mockResolvedValue({ success: true, data: [] });
+  }
+
+  it('lists a project whose R2.1 instance finished as ready to start R2.2', async () => {
+    deployR22();
+    render(<PhaseDetail phaseCode="R2.2" onBack={vi.fn()} />);
+
+    expect(await screen.findByText('24011')).toBeInTheDocument();
+    expect(
+      screen.getByText('Larserweg — ongelijkvloerse aansluiting', { exact: false })
+    ).toBeInTheDocument();
+    expect(mockPhaseCompleted).toHaveBeenCalledWith('R2.1');
+  });
+
+  it('carries the project number and business key into the new instance', async () => {
+    const user = userEvent.setup();
+    deployR22();
+    render(<PhaseDetail phaseCode="R2.2" onBack={vi.fn()} />);
+
+    await screen.findByText('24011');
+    const startButton = screen.getByRole('button', { name: 'R2.2 starten' });
+    expect(startButton).toBeDisabled();
+
+    await user.click(screen.getAllByRole('checkbox')[0]);
+    expect(startButton).not.toBeDisabled();
+    await user.click(startButton);
+
+    // The business key travels with the project, so every phase instance of
+    // one project shares the key its originating R2.1 run minted.
+    expect(mockStart).toHaveBeenCalledWith(
+      'RipR22Process',
+      expect.objectContaining({ projectNumber: '24011' }),
+      'flevoland-1788277164739'
+    );
+  });
+
+  it('does not offer a project that already has a running R2.2 instance', async () => {
+    deployR22();
+    mockPhaseActive.mockResolvedValue({
+      success: true,
+      data: [
+        {
+          id: 'pi-r22',
+          businessKey: 'flevoland-1788277164739',
+          startTime: '2026-02-11T08:00:00Z',
+          projectNumber: '24011',
+          projectName: 'Larserweg — ongelijkvloerse aansluiting',
+          edocsWorkspaceId: 'w1',
+          leadRole: '',
+        },
+      ],
+    });
+    render(<PhaseDetail phaseCode="R2.2" onBack={vi.fn()} />);
+
+    await screen.findByRole('button', { name: 'R2.2 starten' });
+    expect(screen.queryByText('24011')).not.toBeInTheDocument();
+  });
+
+  it('counts the same projects in the Starten tab badge as in the list below it', async () => {
+    deployR22();
+    const { container } = render(<PhaseDetail phaseCode="R2.2" onBack={vi.fn()} />);
+
+    await screen.findByText('24011');
+
+    // The badge used to read `klaar`, the Faseladder's arithmetic estimate
+    // (gereed[predecessor] - wip - gereed across mock and live combined),
+    // while the heading counted the rows actually rendered. On R2.2 those
+    // disagreed by one, because the mock fixtures report projects gereed on
+    // R2.1 that getReadyProjects can never return.
+    const startenTab = [...container.querySelectorAll('.pb-tab-badge')][0];
+    expect(startenTab?.textContent).toBe('1');
+    expect(screen.getByText(/Projecten die R2\.2 kunnen starten/)).toHaveTextContent(
+      'Projecten die R2.2 kunnen starten 1'
+    );
+  });
+
+  it('drops the badge to zero once the only candidate has been started', async () => {
+    const user = userEvent.setup();
+    deployR22();
+    const { container } = render(<PhaseDetail phaseCode="R2.2" onBack={vi.fn()} />);
+
+    await screen.findByText('24011');
+    await user.click(screen.getAllByRole('checkbox')[0]);
+
+    // Starting it makes the project's business key taken, so the next read of
+    // the readiness list excludes it.
+    mockPhaseActive.mockResolvedValue({
+      success: true,
+      data: [
+        {
+          id: 'pi-r22',
+          businessKey: 'flevoland-1788277164739',
+          startTime: '2026-02-11T08:00:00Z',
+          projectNumber: '24011',
+          projectName: 'Larserweg — ongelijkvloerse aansluiting',
+          edocsWorkspaceId: 'w1',
+          leadRole: '',
+        },
+      ],
+    });
+    await user.click(screen.getByRole('button', { name: 'R2.2 starten' }));
+
+    await waitFor(() => {
+      const startenTab = [...container.querySelectorAll('.pb-tab-badge')][0];
+      expect(startenTab?.textContent).toBe('0');
+    });
+    expect(screen.queryByText('24011')).not.toBeInTheDocument();
+  });
+
+  it('discloses on R5.4 that R5.3 is handled outside the tool', () => {
+    render(<PhaseDetail phaseCode="R5.4" onBack={vi.fn()} />);
+
+    // R5.4's entry criterion is "Oplevering areaal na R5.3", so a project
+    // arriving straight from R5.2 must not imply the board saw the oplevering.
+    expect(screen.getByText(/R5\.3.*buiten deze tool afgehandeld/)).toBeInTheDocument();
+  });
+
+  it('shows no such notice on a phase with an ordinary predecessor', () => {
+    render(<PhaseDetail phaseCode="R2.3" onBack={vi.fn()} />);
+    expect(screen.queryByText(/buiten deze tool afgehandeld/)).not.toBeInTheDocument();
   });
 });

--- a/packages/frontend/src/components/InfraBoardDashboard/PhaseDetail.tsx
+++ b/packages/frontend/src/components/InfraBoardDashboard/PhaseDetail.tsx
@@ -4,7 +4,9 @@ import {
   RIP_STAGES,
   RIP_DEPLOY_META,
   getPhaseDeployStatus,
+  previousModelledPhase,
   ripPhaseByCode,
+  skippedPhasesBefore,
 } from '../../pages/infra-board/rip-phases.catalog';
 import {
   getMockPhaseCounts,
@@ -15,16 +17,13 @@ import {
   getMockGereedRows,
   getMockGeparkeerdRows,
 } from '../../pages/infra-board/infra-board.data';
-import {
-  combinePhaseCounts,
-  getKlaarCounts,
-  normalizeLiveCounts,
-} from '../../pages/infra-board/rip-phase-counts';
+import { combinePhaseCounts, normalizeLiveCounts } from '../../pages/infra-board/rip-phase-counts';
 import {
   useDeployedProcessKeys,
   useLivePhaseCounts,
   useRipPhaseActive,
   useRipPhaseCompleted,
+  useRipPhaseReadiness,
 } from '../../services/infra.api';
 import { businessApi } from '../../services/api';
 import {
@@ -61,6 +60,10 @@ export default function PhaseDetail({ phaseCode, onBack }: Props) {
   // Null for a phase with no process model: there are no instances to ask
   // for, and the phase endpoints answer 409 rather than an empty list.
   const livePhaseCode = phase?.processDefinitionKey ? phaseCode : null;
+  // The phase whose completed instances feed this one's ready list. Null when
+  // that predecessor has no process model, since it can have no completions.
+  const predecessor = previousModelledPhase(phaseCode);
+  const predecessorLiveCode = predecessor?.processDefinitionKey ? predecessor.code : null;
   const { data: deployment } = useDeployedProcessKeys();
   const { data: liveCountsRaw } = useLivePhaseCounts();
   const [tab, setTab] = useState<'starten' | 'wip' | 'gereed'>('starten');
@@ -85,6 +88,7 @@ export default function PhaseDetail({ phaseCode, onBack }: Props) {
     error: gereedError,
     reload: reloadGereed,
   } = useRipPhaseCompleted(livePhaseCode);
+  const readiness = useRipPhaseReadiness(livePhaseCode, predecessorLiveCode);
 
   const [wipDerived, setWipDerived] = useState<
     Record<string, { info: WipStepInfo | null; docs: DocProgress }>
@@ -139,13 +143,31 @@ export default function PhaseDetail({ phaseCode, onBack }: Props) {
     liveGereed: 0,
     liveGeparkeerd: 0,
   };
-  const klaarCombined = getKlaarCounts(RIP_PHASES, combined);
-  const klaar = klaarCombined[phase.code];
   const status = getPhaseDeployStatus(phase, deployedKeys);
   const meta = RIP_DEPLOY_META[status];
   const stage = RIP_STAGES.find((s) => s.code === phase.stage);
   const isFirstPhase = RIP_PHASES[0].code === phase.code;
   const canStart = status === 'gedeployed';
+
+  const readyProjects = getReadyProjects(phase.code);
+  const outOfSequenceProjects = getOutOfSequenceProjects(phase.code);
+  const liveCandidates = readiness.candidates;
+  // Phases handled outside this tool that sit between the predecessor and
+  // this one -- R5.3 today. Surfaced so a project appearing here straight
+  // from R5.2 does not imply the board tracked the oplevering.
+  const skipped = skippedPhasesBefore(phase.code);
+
+  // The number of projects this tab actually lists. Deliberately NOT `klaar`,
+  // which the Faseladder derives arithmetically as
+  // gereed[predecessor] - wip[this] - gereed[this] across mock and live
+  // combined. That approximation is right for a twelve-row overview, where
+  // itemising every phase would cost three requests each, but on this screen
+  // it sat in a tab badge directly above a heading counting the rows below
+  // it, and the two disagreed: the mock fixtures report projects as gereed on
+  // R2.1 that getReadyProjects can never return, because no mock project is
+  // ever 'wachtend' at ladder position 1. One screen, one definition of
+  // ready -- the itemised one, since it is the one the user can count.
+  const totalReady = liveCandidates.length + readyProjects.length;
 
   const header = (
     <>
@@ -219,11 +241,27 @@ export default function PhaseDetail({ phaseCode, onBack }: Props) {
     setSubmitting(true);
     try {
       const nrs = [...selected];
-      await Promise.all(nrs.map(() => businessApi.process.start(phase!.processDefinitionKey!, {})));
+      await Promise.all(
+        nrs.map((nr) => {
+          // A live candidate carries the project's businessKey forward, so
+          // every phase instance of one project shares the key its
+          // originating R2.1 run minted. Mock rows have no engine ancestry
+          // and start without one.
+          const candidate = readiness.candidates.find((c) => c.projectNumber === nr);
+          return businessApi.process.start(
+            phase!.processDefinitionKey!,
+            candidate
+              ? { projectNumber: candidate.projectNumber, projectName: candidate.projectName }
+              : { projectNumber: nr },
+            candidate?.businessKey ?? undefined
+          );
+        })
+      );
       setSelected(new Set());
       setReasons({});
       setJustStarted(nrs.length);
       reloadWip();
+      readiness.reload();
     } finally {
       setSubmitting(false);
     }
@@ -246,9 +284,6 @@ export default function PhaseDetail({ phaseCode, onBack }: Props) {
       setSubmitting(false);
     }
   }
-
-  const readyProjects = getReadyProjects(phase.code);
-  const outOfSequenceProjects = getOutOfSequenceProjects(phase.code);
 
   function toggleReady(nr: string) {
     setSelected((s) => {
@@ -315,7 +350,7 @@ export default function PhaseDetail({ phaseCode, onBack }: Props) {
           className={tab === 'starten' ? 'active' : ''}
           onClick={() => setTab('starten')}
         >
-          Starten <span className="pb-tab-badge">{klaar ?? 0}</span>
+          Starten <span className="pb-tab-badge">{totalReady}</span>
         </button>
         <button
           type="button"
@@ -545,8 +580,7 @@ export default function PhaseDetail({ phaseCode, onBack }: Props) {
           <div className="pb-starten-main">
             {!canStart && (
               <div className="pb-banner">
-                {meta.label} — {meta.note} Er staan wel {readyProjects.length} projecten klaar voor
-                deze fase.
+                {meta.label} — {meta.note} Er staan wel {totalReady} projecten klaar voor deze fase.
               </div>
             )}
 
@@ -555,10 +589,18 @@ export default function PhaseDetail({ phaseCode, onBack }: Props) {
             )}
 
             <h2>
-              Projecten die {phase.code} kunnen starten <span>{readyProjects.length}</span>
+              Projecten die {phase.code} kunnen starten <span>{totalReady}</span>
             </h2>
 
-            {isFirstPhase && readyProjects.length === 0 ? (
+            {skipped.length > 0 && (
+              <p className="pb-skip-note">
+                {skipped.map((sp) => `${sp.code} (${sp.name})`).join(', ')} wordt buiten deze tool
+                afgehandeld. Projecten komen hier binnen vanuit{' '}
+                {predecessor ? predecessor.code : '—'}.
+              </p>
+            )}
+
+            {isFirstPhase && totalReady === 0 ? (
               fallbackStarted ? (
                 <div className="pb-banner pb-banner-success">
                   {phase.code} gestart. De intake taak staat klaar in de wachtrij.
@@ -585,6 +627,23 @@ export default function PhaseDetail({ phaseCode, onBack }: Props) {
             ) : (
               <>
                 <ul className="pb-ready-list">
+                  {liveCandidates.map((c) => (
+                    <li key={c.instanceId}>
+                      <input
+                        type="checkbox"
+                        disabled={!canStart}
+                        checked={selected.has(c.projectNumber)}
+                        onChange={() => toggleReady(c.projectNumber)}
+                      />
+                      <span className="pb-proj-nr">{c.projectNumber}</span> {c.projectName}
+                      <span className="pb-badge-klaar">KLAAR</span>
+                      <span className="pb-live-badge">live</span>
+                      <div className="sub">
+                        {predecessor ? `${predecessor.code} afgerond` : 'Vorige fase afgerond'} ·{' '}
+                        {new Date(c.endTime).toLocaleDateString('nl-NL')}
+                      </div>
+                    </li>
+                  ))}
                   {readyProjects.map((p) => (
                     <li key={p.id}>
                       <input

--- a/packages/frontend/src/pages/infra-board/dashboard-infra.css
+++ b/packages/frontend/src/pages/infra-board/dashboard-infra.css
@@ -925,6 +925,14 @@
   font-size: 11px;
   border-radius: 3px;
 }
+.pbd .pb-skip-note {
+  margin: 0 0 12px;
+  padding: 8px 12px;
+  border-left: 3px solid var(--v2-ink-3);
+  background: var(--v2-surface-2, #f4f5f7);
+  font-size: 12px;
+  color: var(--v2-ink-2);
+}
 .pbd .pb-ready-list .sub {
   font-size: 12px;
   color: var(--v2-ink-3);

--- a/packages/frontend/src/pages/infra-board/infra-board.data.ts
+++ b/packages/frontend/src/pages/infra-board/infra-board.data.ts
@@ -10,7 +10,7 @@
  */
 
 import { ROLES, type StatusKey, type HealthKey } from './rip-model';
-import { RIP_PHASES, type RipPhase } from './rip-phases.catalog';
+import { previousModelledPhase, RIP_PHASES, type RipPhase } from './rip-phases.catalog';
 import type { PhaseCounts } from './rip-phase-counts';
 
 /** Valid portfolio lead-role keys (rip-model vocabulary). */
@@ -808,11 +808,10 @@ export function getMockGeparkeerdRows(phase: RipPhase): PortfolioProject[] {
  * there is no predecessor to be ready from.
  */
 export function getReadyProjects(phaseCode: string): PortfolioProject[] {
-  const idx = RIP_PHASES.findIndex((p) => p.code === phaseCode);
-  if (idx <= 0) return [];
-  const prevCode = RIP_PHASES[idx - 1].code;
+  const prev = previousModelledPhase(phaseCode);
+  if (!prev) return [];
   return getMockPortfolio().filter(
-    (p) => p.ripPhaseCode === prevCode && p.ripPhaseState === 'wachtend'
+    (p) => p.ripPhaseCode === prev.code && p.ripPhaseState === 'wachtend'
   );
 }
 

--- a/packages/frontend/src/pages/infra-board/rip-phase-counts.test.ts
+++ b/packages/frontend/src/pages/infra-board/rip-phase-counts.test.ts
@@ -68,6 +68,26 @@ describe('combinePhaseCounts', () => {
   });
 });
 
+describe('getKlaarCounts and beyond phases', () => {
+  it('derives R5.4 from R5.2, stepping over the beyond phase R5.3', () => {
+    // With R5.3 as the literal predecessor this reads max(0, 0 - 0 - 0) = 0
+    // for any input, because a beyond phase can never carry a completed
+    // instance. Stepping back to R5.2 makes the figure mean something.
+    const counts: Record<string, PhaseCounts> = {
+      'R5.2': { wip: 0, gereed: 9, geparkeerd: 0 },
+      'R5.3': { wip: 0, gereed: 0, geparkeerd: 0 },
+      'R5.4': { wip: 2, gereed: 1, geparkeerd: 0 },
+    };
+    const result = getKlaarCounts(RIP_PHASES, counts);
+    expect(result['R5.4']).toBe(6); // 9 - 2 - 1
+  });
+
+  it('still gives the first phase no klaar figure at all', () => {
+    const result = getKlaarCounts(RIP_PHASES, {});
+    expect(result[RIP_PHASES[0].code]).toBeUndefined();
+  });
+});
+
 describe('normalizeLiveCounts', () => {
   it('maps backend processDefinitionKey counts onto phase codes with geparkeerd: 0', () => {
     const raw = { RipR21Process: { wip: 3, gereed: 7 } };

--- a/packages/frontend/src/pages/infra-board/rip-phase-counts.ts
+++ b/packages/frontend/src/pages/infra-board/rip-phase-counts.ts
@@ -24,8 +24,8 @@ export interface AnnotatedPhaseCounts extends PhaseCounts {
 const EMPTY: PhaseCounts = { wip: 0, gereed: 0, geparkeerd: 0 };
 
 /**
- * klaar[N] = max(0, gereed[N-1] - wip[N] - gereed[N]) — projects that
- * finished the previous phase but haven't reached this one yet. The first
+ * klaar[N] = max(0, gereed[prev] - wip[N] - gereed[N]) — projects that
+ * finished the preceding phase but haven't reached this one yet. The first
  * phase in ladder order has no predecessor, so it's always undefined
  * (render "—", not 0 — there's nothing to be ready *for*).
  */
@@ -35,11 +35,17 @@ export function getKlaarCounts(
 ): Record<string, number | undefined> {
   const out: Record<string, number | undefined> = {};
   phases.forEach((phase, i) => {
-    if (i === 0) {
+    // Step back past any `beyond` phase, matching previousModelledPhase in
+    // the catalogue. R5.3 is beyond, so R5.4's klaar figure derives from
+    // R5.2: a beyond phase can never carry a completed instance, so reading
+    // it as the predecessor would peg R5.4 at zero forever.
+    let p = i - 1;
+    while (p >= 0 && phases[p].beyond) p--;
+    if (p < 0) {
       out[phase.code] = undefined;
       return;
     }
-    const prev = counts[phases[i - 1].code] ?? EMPTY;
+    const prev = counts[phases[p].code] ?? EMPTY;
     const cur = counts[phase.code] ?? EMPTY;
     out[phase.code] = Math.max(0, prev.gereed - cur.wip - cur.gereed);
   });

--- a/packages/frontend/src/pages/infra-board/rip-phases.catalog.test.ts
+++ b/packages/frontend/src/pages/infra-board/rip-phases.catalog.test.ts
@@ -1,7 +1,9 @@
 import { describe, expect, it } from 'vitest';
 import {
   getPhaseDeployStatus,
+  previousModelledPhase,
   ripPhaseByCode,
+  skippedPhasesBefore,
   RIP_PHASES,
   RIP_STAGES,
   type RipPhase,
@@ -74,6 +76,48 @@ describe('RIP_PHASES catalogue', () => {
     const stageCodes = new Set(RIP_STAGES.map((s) => s.code));
     for (const phase of RIP_PHASES) {
       expect(stageCodes.has(phase.stage)).toBe(true);
+    }
+  });
+});
+
+describe('previousModelledPhase / skippedPhasesBefore', () => {
+  it('is the immediate predecessor for every ordinary phase', () => {
+    expect(previousModelledPhase('R2.2')?.code).toBe('R2.1');
+    expect(previousModelledPhase('R3.1')?.code).toBe('R2.4');
+    expect(previousModelledPhase('R5.2')?.code).toBe('R5.1');
+    expect(previousModelledPhase('R6.1')?.code).toBe('R5.4');
+  });
+
+  it('is undefined for the first phase, which has nothing to be ready for', () => {
+    expect(previousModelledPhase('R2.1')).toBeUndefined();
+    expect(skippedPhasesBefore('R2.1')).toEqual([]);
+  });
+
+  it('skips R5.3, so R5.4 follows R5.2', () => {
+    // R5.4's entry criterion reads "Oplevering areaal na R5.3", so R5.3 does
+    // happen -- but it is `beyond`: no process model, and no exit artefact at
+    // all, so nothing about its completion is observable here. Reading it as
+    // R5.4's predecessor would peg R5.4 at zero candidates forever.
+    expect(ripPhaseByCode('R5.3')?.beyond).toBe(true);
+    expect(previousModelledPhase('R5.4')?.code).toBe('R5.2');
+  });
+
+  it('names the skipped phase so the UI can disclose it', () => {
+    expect(skippedPhasesBefore('R5.4').map((p) => p.code)).toEqual(['R5.3']);
+  });
+
+  it('reports no skip for any phase other than R5.4', () => {
+    for (const phase of RIP_PHASES) {
+      if (phase.code === 'R5.4') continue;
+      expect(skippedPhasesBefore(phase.code)).toEqual([]);
+    }
+  });
+
+  it('every phase after the first resolves to a predecessor that is not beyond', () => {
+    for (const phase of RIP_PHASES.slice(1)) {
+      const prev = previousModelledPhase(phase.code);
+      expect(prev).toBeDefined();
+      expect(prev?.beyond).toBeUndefined();
     }
   });
 });

--- a/packages/frontend/src/pages/infra-board/rip-phases.catalog.ts
+++ b/packages/frontend/src/pages/infra-board/rip-phases.catalog.ts
@@ -463,3 +463,44 @@ export function getPhaseDeployStatus(
   if (phase.beyond) return 'onbekend';
   return 'ontwerp';
 }
+
+/**
+ * The phase a project must have finished before it can start `code`.
+ *
+ * Not simply `RIP_PHASES[i - 1]`: a `beyond` phase is skipped. R5.3 is the
+ * only one today, and skipping it is a deliberate assertion rather than a
+ * technicality. R5.4's entry criterion reads "Oplevering areaal na R5.3", so
+ * R5.3 genuinely happens — but it has no overzichtsplaat, no process model,
+ * and (decisively) no exit artefact at all, so nothing about its completion
+ * is observable here. Every other transition in the ladder is triggered by a
+ * named deliverable that the previous phase's exit criterion produces.
+ *
+ * Callers that surface a skip to the user should say so; see
+ * `skippedPhasesBefore`.
+ *
+ * Returns undefined for the first phase, which has no predecessor.
+ */
+export function previousModelledPhase(code: string): RipPhase | undefined {
+  const idx = RIP_PHASES.findIndex((p) => p.code === code);
+  if (idx <= 0) return undefined;
+  for (let i = idx - 1; i >= 0; i--) {
+    if (!RIP_PHASES[i].beyond) return RIP_PHASES[i];
+  }
+  return undefined;
+}
+
+/**
+ * Phases between `code` and its effective predecessor that are handled
+ * outside this tool — what `previousModelledPhase` stepped over. Empty for
+ * every phase except R5.4 today.
+ */
+export function skippedPhasesBefore(code: string): RipPhase[] {
+  const idx = RIP_PHASES.findIndex((p) => p.code === code);
+  if (idx <= 0) return [];
+  const skipped: RipPhase[] = [];
+  for (let i = idx - 1; i >= 0; i--) {
+    if (!RIP_PHASES[i].beyond) break;
+    skipped.unshift(RIP_PHASES[i]);
+  }
+  return skipped;
+}

--- a/packages/frontend/src/services/api.ts
+++ b/packages/frontend/src/services/api.ts
@@ -315,6 +315,7 @@ export const businessApi = {
       ApiResponse<
         Array<{
           id: string;
+          businessKey: string | null;
           startTime: string;
           projectNumber: string;
           projectName: string;
@@ -359,6 +360,7 @@ export const businessApi = {
       ApiResponse<
         Array<{
           id: string;
+          businessKey: string | null;
           startTime: string;
           endTime: string;
           projectNumber: string;

--- a/packages/frontend/src/services/infra.api.test.ts
+++ b/packages/frontend/src/services/infra.api.test.ts
@@ -9,6 +9,7 @@ import {
   useLivePhaseCounts,
   useOpenTasks,
   useRipActiveAcrossPhases,
+  useRipPhaseReadiness,
   useRipPhaseCompleted,
 } from './infra.api';
 
@@ -308,6 +309,110 @@ describe('useRipActiveAcrossPhases', () => {
     await waitFor(() => expect(result.current.loading).toBe(false));
 
     expect(result.current.error).toBe(true);
+  });
+});
+
+describe('useRipPhaseReadiness', () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  const done = (nr: string, key: string | null) => ({
+    id: 'done-' + nr,
+    businessKey: key,
+    startTime: '2026-01-01T00:00:00Z',
+    endTime: '2026-02-01T00:00:00Z',
+    projectNumber: nr,
+    projectName: 'Project ' + nr,
+    edocsWorkspaceId: 'w1',
+  });
+
+  const running = (key: string | null) => ({
+    id: 'run-' + key,
+    businessKey: key,
+    startTime: '2026-03-01T00:00:00Z',
+    projectNumber: '00000',
+    projectName: 'Running',
+    edocsWorkspaceId: 'w1',
+    leadRole: '',
+  });
+
+  function arrange(opts: {
+    predecessorDone?: ReturnType<typeof done>[];
+    thisActive?: ReturnType<typeof running>[];
+    thisDone?: ReturnType<typeof done>[];
+  }) {
+    mockBusinessApi.rip.phaseCompleted.mockClear();
+    mockBusinessApi.rip.phaseActive.mockClear();
+    mockBusinessApi.rip.phaseCompleted.mockImplementation((code: string) =>
+      Promise.resolve({
+        success: true,
+        data: code === 'R2.1' ? (opts.predecessorDone ?? []) : (opts.thisDone ?? []),
+      })
+    );
+    mockBusinessApi.rip.phaseActive.mockResolvedValue({
+      success: true,
+      data: opts.thisActive ?? [],
+    });
+  }
+
+  it('offers projects whose predecessor instance completed', async () => {
+    arrange({ predecessorDone: [done('24011', 'flevoland-1'), done('24056', 'flevoland-2')] });
+
+    const { result } = renderHook(() => useRipPhaseReadiness('R2.2', 'R2.1'));
+    await waitFor(() => expect(result.current.loading).toBe(false));
+
+    expect(result.current.candidates.map((c) => c.projectNumber)).toEqual(['24011', '24056']);
+    expect(result.current.candidates[0].businessKey).toBe('flevoland-1');
+  });
+
+  it('drops a project whose business key already has a running instance of this phase', async () => {
+    arrange({
+      predecessorDone: [done('24011', 'flevoland-1'), done('24056', 'flevoland-2')],
+      thisActive: [running('flevoland-1')],
+    });
+
+    const { result } = renderHook(() => useRipPhaseReadiness('R2.2', 'R2.1'));
+    await waitFor(() => expect(result.current.loading).toBe(false));
+
+    expect(result.current.candidates.map((c) => c.projectNumber)).toEqual(['24056']);
+  });
+
+  it('drops a project whose business key already has a completed instance of this phase', async () => {
+    arrange({
+      predecessorDone: [done('24011', 'flevoland-1')],
+      thisDone: [done('24011', 'flevoland-1')],
+    });
+
+    const { result } = renderHook(() => useRipPhaseReadiness('R2.2', 'R2.1'));
+    await waitFor(() => expect(result.current.loading).toBe(false));
+
+    expect(result.current.candidates).toEqual([]);
+  });
+
+  it('keeps a candidate that carries no business key rather than hiding it', async () => {
+    // An instance predating the convention, or started by hand. Offering a
+    // possibly-duplicate start is recoverable; silently dropping a project
+    // from the board is not.
+    arrange({
+      predecessorDone: [done('24011', null)],
+      thisActive: [running(null)],
+    });
+
+    const { result } = renderHook(() => useRipPhaseReadiness('R2.2', 'R2.1'));
+    await waitFor(() => expect(result.current.loading).toBe(false));
+
+    expect(result.current.candidates.map((c) => c.projectNumber)).toEqual(['24011']);
+  });
+
+  it('asks for nothing when the predecessor phase has no process model', async () => {
+    arrange({});
+
+    const { result } = renderHook(() => useRipPhaseReadiness('R2.3', null));
+    await waitFor(() => expect(result.current.loading).toBe(false));
+
+    expect(result.current.candidates).toEqual([]);
+    expect(mockBusinessApi.rip.phaseCompleted).not.toHaveBeenCalledWith(null);
   });
 });
 

--- a/packages/frontend/src/services/infra.api.ts
+++ b/packages/frontend/src/services/infra.api.ts
@@ -16,6 +16,9 @@ import { RIP_PHASES } from '../pages/infra-board/rip-phases.catalog';
 
 export interface RipPhaseInstance {
   id: string;
+  /** Identifies the project's journey across phases, not just this instance:
+   *  the originating R2.1 run mints it and every later phase inherits it. */
+  businessKey: string | null;
   startTime: string;
   projectNumber: string;
   projectName: string;
@@ -98,6 +101,7 @@ export const useRipPhaseActive = (phaseCode: string | null) =>
 
 export interface RipPhaseCompletedInstance {
   id: string;
+  businessKey: string | null;
   startTime: string;
   endTime: string;
   projectNumber: string;
@@ -146,6 +150,70 @@ async function fetchActiveAcrossPhases(): Promise<{
 /** Running instances portfolio-wide, across every deployed phase. */
 export const useRipActiveAcrossPhases = () =>
   useAsync<RipPhaseInstanceRow[]>(fetchActiveAcrossPhases, []);
+
+/** A project that finished the preceding phase and can start this one. */
+export interface RipPhaseCandidate {
+  /** The completed predecessor instance this candidate came from. */
+  instanceId: string;
+  businessKey: string | null;
+  projectNumber: string;
+  projectName: string;
+  endTime: string;
+}
+
+export interface RipPhaseReadiness {
+  candidates: RipPhaseCandidate[];
+  loading: boolean;
+  error: boolean;
+  reload: () => void;
+}
+
+/**
+ * Projects whose completed predecessor-phase instance makes them ready to
+ * start `phaseCode`, minus those already started.
+ *
+ * "Already started" is decided on businessKey rather than project number: the
+ * key travels with the project from its originating R2.1 run, so an instance
+ * of this phase carrying it is proof the project is past this rung. A
+ * candidate whose predecessor has no businessKey at all (an instance started
+ * before the convention, or by hand) is kept rather than dropped -- offering
+ * a duplicate start is recoverable, silently hiding a project is not.
+ */
+export function useRipPhaseReadiness(
+  phaseCode: string | null,
+  predecessorCode: string | null
+): RipPhaseReadiness {
+  const completed = useRipPhaseCompleted(predecessorCode);
+  const active = useRipPhaseActive(phaseCode);
+  const started = useRipPhaseCompleted(phaseCode);
+
+  const taken = new Set(
+    [...(active.data ?? []), ...(started.data ?? [])]
+      .map((i) => i.businessKey)
+      .filter((k): k is string => !!k)
+  );
+
+  const candidates = (completed.data ?? [])
+    .filter((i) => !(i.businessKey && taken.has(i.businessKey)))
+    .map((i) => ({
+      instanceId: i.id,
+      businessKey: i.businessKey,
+      projectNumber: i.projectNumber,
+      projectName: i.projectName,
+      endTime: i.endTime,
+    }));
+
+  return {
+    candidates,
+    loading: completed.loading || active.loading || started.loading,
+    error: completed.error || active.error || started.error,
+    reload: () => {
+      completed.reload();
+      active.reload();
+      started.reload();
+    },
+  };
+}
 
 /** Activity-history for a process instance — drives swimlane node status. */
 export const useActivityHistory = (instanceId: string | null) =>

--- a/scripts/rip-purge-instances.sh
+++ b/scripts/rip-purge-instances.sh
@@ -1,0 +1,152 @@
+#!/usr/bin/env bash
+# rip-purge-instances.sh
+# Removes every runtime and history record of the RIP phase processes from an
+# Operaton engine, leaving the deployed process definitions in place. This is
+# the "start the walkthrough from nothing" reset: after it, the Faseladder's
+# LIVE figures are all zero and the Starten tabs offer nothing, so a run
+# through R2.1 -> R2.2 -> ... begins from a known state.
+#
+# Scoped by process-definition key. Every other process on the engine
+# (AwbShellProcess, the E2E sub-processes, ...) is untouched, and the script
+# prints what remains deployed afterwards so you can see that it was.
+#
+# Deleting a running instance produces a history entry, so history is listed
+# again AFTER the runtime deletions rather than before — otherwise the
+# instances cancelled by this very script would survive in history.
+#
+# Usage:
+#   bash scripts/rip-purge-instances.sh                 # purge, with confirmation
+#   bash scripts/rip-purge-instances.sh --yes           # no confirmation
+#   bash scripts/rip-purge-instances.sh --dry-run       # list what would go
+#
+# Optional overrides (env vars):
+#   OPERATON_URL   engine REST base (default: http://localhost:8081/engine-rest)
+#   RIP_KEYS       comma-separated process-definition keys
+#                  (default: RipR21Process,RipR22Process — extend as phases deploy)
+#
+# ACC: OPERATON_URL=https://operaton.open-regels.nl/engine-rest bash scripts/rip-purge-instances.sh
+# Think twice before doing that — ACC history is not yours alone.
+#
+# Note on Windows: python opens stdout in text mode, so a bare print() emits
+# CRLF and every id would carry a trailing CR straight into the request URL,
+# where curl reports HTTP 000 rather than anything you can act on. Hence the
+# reconfigure(newline='') below. Same trap as jq on this machine.
+
+set -uo pipefail
+
+OPERATON_URL="${OPERATON_URL:-http://localhost:8081/engine-rest}"
+RIP_KEYS="${RIP_KEYS:-RipR21Process,RipR22Process}"
+
+ASSUME_YES=0
+DRY_RUN=0
+for arg in "$@"; do
+  case "$arg" in
+    --yes|-y)  ASSUME_YES=1 ;;
+    --dry-run) DRY_RUN=1 ;;
+    -h|--help) sed -n '2,32p' "$0"; exit 0 ;;
+    *) echo "Unknown argument: $arg" >&2; exit 2 ;;
+  esac
+done
+
+PY_BIN="$(command -v python || command -v python3 || true)"
+if [ -z "$PY_BIN" ]; then
+  echo "python is required (used to parse the engine's JSON)." >&2
+  exit 1
+fi
+
+# ["RipR21Process","RipR22Process"] from the comma-separated list.
+KEYS_JSON=$(printf '%s' "$RIP_KEYS" | "$PY_BIN" -c \
+  "import sys,json;print(json.dumps([k.strip() for k in sys.stdin.read().split(',') if k.strip()]))")
+
+PY_IDS="import sys,json;sys.stdout.reconfigure(newline='');[print(i['id']) for i in json.load(sys.stdin)]"
+
+if ! curl -sf -o /dev/null "$OPERATON_URL/version"; then
+  echo "Operaton not reachable at $OPERATON_URL" >&2
+  exit 1
+fi
+
+query_ids() { # $1 = '' for runtime, 'history/' for history
+  curl -s -X POST "$OPERATON_URL/${1}process-instance" \
+    -H 'Content-Type: application/json' \
+    -d "{\"processDefinitionKeyIn\":$KEYS_JSON}" | "$PY_BIN" -c "$PY_IDS"
+}
+
+count() { # $1 = '' | 'history/', $2 = key
+  curl -s -X POST "$OPERATON_URL/${1}process-instance/count" \
+    -H 'Content-Type: application/json' -d "{\"processDefinitionKey\":\"$2\"}" |
+    "$PY_BIN" -c "import sys,json;print(json.load(sys.stdin)['count'])"
+}
+
+# Report anything other than success or an already-absent record. A silent
+# delete loop that swallows a 500 leaves you believing the engine is clean.
+del() { # $1 = url, $2 = label
+  local code
+  code=$(curl -s -o /dev/null -w '%{http_code}' -X DELETE "$1")
+  case "$code" in
+    200|204) echo "  ok      $2" ;;
+    404)     echo "  gone    $2 (already absent)" ;;
+    *)       echo "  FAILED  $2 -> HTTP $code"; FAILURES=$((FAILURES + 1)) ;;
+  esac
+}
+
+echo "Engine: $OPERATON_URL"
+echo "Keys  : $RIP_KEYS"
+echo
+echo "Current state:"
+for k in ${RIP_KEYS//,/ }; do
+  echo "  $k  runtime=$(count '' "$k")  history=$(count 'history/' "$k")"
+done
+echo
+
+if [ "$DRY_RUN" -eq 1 ]; then
+  echo "Dry run — would delete:"
+  for id in $(query_ids ''); do echo "  runtime $id"; done
+  for id in $(query_ids 'history/'); do echo "  history $id"; done
+  exit 0
+fi
+
+if [ "$ASSUME_YES" -eq 0 ]; then
+  printf 'Delete all runtime and history records for these keys? [y/N] '
+  read -r reply
+  case "$reply" in [yY]*) ;; *) echo "Aborted."; exit 0 ;; esac
+fi
+
+FAILURES=0
+
+echo "== runtime instances =="
+RUN_IDS=$(query_ids '')
+[ -z "$RUN_IDS" ] && echo "  (none)"
+for id in $RUN_IDS; do
+  del "$OPERATON_URL/process-instance/$id?skipCustomListeners=true&skipIoMappings=true" "runtime $id"
+done
+
+echo "== history (re-listed, so it includes what was just cancelled) =="
+HIST_IDS=$(query_ids 'history/')
+[ -z "$HIST_IDS" ] && echo "  (none)"
+for id in $HIST_IDS; do
+  del "$OPERATON_URL/history/process-instance/$id" "history $id"
+done
+
+echo
+echo "== verification =="
+REMAINING=0
+for k in ${RIP_KEYS//,/ }; do
+  r=$(count '' "$k")
+  h=$(count 'history/' "$k")
+  echo "  $k  runtime=$r  history=$h"
+  REMAINING=$((REMAINING + r + h))
+done
+
+echo
+echo "== still deployed, untouched =="
+curl -s "$OPERATON_URL/process-definition?latestVersion=true" | "$PY_BIN" -c \
+  "import sys,json;[print('  ',d['key'],'tenant='+str(d['tenantId'])) for d in json.load(sys.stdin)]"
+
+if [ "$FAILURES" -gt 0 ] || [ "$REMAINING" -gt 0 ]; then
+  echo
+  echo "NOT clean: $FAILURES delete failure(s), $REMAINING record(s) remaining." >&2
+  exit 1
+fi
+
+echo
+echo "Clean."


### PR DESCRIPTION
> **Stacked on #44.** Base is `feat/rip-r22-phase-key`, not `acc` — this work calls `/v1/rip/phases/:code/completed`, which only exists there. Retarget to `acc` once #44 merges.

Completing R2.1 did nothing for R2.2. This makes finishing a phase hand the project to the next one, and it generalises to every rung of the ladder rather than to R2.1→R2.2 alone.

## Why it couldn't work before

`getReadyProjects` reads only the mock portfolio, so a completed live instance never entered it. And in the mock data a project at ladder position 1 can never be `wachtend` — which is precisely what R2.2's ready list requires — so that list was structurally always empty. Both routes to a ready project were closed.

## The rule

> A completed instance of phase N makes its project ready to start the next **modelled** phase after N.

Taken from the phase specs in LDE's `rip-phases-left`. Every phase's entry criterion names the previous phase's exit artefact, several verbatim (`R2.4` exits *Projectplan 6. Afronding DO-fase*, `R3.1` enters on it), so the ladder is strictly linear: one predecessor each, no parallel branches, no conditional skips.

### R5.3 is why this isn't `RIP_PHASES[i - 1]`

R5.4's entry reads *"Oplevering areaal **na R5.3**"*, so R5.3 genuinely happens. But it has no overzichtsplaat (there's no `R5_3` PDF; the catalogue's own `bron` says *"PLACEHOLDER — geen overzichtsplaat aangeleverd"*), no process model, and decisively **no exit artefact at all**. Every other transition is triggered by a named deliverable; R5.3 has nothing that could ever be observed here.

So `previousModelledPhase` skips `beyond` phases, and `skippedPhasesBefore` names what was stepped over so R5.4's Starten tab can say the oplevering is handled outside this tool. Skipping is an assertion about the process, not a technicality, and the UI discloses it rather than quietly implying the board tracked something it didn't.

`getKlaarCounts` had the same bug independently: it read the literal predecessor, pegging R5.4's klaar figure to a phase that can never carry a completed instance — `max(0, 0 − wip − gereed)` = 0 for any input.

## Carrying the project forward

`businessKey` identifies the project's **journey**, not one instance: the originating R2.1 run mints it and every later phase inherits it.

- It now flows through both RIP list builders. Operaton *omits* the field rather than sending null when an instance has none, so both map it to an explicit `null` — the readiness filter distinguishes "no key" from "key not taken", and there's a test for it.
- Starting a phase passes `projectNumber`, `projectName` and the inherited key. Mock rows have no engine ancestry and start without one.
- `useRipPhaseReadiness` excludes candidates whose key already appears among this phase's active *or* completed instances. **A candidate whose predecessor carries no key is kept, not dropped** — offering a possibly-duplicate start is recoverable; silently dropping a project from the board is not.

### The middleware fix this depended on

`addTenantToProcessVariables` minted a fresh `businessKey` on *every* start, unconditionally, discarding whatever the caller sent. Invisible, because the key it produced looked exactly like the one it threw away — and harmless until two instances needed to be recognisably related. With it in place each phase got its own key and the R2.2 Starten tab kept offering projects that were already running.

Now minted only when the caller has none. Safe to honour: `businessKey` grants no access anywhere, and tenant isolation runs on the `municipality` variable set on the line below, always from the token and never from the request body. The new test asserts that still holds when a key is supplied.

## One UI inconsistency fixed on the way

The Starten tab badge read `klaar` — the Faseladder's arithmetic estimate, `gereed[predecessor] − wip − gereed` across mock and live combined — while the heading directly beneath it counted the rows actually rendered. On R2.2 they disagreed by one, because the mock fixtures report a project `gereed` on R2.1 that `getReadyProjects` can never return.

The badge now uses the same itemised count as the heading. The Faseladder keeps the arithmetic, which is the right call for a twelve-row overview where itemising every phase would cost three requests each. The two converge exactly — not approximately — once mock data comes out of the counts.

## `scripts/rip-purge-instances.sh`

Resets an engine to "no RIP has ever run" without touching the deployed definitions, so a walkthrough starts from a state you can reason about. Scoped by process-definition key; prints what remains deployed afterwards so "nothing else touched" is visible rather than asserted.

Two deliberate details: history is listed **after** the runtime deletions (cancelling a running instance *creates* a history entry, so listing first leaves behind exactly what the script just cancelled), and any status other than 200/204/404 is reported with a non-zero exit — a delete loop that swallows a 500 leaves you believing the engine is clean when it isn't.

## Testing

`type-check`, `lint`, `prettier --check` clean. New coverage: 7 catalogue/klaar tests for the predecessor rule, 5 readiness-hook tests, 7 `PhaseDetail` tests, 3 backend tests for `businessKey` mapping and the middleware.

Two claims were mutation-checked rather than trusted green:

- removing the `beyond` skip from `previousModelledPhase` fails 2 tests (the R5.4→R5.2 assertion and the disclosure notice);
- making the tab badge off-by-one fails 2 tests.

Walked through in the browser against a freshly purged engine: complete one R2.1 → R2.2 offers exactly that project → starting it leaves zero, and the new instance carries its parent's business key.

## Not addressed here

The Faseladder's Klaar column still reads one higher than the phase page, because mock data is still mixed into the counts. Stripping it is the agreed follow-up and closes this properly; a second special case here would only paper over it.
