### PR TITLE
chore: bump release to v2026.09.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "ronl-business-api",
-  "version": "2026.08.36",
+  "version": "2026.09.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "ronl-business-api",
-      "version": "2026.08.36",
+      "version": "2026.09.0",
       "hasInstallScript": true,
       "license": "EUPL-1.2",
       "workspaces": [
@@ -16710,7 +16710,7 @@
     },
     "packages/backend": {
       "name": "@ronl/backend",
-      "version": "2026.08.36",
+      "version": "2026.09.0",
       "license": "EUPL-1.2",
       "dependencies": {
         "@anthropic-ai/sdk": "^0.122.0",
@@ -16838,7 +16838,7 @@
     },
     "packages/frontend": {
       "name": "@ronl/frontend",
-      "version": "2026.08.36",
+      "version": "2026.09.0",
       "dependencies": {
         "@bpmn-io/form-js": "^1.20.1",
         "@ronl/pa-cockpit": "*",
@@ -18937,7 +18937,7 @@
     },
     "packages/shared": {
       "name": "@ronl/shared",
-      "version": "2026.08.36",
+      "version": "2026.09.0",
       "license": "EUPL-1.2",
       "devDependencies": {
         "typescript": "^5.3.3"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ronl-business-api",
-  "version": "2026.08.36",
+  "version": "2026.09.0",
   "description": "Secure, multi-tenant Business API for Dutch municipality BPMN/DMN services",
   "private": true,
   "workspaces": [

--- a/packages/backend/package.json
+++ b/packages/backend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ronl/backend",
-  "version": "2026.08.36",
+  "version": "2026.09.0",
   "description": "Secure Business API layer for Dutch municipality BPMN services",
   "main": "dist/index.js",
   "scripts": {

--- a/packages/backend/src/index.ts
+++ b/packages/backend/src/index.ts
@@ -171,6 +171,7 @@ app.get('/', (req: Request, res: Response) => {
       rip: '/v1/rip',
       edocs: '/v1/edocs',
       doccle: '/v1/doccle',
+      validsign: '/v1/validsign',
       curator: '/v1/pa',
       mediaAggregator: '/v1/media-aggregator',
       admin: '/v1/admin',

--- a/packages/frontend/package.json
+++ b/packages/frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ronl/frontend",
-  "version": "2026.08.36",
+  "version": "2026.09.0",
   "description": "Municipality portal (MijnOmgeving) with identity provider selection",
   "type": "module",
   "scripts": {

--- a/packages/frontend/src/pages/changelog-data.ts
+++ b/packages/frontend/src/pages/changelog-data.ts
@@ -108,6 +108,76 @@ export const changelog: Changelog = {
   versions: [
     {
       format: 'commits',
+      version: '2026.09.0',
+      status: 'Released',
+      date: '1 sep 2026',
+      scope: ['backend', 'frontend'],
+      commits: [
+        {
+          sha: 'f556444',
+          author: 'Steven Gort',
+          type: 'feat',
+          subject: 'Finishing a phase makes its project ready to start the next one',
+          details: [
+            "Completing R2.1 did nothing for R2.2. getReadyProjects read only the mock portfolio, so a completed live instance never entered it — and in the mock data a project at ladder position 1 can never be wachtend, which is what R2.2's ready list requires. Both routes to a ready project were closed.",
+            'The rule, taken from the phase specs: a completed instance of phase N makes its project ready to start the next modelled phase after N. Every phase’s entry criterion names the previous phase’s exit artefact, several verbatim, so the ladder is strictly linear. R5.3 is the exception and the reason previousModelledPhase exists rather than RIP_PHASES[i-1]: R5.4 enters on “Oplevering areaal na R5.3”, so R5.3 happens — but it has no overzichtsplaat, no process model, and no exit artefact at all, so nothing about its completion is observable. Skipping it is an assertion, and skippedPhasesBefore surfaces it so R5.4 can say the oplevering is handled outside the tool.',
+            'businessKey identifies the project’s journey rather than one instance: the originating R2.1 run mints it and every later phase inherits it. It now flows through both RIP list builders, and useRipPhaseReadiness excludes candidates whose key already has an active or completed instance of this phase. A candidate whose predecessor carries no key is kept — offering a possibly-duplicate start is recoverable, silently dropping a project from the board is not.',
+          ],
+        },
+        {
+          sha: '107ab72',
+          author: 'Steven Gort',
+          type: 'fix',
+          subject: 'A caller-supplied business key survives instead of being overwritten',
+          details: [
+            'addTenantToProcessVariables minted a fresh businessKey on every process start, unconditionally, discarding anything the caller sent before the service saw it. Invisible, because the key it produced looked exactly like the one it threw away — and harmless while every instance stood alone.',
+            'It stops being harmless once two instances need to be recognisably related: with the overwrite in place each RIP phase got its own key, nothing was related to anything, and the R2.2 Starten tab kept offering projects that were already running. Now minted only when the caller has none. Honouring a supplied key is safe — businessKey grants no access, and tenant isolation runs on the municipality variable taken from the token on the line below, which the added test asserts still holds.',
+          ],
+        },
+        {
+          sha: '262401d',
+          author: 'Steven Gort',
+          type: 'fix',
+          subject: 'A disabled button on the infra board now looks disabled',
+          details: [
+            '.cwd-v2 .v2-btn set cursor: pointer unconditionally and no :disabled rule existed anywhere in the stylesheet, so a disabled button rendered in full accent pink with a hand cursor — indistinguishable from a live one, on every screen using the shared v2 chrome. Found on Beheer → R2.2 → Starten, where the start button is correctly disabled with nothing selected but read as broken.',
+          ],
+        },
+        {
+          sha: '06b5015',
+          author: 'Steven Gort',
+          type: 'refactor',
+          subject: 'RIP phase endpoints take a phase code instead of assuming R2.1',
+          details: [
+            'Deploying RipR22Process exposed how much of the live data path was pinned to R2.1 by a literal. The Faseladder badge and the per-phase counts generalised for free from the catalogue, but the WIP and Gereed lists, the portfolio’s live rows and the command palette read RipR21Process or R2.1 directly, so R2.2 rendered mock data beside a Gedeployed badge. /v1/rip/phase1/active and /completed become /v1/rip/phases/:code/…, and the documents route moves to /v1/rip/instances/:instanceId/documents — instance-keyed, because it resolves the deployment from the instance itself and its three resource names are R2.1’s document set rather than a general RIP convention.',
+            'resolvePhaseKey separates two failure modes an empty list would conflate: 404 UNKNOWN_PHASE for a code the catalogue does not carry, 409 PHASE_NOT_MODELLED for a known phase with no process yet. A caller must be able to tell “no process deployed” from “deployed and idle”. The engine is not consulted, so a phase modelled here but absent from the target environment still answers 200 with an empty list; only deployment-status speaks to what is deployed where.',
+            'The cross-phase portfolio fetch catches per request rather than relying on Promise.all — a non-2xx rejects the axios promise instead of resolving { success: false }, so one failing phase discarded every phase’s rows. PROCESS_DISPLAY_NAMES now derives from the phase catalogue: it feeds INFRA_PROCESS_KEYS, which filters both the infra task list and the Archief split, so the hand-written map would have silently dropped every R2.2 task from Mijn dag.',
+          ],
+        },
+        {
+          sha: '87f84d7',
+          author: 'Steven Gort',
+          type: 'feat',
+          subject: 'R2.2 maps to RipR22Process in the RIP phase catalogue',
+          details: [
+            'RipR22Process was deployed on the engine but RIP_PHASE_KEYS still carried R2.2 with no processDefinitionKey. That single omission broke the chain at both ends: the deployment-status endpoint builds its keysIn query from this list, so the engine was never asked about RipR22Process; and getPhaseDeployStatus requires the field to be set before it can match a returned key. R2.2 rendered as In ontwerp and the Faseladder read 1 / 12 deelprocessen inzetbaar.',
+            'Note for anyone repeating this: @ronl/shared must be rebuilt and packages/frontend/node_modules/.vite deleted before the frontend sees the change. Vite validates its pre-bundle cache against the dependency’s version, not its dist content, so a rebuilt workspace dist is invisible to it — restarting the dev server and hard-refreshing both appear to do nothing.',
+          ],
+        },
+        {
+          sha: '40449fc',
+          author: 'Steven Gort',
+          type: 'fix',
+          subject: 'The untenanted start-form fallback sees a text-typed error body',
+          details: [
+            'getByKeyWithTenantFallback decides whether to retry a failed tenant-scoped lookup against the untenanted path by matching Operaton’s “No matching process definition with key” wording in error.response.data.message. getDeployedStartForm is the only caller passing responseType: ‘text’, and axios disables JSON parsing of the error body when responseType is set — so the body arrived as an unparsed string, .message was undefined, the guard rethrew, and the fallback could never fire. Every process deployed without a tenant answered 404 FORM_NOT_FOUND to any caller carrying one: on ACC, 21 of 23 latest-version definitions, including AwbShellProcess behind the citizen Kapvergunning form.',
+            'The raw body is now matched when it has not been parsed. The existing fallback test mocked the error body as an already-parsed object, which is why the suite stayed green while the path was dead; the added test uses the shape axios actually delivers.',
+          ],
+        },
+      ],
+    },
+    {
+      format: 'commits',
       version: '2026.08.36',
       status: 'Released',
       date: '30 aug 2026',

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ronl/shared",
-  "version": "2026.08.36",
+  "version": "2026.09.0",
   "description": "Shared types and utilities for RONL Business API",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",


### PR DESCRIPTION
First release of September, so the patch resets to `0` — the previous release was `2026.08.36`.

## Scope: `['backend', 'frontend']`

The range touches `packages/backend`, `packages/frontend` and `packages/shared`. `shared` has no scope tag of its own because it feeds both builds, so the declared scope covers everything detected — no mismatch, nothing inferred.

| File | Change |
|---|---|
| `package.json` (root) | `2026.08.36 → 2026.09.0` — always bumped, triggers no CI |
| `packages/frontend/package.json` | `2026.08.36 → 2026.09.0` |
| `packages/backend/package.json` | `2026.08.36 → 2026.09.0` |
| `packages/shared/package.json` | `2026.08.36 → 2026.09.0` — versioned in lockstep, and it changed |
| `package-lock.json` | top-level, `packages[""]`, and the three workspace entries |

`packages/public-site` stays at `2026.08.29` and `packages/pa-demo` at `2026.08.30`. Neither was touched; bumping them would trip their path-filtered workflows and deploy code that did not change.

Versions were edited by hand rather than with `npm version`, which coerces its argument to strict SemVer and would silently write `2026.9.0`. `npm ci --dry-run` re-verified that the lockfile still resolves.

## Endpoint map

Gained one key: `validsign: '/v1/validsign'`. It is mounted twice in `index.ts` (callback routes and main routes) but had never been advertised — it shipped in `v2026.08.36` and this reconcile step missed it then. The RIP changes in this release needed no map edit; they are routes *within* `/v1/rip`, which is mounted as a whole.

## What ships

Six commits, newest first:

| | |
|---|---|
| `f556444` feat | Finishing a phase makes its project ready to start the next one |
| `107ab72` fix | A caller-supplied business key survives instead of being overwritten |
| `262401d` fix | A disabled button on the infra board now looks disabled |
| `06b5015` refactor | RIP phase endpoints take a phase code instead of assuming R2.1 |
| `87f84d7` feat | R2.2 maps to `RipR22Process` in the RIP phase catalogue |
| `40449fc` fix | The untenanted start-form fallback sees a text-typed error body |

Two notes on the commit list:

- **`40449fc` is included deliberately.** It merged as #43 *after* `v2026.08.36` was cut, so it belongs to this release rather than the previous one, and it appears in no other entry. Leaving it out would mean a fix that is already deployed to ACC shows up in no changelog at all.
- **A seventh commit in range, `a00af7c`, is deliberately unlisted.** It adds `scripts/rip-purge-instances.sh`, a developer tool that ships no product change. The commit stays on `acc`; it simply is not release-note material.

## Deferred

Renovate's `vite` v8 PR (#30) and the renovate-config PR (#20) were reviewed under step 0 and deferred. Both stay open and will be gathered by the next release. #30 rewrites `package-lock.json`, so merging it *after* this bump would either conflict or silently revert the version — it needs to go first in whichever release takes it.

## Merge method

**Merge commit, not squash or rebase.** The changelog entry names each commit by SHA, and both alternatives rewrite those hashes — squashing collapses them into one new commit, rebasing replays them as new ones while deceptively preserving the count. Either leaves the entry pointing at commits that do not exist on `acc`.

Merging redeploys frontend, pa-demo and public-site (no path filter on those workflows), and backend too, since `packages/backend/**` changed.

## Checks

`npm run format`, `npm run lint` and `npm run type-check` clean. `ChangelogPanel` 15/15 with the new entry rendering.
