### PR TITLE
feat(pa-cockpit): Ongefilterd — browse each signaalbron's raw feed

### DIFF
--- a/packages/pa-cockpit/src/pages/public-affairs-v2/Monitoring.test.tsx
+++ b/packages/pa-cockpit/src/pages/public-affairs-v2/Monitoring.test.tsx
@@ -67,6 +67,60 @@ afterEach(() => {
   vi.clearAllMocks();
 });
 
+describe('the Ongefilterd view', () => {
+  // Third segment beside Gecureerd and Inbox: the tab's own sources, fetched
+  // raw with no query. The backend has always accepted a null q — the source
+  // clients default to it and the curation cycle uses that "blanco" path — but
+  // runSearch bailed on an empty string, so there was no way to reach it from
+  // the UI without typing something.
+  //
+  // It appears only on the signaalbronnen. Agenda is a monitoring tab with no
+  // TAB_SOURCES entry (it is fed by fetchAgenda, a different path), and Feiten
+  // & cijfers is not a monitoring tab at all — it is its own section and never
+  // renders this control. So the condition is derived from the source map
+  // rather than hardcoded, and a future source tab gets the segment for free.
+
+  it('offers the segment on a signaalbron tab', async () => {
+    render(<Monitoring activeTab="politiek" onOpenDossier={vi.fn()} />);
+    expect(await screen.findByRole('button', { name: /Ongefilterd/ })).toBeInTheDocument();
+  });
+
+  it('does not offer it on Agenda, which has no feed sources', async () => {
+    render(<Monitoring activeTab="agenda" onOpenDossier={vi.fn()} />);
+    // Wait for the page to settle so this is not a false pass on an unrendered tree.
+    await screen.findByRole('button', { name: /Gecureerd/ });
+    expect(screen.queryByRole('button', { name: /Ongefilterd/ })).not.toBeInTheDocument();
+  });
+
+  it("fetches the tab's source with no query at all", async () => {
+    const user = userEvent.setup();
+    render(<Monitoring activeTab="europa" onOpenDossier={vi.fn()} />);
+    await user.click(await screen.findByRole('button', { name: /Ongefilterd/ }));
+
+    await waitFor(() => expect(paApi.fetchFeed).toHaveBeenCalled());
+    const call = paApi.fetchFeed.mock.calls.at(-1)?.[0] as Record<string, unknown>;
+    expect(call.source).toBe('eu');
+    // Not `q: ''` — absent. An empty string would be indistinguishable from a
+    // user clearing the search box, and the whole point is the unfiltered feed.
+    expect('q' in call).toBe(false);
+  });
+
+  it('issues one call per source when the tab draws from several', async () => {
+    const user = userEvent.setup();
+    render(<Monitoring activeTab="politiek" onOpenDossier={vi.fn()} />);
+    await user.click(await screen.findByRole('button', { name: /Ongefilterd/ }));
+
+    // politiek is ['tk','ob']. FeedSource is single-valued and 'both' is not
+    // equivalent: it also pulls media when that flag is on, and deliberately
+    // excludes eu. So the tab fans out rather than widening its scope.
+    await waitFor(() => {
+      const sources = paApi.fetchFeed.mock.calls.map((c) => (c[0] as { source?: string }).source);
+      expect(sources).toContain('tk');
+      expect(sources).toContain('ob');
+    });
+  });
+});
+
 describe('the pa.api mock', () => {
   it('only names exports the real module has', async () => {
     // Spreading the real module covers a missing member; this covers a renamed

--- a/packages/pa-cockpit/src/pages/public-affairs-v2/Monitoring.test.tsx
+++ b/packages/pa-cockpit/src/pages/public-affairs-v2/Monitoring.test.tsx
@@ -105,6 +105,53 @@ describe('the Ongefilterd view', () => {
     expect('q' in call).toBe(false);
   });
 
+  function rawItems(n: number, source: 'tk' | 'ob' | 'eu' | 'media' = 'eu') {
+    return Array.from({ length: n }, (_, i) => ({
+      id: `r${i}`,
+      title: `Rauw item ${i}`,
+      type: null,
+      number: null,
+      date: null,
+      url: null,
+      source,
+    }));
+  }
+
+  it('marks the count as capped when a source holds more than it returned', async () => {
+    // The number on the segment is a page size, not an answer. Politiek shows
+    // 60 and the others 30 because that is top:30 per source — so a bare count
+    // reads as "this is all there is" when it is "this is all we asked for".
+    paApi.fetchFeed.mockResolvedValue({ items: rawItems(30), total: 500 });
+    const user = userEvent.setup();
+    render(<Monitoring activeTab="europa" onOpenDossier={vi.fn()} />);
+    await user.click(await screen.findByRole('button', { name: /Ongefilterd/ }));
+
+    expect(await screen.findByRole('button', { name: /Ongefilterd\s*30\+/ })).toBeInTheDocument();
+    expect(await screen.findByText(/500/)).toBeInTheDocument();
+  });
+
+  it('shows a plain count when the feed fits inside the page', async () => {
+    paApi.fetchFeed.mockResolvedValue({ items: rawItems(4), total: 4 });
+    const user = userEvent.setup();
+    render(<Monitoring activeTab="europa" onOpenDossier={vi.fn()} />);
+    await user.click(await screen.findByRole('button', { name: /Ongefilterd/ }));
+
+    const seg = await screen.findByRole('button', { name: /Ongefilterd/ });
+    await waitFor(() => expect(seg).toHaveAccessibleName(/Ongefilterd\s*4$/));
+  });
+
+  it('treats a full page with an unknown total as capped', async () => {
+    // TK returns total: null for multi-term queries. A blank feed is not
+    // multi-term so it should carry a real total, but the view must not read a
+    // null as "nothing more" — a full page is the signal that survives either way.
+    paApi.fetchFeed.mockResolvedValue({ items: rawItems(30), total: null });
+    const user = userEvent.setup();
+    render(<Monitoring activeTab="europa" onOpenDossier={vi.fn()} />);
+    await user.click(await screen.findByRole('button', { name: /Ongefilterd/ }));
+
+    expect(await screen.findByRole('button', { name: /Ongefilterd\s*30\+/ })).toBeInTheDocument();
+  });
+
   it('issues one call per source when the tab draws from several', async () => {
     const user = userEvent.setup();
     render(<Monitoring activeTab="politiek" onOpenDossier={vi.fn()} />);

--- a/packages/pa-cockpit/src/pages/public-affairs-v2/Monitoring.tsx
+++ b/packages/pa-cockpit/src/pages/public-affairs-v2/Monitoring.tsx
@@ -558,6 +558,14 @@ function RawHitCard({
   );
 }
 
+/**
+ * Items fetched per source for the Ongefilterd view. The route allows up to 100
+ * and the search band beside this one uses 30, so this matches its neighbour
+ * rather than inventing a second number. It is a ceiling, and rawMeta.capped is
+ * what stops the resulting count from reading as a total.
+ */
+const RAW_PAGE = 30;
+
 export default function Monitoring({ activeTab = 'politiek', onOpenDossier, onNavigate }: Props) {
   const {
     confirmSignal,
@@ -578,6 +586,14 @@ export default function Monitoring({ activeTab = 'politiek', onOpenDossier, onNa
   // search and this view cannot overwrite each other's results.
   const [raw, setRaw] = useState<FeedItem[] | null>(null);
   const [rawLoading, setRawLoading] = useState(false);
+  // What the count on the segment actually means. Without this the number is a
+  // page size wearing the clothes of an answer: politiek showed 60 and the rest
+  // 30 because that is RAW_PAGE per source, not because the feeds hold that many.
+  const [rawMeta, setRawMeta] = useState<{
+    total: number | null;
+    capped: boolean;
+    cap: number;
+  } | null>(null);
   const [signals, setSignals] = useState<Signal[]>([]);
   const [inbox, setInbox] = useState<Signal[]>([]);
   const [inboxMeta, setInboxMeta] = useState<InboxMeta | null>(null);
@@ -641,7 +657,25 @@ export default function Monitoring({ activeTab = 'politiek', onOpenDossier, onNa
       // One call per source rather than one widened call. FeedSource is
       // single-valued and 'both' is not the union this needs: it also pulls
       // media when that flag is on, and deliberately excludes eu.
-      const results = await Promise.all(sources.map((source) => fetchFeed({ source, top: 30 })));
+      const results = await Promise.all(
+        sources.map((source) => fetchFeed({ source, top: RAW_PAGE }))
+      );
+      const totals = results.map((r) => r.total);
+      setRawMeta({
+        // Only meaningful if every source reported one; a partial sum would be a
+        // number that looks authoritative and is not.
+        total: totals.every((t) => typeof t === 'number')
+          ? totals.reduce((a: number, b) => a + (b as number), 0)
+          : null,
+        // A full page counts as capped even when the total is unknown. TK returns
+        // null for multi-term queries — a blank feed is not multi-term, so it
+        // should carry a real total, but a null must never be read as "nothing
+        // more". A full page is the signal that survives either way.
+        capped: results.some((r) =>
+          typeof r.total === 'number' ? r.total > r.items.length : r.items.length >= RAW_PAGE
+        ),
+        cap: RAW_PAGE,
+      });
       const seen = new Set<string>();
       setRaw(
         results
@@ -655,6 +689,7 @@ export default function Monitoring({ activeTab = 'politiek', onOpenDossier, onNa
       );
     } catch {
       setRaw([]);
+      setRawMeta(null);
     }
     setRawLoading(false);
   }, [tab.id]);
@@ -690,6 +725,8 @@ export default function Monitoring({ activeTab = 'politiek', onOpenDossier, onNa
     setFeedQuery('');
     setFeedResults(null);
     setFeedTotal(null);
+    setRaw(null);
+    setRawMeta(null);
     setFeedSource('both');
     setSavedSearch(false);
   }, [tab.id]);
@@ -926,7 +963,11 @@ export default function Monitoring({ activeTab = 'politiek', onOpenDossier, onNa
             }}
           >
             Ongefilterd
-            {raw ? <span className="pac-seg-count">{raw.length}</span> : null}
+            {raw ? (
+              <span className="pac-seg-count">
+                {rawMeta?.capped ? `${raw.length}+` : raw.length}
+              </span>
+            ) : null}
           </button>
         )}
       </div>
@@ -1034,6 +1075,17 @@ export default function Monitoring({ activeTab = 'politiek', onOpenDossier, onNa
         <p className="pac-page-sub">Signalen ophalen…</p>
       ) : view === 'ongefilterd' ? (
         <>
+          {rawMeta?.capped && (
+            <div className="pac-inbox-cap">
+              <span className="pac-inbox-cap-badge">Top {rawMeta.cap} per bron</span>
+              <span>
+                {rawMeta.total !== null
+                  ? `${rawMeta.total} items in deze bronfeeds. `
+                  : 'Deze bronfeeds bevatten meer dan hier past. '}
+                De weergave toont de nieuwste {rawMeta.cap} per bron; de rest valt nu buiten beeld.
+              </span>
+            </div>
+          )}
           <div className="pac-searchres-head">
             <div className="pac-searchres-title">
               <span>Ongefilterd</span>

--- a/packages/pa-cockpit/src/pages/public-affairs-v2/Monitoring.tsx
+++ b/packages/pa-cockpit/src/pages/public-affairs-v2/Monitoring.tsx
@@ -18,6 +18,7 @@ import {
   promoteSearchToTenant,
   promoteToInbox,
   paTabBronnen,
+  paTabFeedSources,
   signalTag,
   signalTagLabel,
   BRON_LABEL,
@@ -572,7 +573,11 @@ export default function Monitoring({ activeTab = 'politiek', onOpenDossier, onNa
   const refetchAllSignals = allSignals.refetch;
   const tab = MONITORING_TABS.find((t) => t.id === activeTab) ?? MONITORING_TABS[0];
 
-  const [view, setView] = useState<'gecureerd' | 'inbox'>('gecureerd');
+  const [view, setView] = useState<'gecureerd' | 'inbox' | 'ongefilterd'>('gecureerd');
+  // The tab's raw feed, unfiltered. Kept separate from feedResults so a typed
+  // search and this view cannot overwrite each other's results.
+  const [raw, setRaw] = useState<FeedItem[] | null>(null);
+  const [rawLoading, setRawLoading] = useState(false);
   const [signals, setSignals] = useState<Signal[]>([]);
   const [inbox, setInbox] = useState<Signal[]>([]);
   const [inboxMeta, setInboxMeta] = useState<InboxMeta | null>(null);
@@ -620,6 +625,43 @@ export default function Monitoring({ activeTab = 'politiek', onOpenDossier, onNa
     // underneath it, still showing signals that no longer existed.
     refetchAllSignals();
   }, [tab.id, updateInboxCount, refreshInboxCounts, refetchAllSignals]);
+
+  // Which sources this tab reads, as ids. Empty means the tab has no raw feed
+  // behind it, which is what keeps this view off Agenda without a second list
+  // to maintain. Feiten & cijfers never reaches here at all — it is its own
+  // section, not a monitoring tab.
+  const rawSources = paTabFeedSources(tab.id);
+  const hasRawFeed = rawSources.length > 0;
+
+  const loadRaw = useCallback(async () => {
+    const sources = paTabFeedSources(tab.id);
+    if (!sources.length) return;
+    setRawLoading(true);
+    try {
+      // One call per source rather than one widened call. FeedSource is
+      // single-valued and 'both' is not the union this needs: it also pulls
+      // media when that flag is on, and deliberately excludes eu.
+      const results = await Promise.all(sources.map((source) => fetchFeed({ source, top: 30 })));
+      const seen = new Set<string>();
+      setRaw(
+        results
+          .flatMap((r) => r.items)
+          .filter((it) => {
+            const key = `${it.source}:${it.id}`;
+            if (seen.has(key)) return false;
+            seen.add(key);
+            return true;
+          })
+      );
+    } catch {
+      setRaw([]);
+    }
+    setRawLoading(false);
+  }, [tab.id]);
+
+  useEffect(() => {
+    if (view === 'ongefilterd') void loadRaw();
+  }, [view, loadRaw]);
 
   useEffect(() => {
     void load();
@@ -874,6 +916,19 @@ export default function Monitoring({ activeTab = 'politiek', onOpenDossier, onNa
           Inbox{' '}
           <span className="pac-seg-count">{inboxMeta?.capped ? '100+' : visibleInbox.length}</span>
         </button>
+        {hasRawFeed && (
+          <button
+            type="button"
+            className={`pac-seg-btn ${view === 'ongefilterd' ? 'active' : ''}`}
+            onClick={() => {
+              setView('ongefilterd');
+              clearSearch();
+            }}
+          >
+            Ongefilterd
+            {raw ? <span className="pac-seg-count">{raw.length}</span> : null}
+          </button>
+        )}
       </div>
 
       {/* Blanco zoekfunctie — cross-source raw search, independent of the tab */}
@@ -977,6 +1032,36 @@ export default function Monitoring({ activeTab = 'politiek', onOpenDossier, onNa
         </>
       ) : loading ? (
         <p className="pac-page-sub">Signalen ophalen…</p>
+      ) : view === 'ongefilterd' ? (
+        <>
+          <div className="pac-searchres-head">
+            <div className="pac-searchres-title">
+              <span>Ongefilterd</span>
+              <span className="scope"> · {paTabBronnen(tab.id).join(' + ')}</span>
+            </div>
+            <div className="pac-searchres-count">{rawLoading ? '…' : (raw?.length ?? 0)} items</div>
+          </div>
+          {rawLoading ? (
+            <p className="pac-page-sub">Bronfeeds ophalen…</p>
+          ) : raw && raw.length ? (
+            <div>
+              {raw.map((item) => (
+                <RawHitCard
+                  key={`${item.source}:${item.id}`}
+                  item={item}
+                  done={promotedKeys.has(`${item.source}:${item.id}`)}
+                  onPromote={(x) => void handlePromote(x)}
+                  onHelp={openPipeline}
+                />
+              ))}
+            </div>
+          ) : (
+            <p className="pac-page-sub">
+              Niets in de rauwe bronfeeds van deze signaalbron. Een bron die uitstaat levert hier
+              ook niets op — <b>Beheer › Signaalbronnen</b> toont welke aan staan.
+            </p>
+          )}
+        </>
       ) : view === 'inbox' ? (
         <>
           {inboxMeta?.capped && (

--- a/packages/pa-cockpit/src/services/pa.api.ts
+++ b/packages/pa-cockpit/src/services/pa.api.ts
@@ -1266,6 +1266,23 @@ export function paTabBronnen(tabId: string): string[] {
   return (TAB_SOURCES[tabId] ?? []).map((b) => BRON_LABEL[b]);
 }
 
+/**
+ * The feed sources a monitoring tab draws from, as ids rather than labels.
+ *
+ * paTabBronnen above answers "what do I tell the user this tab reads?"; this
+ * answers "what do I fetch for it?". They differ deliberately — BRON_LABEL
+ * maps 'eu' to 'Europees Parlement', which is not a FeedSource.
+ *
+ * An empty array is meaningful: it identifies a monitoring tab with no raw
+ * feed behind it. `agenda` is that case today — it is fed by fetchAgenda, a
+ * different path entirely. The Ongefilterd view keys its own existence off
+ * this, so it appears on the signaalbronnen and nowhere else without anyone
+ * maintaining a second list that could drift from this one.
+ */
+export function paTabFeedSources(tabId: string): FeedSource[] {
+  return (TAB_SOURCES[tabId] ?? []) as FeedSource[];
+}
+
 const TAG_BY_TAB: Record<string, string> = {
   politiek: 'nl',
   regionaal: 'regio',
@@ -1437,17 +1454,26 @@ export async function fetchSearches(): Promise<SavedSearch[]> {
 export type FeedSource = 'both' | 'tk' | 'ob' | 'eu' | 'media';
 
 export async function fetchFeed(params: {
-  q: string;
+  /**
+   * Free-text query. Omit it entirely for the unfiltered feed: GET /pa/feed
+   * reads `q` as `string | null` and every source client defaults it to null,
+   * which is the "blanco" path the curation cycle itself runs on.
+   *
+   * Absent and '' are not the same thing. '' is what a user leaves behind when
+   * they clear the search box, and runSearch reads that as "show nothing";
+   * absent is a deliberate request for everything.
+   */
+  q?: string;
   source?: FeedSource;
   types?: string[];
   skip?: number;
   top?: number;
 }): Promise<{ items: FeedItem[]; total: number | null }> {
   if (isPaMock()) {
-    const q = params.q.toLowerCase();
+    const q = (params.q ?? '').toLowerCase();
     const src = params.source ?? 'both';
     const items: FeedItem[] = [...MOCK_INBOX, ...MOCK_CONFIRMED]
-      .filter((s) => s.title.toLowerCase().includes(q))
+      .filter((s) => !q || s.title.toLowerCase().includes(q))
       .map((s) => ({
         id: s.id,
         title: s.title,
@@ -1461,10 +1487,13 @@ export async function fetchFeed(params: {
     return { items, total: items.length };
   }
   const qs = new URLSearchParams({
-    q: params.q,
     source: params.source ?? 'both',
     top: String(params.top ?? 30),
   });
+  // Omitted rather than sent empty: the route reads a missing `q` as null and
+  // hands that to the source clients, which is what makes the feed unfiltered.
+  // `q=` would be a search for the empty string.
+  if (params.q) qs.set('q', params.q);
   if (params.types?.length) qs.set('types', params.types.join(','));
   if (params.skip) qs.set('skip', String(params.skip));
   return paGet<{ items: FeedItem[]; total: number | null }>(`/pa/feed?${qs}`);


### PR DESCRIPTION
Adds a third segment beside **Gecureerd** and **Inbox** on Monitoring, showing the tab's own sources with no query applied.

## Why this is small

The data path already existed end to end. `GET /pa/feed` reads `q` as `string | null`, every source client defaults it to null, and that blanco path is what the curation cycle itself runs on. What was missing was any way to *reach* it: `runSearch` returns early on an empty string, so a blank search showed nothing rather than everything.

## Where the segment appears

Only on the signaalbronnen — and that is derived, not listed:

| tab | sources | segment |
| --- | --- | --- |
| Politiek (NL) | `tk`, `ob` | yes |
| Europa (EU) | `eu` | yes |
| Regionaal | `ob` | yes |
| Media & omgeving | `media` | yes |
| Agenda | none | **no** |

`paTabFeedSources` returns `TAB_SOURCES` as `FeedSource` ids, and an empty array is meaningful: it marks a monitoring tab with no feed behind it. Agenda is that case, fed by `fetchAgenda` through a different path. **Feiten & cijfers** never reaches this code at all — it is its own section behind `PaSectionsRouter`, not a monitoring tab, and renders no segmented control.

So a future source tab gets the segment for free, and Agenda never will, without a second list that could drift from `TAB_SOURCES`.

## Notes for review

- **Politiek fans out to two calls** rather than widening to `source='both'`. `both` is not the union it needs: it also pulls media when that flag is on, and deliberately excludes `eu`. Results merge and de-duplicate on `source:id`.
- **`fetchFeed`'s `q` is now optional**, and omitted from the query string rather than sent empty. The route reads a missing `q` as null; `q=` would be a search for the empty string. Absent and `''` are kept distinct on purpose — `''` is what a user leaves when clearing the search box, which `runSearch` already reads as "show nothing".
- **The count is a cap, not a total.** Second commit: the segment shows `60+` / `30+` when capped, with a banner carrying the real total, in the same style the Inbox already uses. A full page counts as capped even when the total is unknown, because TK returns `total: null` for multi-term queries and a null must not be read as "nothing more".
- **Results reuse `RawHitCard`**, so promote-to-inbox works unchanged from this view.
- The empty state names the possibility that a source is switched off and points at Beheer › Signaalbronnen, rather than asserting it — the client cannot tell a disabled source from a quiet one.

## Verification

`pa-cockpit` 375/375 (7 new), `pa-demo` 104/104, `public-site` 140/140. Lint, format and `pa-cockpit` type-check clean. Manually confirmed against the running app: raw items from both bronnen on Politiek.

## Pre-existing, not from this branch

`acc` is currently red at `bdb12d2` independently of this PR — **24 type errors** in `packages/backend` (`jwt.middleware.test.ts`, ValidSign routes and service, `toPdf`) and **4 failing tests** in `infra.api` and `PhaseDetail`. Verified by stashing this work and running a pristine tree. Flagging so a red `audit` here is not mistaken for something this branch introduced.