### PR TITLE
chore: bump release to v2026.09.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "ronl-business-api",
-  "version": "2026.09.0",
+  "version": "2026.09.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "ronl-business-api",
-      "version": "2026.09.0",
+      "version": "2026.09.1",
       "hasInstallScript": true,
       "license": "EUPL-1.2",
       "workspaces": [
@@ -17226,7 +17226,7 @@
     },
     "packages/backend": {
       "name": "@ronl/backend",
-      "version": "2026.09.0",
+      "version": "2026.09.1",
       "license": "EUPL-1.2",
       "dependencies": {
         "@anthropic-ai/sdk": "^0.122.0",
@@ -17354,7 +17354,7 @@
     },
     "packages/frontend": {
       "name": "@ronl/frontend",
-      "version": "2026.09.0",
+      "version": "2026.09.1",
       "dependencies": {
         "@bpmn-io/form-js": "^1.20.1",
         "@ronl/pa-cockpit": "*",
@@ -18372,7 +18372,7 @@
     },
     "packages/pa-demo": {
       "name": "@ronl/pa-demo",
-      "version": "2026.08.30",
+      "version": "2026.09.1",
       "dependencies": {
         "@ronl/pa-cockpit": "*",
         "@ronl/shared": "*",
@@ -18913,7 +18913,7 @@
     },
     "packages/public-site": {
       "name": "@ronl/public-site",
-      "version": "2026.08.29",
+      "version": "2026.09.1",
       "dependencies": {
         "react": "^18.2.0",
         "react-dom": "^18.2.0",
@@ -19453,7 +19453,7 @@
     },
     "packages/shared": {
       "name": "@ronl/shared",
-      "version": "2026.09.0",
+      "version": "2026.09.1",
       "license": "EUPL-1.2",
       "devDependencies": {
         "typescript": "^5.3.3"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ronl-business-api",
-  "version": "2026.09.0",
+  "version": "2026.09.1",
   "description": "Secure, multi-tenant Business API for Dutch municipality BPMN/DMN services",
   "private": true,
   "workspaces": [

--- a/packages/backend/package.json
+++ b/packages/backend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ronl/backend",
-  "version": "2026.09.0",
+  "version": "2026.09.1",
   "description": "Secure Business API layer for Dutch municipality BPMN services",
   "main": "dist/index.js",
   "scripts": {

--- a/packages/frontend/package.json
+++ b/packages/frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ronl/frontend",
-  "version": "2026.09.0",
+  "version": "2026.09.1",
   "description": "Municipality portal (MijnOmgeving) with identity provider selection",
   "type": "module",
   "scripts": {

--- a/packages/frontend/src/pages/changelog-data.ts
+++ b/packages/frontend/src/pages/changelog-data.ts
@@ -108,6 +108,84 @@ export const changelog: Changelog = {
   versions: [
     {
       format: 'commits',
+      version: '2026.09.1',
+      status: 'Released',
+      date: '2 sep 2026',
+      scope: ['backend', 'frontend', 'pa-demo', 'public-site'],
+      commits: [
+        {
+          sha: 'c2906dd',
+          author: 'Steven Gort',
+          type: 'fix',
+          subject: 'The RIP ladder gets the 28 roles its models address work to',
+          details: [
+            'The process models address tasks to 34 candidate groups; the Keycloak realm defined 6. GET /v1/task passes the caller’s realm roles to Operaton as candidateGroups, so a task whose groups all fall outside them is filtered out before it reaches the client — not “cannot claim”, not listed at all. task.routes.ts states the assumption that made this invisible: “Candidate groups in the BPMN map 1:1 to realm role names in this platform.”',
+            'Measured against the roles test-infra-flevoland held, 113 of the ladder’s 201 user tasks were unreachable, and it grew down the ladder — R4.1 onward majority-invisible, R5.2 showing 9 of its 36 tasks. Nothing caught it because the surfaces used most do not take that path: the Faseladder and its WIP/Gereed lists filter on the municipality process variable and never look at candidate groups.',
+            'Only the local seed realm is changed here. ACC and production run their own realms, so the roles have to be created there too.',
+          ],
+        },
+        {
+          sha: 'c614cfb',
+          author: 'Steven Gort',
+          type: 'fix',
+          subject: 'Rollen & rechten describes roles that exist',
+          details: [
+            'Of seven rip-* entries in the description map, exactly one described something real, while five of the six realm rip roles had no description at all. The map is now maintained additively: an entry for something that appears in no list simply never renders, whereas a missing one degrades the page to a bare identifier.',
+          ],
+        },
+        {
+          sha: '035d393',
+          author: 'Steven Gort',
+          type: 'feat',
+          subject: 'The RIP ladder is complete: R5.1, R5.2, R5.4 and R6.1',
+          details: [
+            'Eleven phases modelled. R5.3 is the only one without a process definition and stays that way — a real step, named by R5.4’s own entry criterion, with no design sheet, no BPMN and no observable exit. previousModelledPhase skips it so R5.4 follows R5.2, and that path now runs against live data rather than only a test fixture.',
+            'The withoutKey test fixture is synthesised rather than taken from a real phase: every phase now either carries a processDefinitionKey or is beyond, and beyond short-circuits before the key is consulted, so no real phase can exercise that branch any more.',
+          ],
+        },
+        {
+          sha: '489bdcb',
+          author: 'Steven Gort',
+          type: 'fix',
+          subject: 'The Ongefilterd count reads as a cap, not a total',
+          details: [
+            'The number on the segment was a page size wearing the clothes of an answer. Politiek showed 60 and the other signaalbronnen 30 — not because the feeds hold that many, but because the view asks for 30 per source and politiek has two. fetchFeed returns { items, total } and the total was being discarded. Ongefilterd now follows the convention the Inbox segment already had: 60+ / 30+ when capped, with a banner carrying the real total.',
+            'Two judgements are pinned by tests. A full page counts as capped even when the total is unknown — TK returns total: null for multi-term queries, and a null must never be read as “nothing more”; the page being full is the signal that survives either way. And the total is shown only when every source reported one, because a partial sum across sources would look authoritative without being so.',
+          ],
+        },
+        {
+          sha: 'efd39d6',
+          author: 'Steven Gort',
+          type: 'feat',
+          subject: 'Browse each signaalbron’s raw feed unfiltered',
+          details: [
+            'An Ongefilterd segment beside Gecureerd and Inbox, showing the tab’s own sources with no query applied. The data path already existed end to end — GET /pa/feed reads q as string | null, every source client defaults it to null, and that blanco path is what the curation cycle itself runs on. What was missing was any way to reach it: runSearch returned early on an empty string, so a blank search showed nothing rather than everything.',
+            'Where the segment appears is derived rather than listed. paTabFeedSources returns TAB_SOURCES as FeedSource ids, and an empty array is meaningful — it marks a monitoring tab with no feed, which today is agenda. So a future source tab gets the segment for free and agenda never does, without a second list that could drift from TAB_SOURCES.',
+          ],
+        },
+        {
+          sha: 'c561d48',
+          author: 'Steven Gort',
+          type: 'feat',
+          subject: 'R2.3 through R4.1 adopted in the phase catalogue',
+          details: [
+            'Five phases deployed via LDE, verified off the engine before adopting rather than taken from the deploy pull requests. The Faseladder reads 7 / 12 deelprocessen inzetbaar, and no source change was needed beyond the catalogue itself — the endpoints, readiness rule and progression generalised in v2026.09.0 already cover any modelled phase.',
+            'Three test fixtures had pinned a literal phase code as “the one without a process model” and all three broke identically. They now derive it, so the next deployment does not break tests that have nothing to do with the phase being deployed.',
+          ],
+        },
+        {
+          sha: '046a7ab',
+          author: 'renovate[bot]',
+          type: 'chore',
+          subject: 'vite 5 → 6 (security)',
+          details: [
+            'Raised across frontend, pa-cockpit, pa-demo and public-site from ^5.0.8 to ^6.4.3, with the lockfile regenerated. Build-time only — nothing vite-related ships in the deployed bundle. Open since 29 August and deferred from the previous two releases.',
+          ],
+        },
+      ],
+    },
+    {
+      format: 'commits',
       version: '2026.09.0',
       status: 'Released',
       date: '1 sep 2026',

--- a/packages/pa-demo/package.json
+++ b/packages/pa-demo/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ronl/pa-demo",
-  "version": "2026.08.30",
+  "version": "2026.09.1",
   "description": "Public mock-only PA Cockpit demo — plato.open-regels.nl",
   "type": "module",
   "scripts": {

--- a/packages/public-site/package.json
+++ b/packages/public-site/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ronl/public-site",
-  "version": "2026.08.29",
+  "version": "2026.09.1",
   "description": "Public, unauthenticated search site for Open Regels Nederland — publiek.open-regels.nl",
   "type": "module",
   "scripts": {

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ronl/shared",
-  "version": "2026.09.0",
+  "version": "2026.09.1",
   "description": "Shared types and utilities for RONL Business API",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",


### PR DESCRIPTION
Second release of September, and the first to touch four of the five deployables.

## Scope: `['backend', 'frontend', 'pa-demo', 'public-site']`

Wider than this release was proposed with. The vite security upgrade was brought in during PR reconciliation and touches `pa-cockpit`, `pa-demo` and `public-site`; `pa-cockpit` maps to frontend + pa-demo, and `packages/shared` to frontend + backend.

| File | From → To |
| --- | --- |
| `package.json` (root) | `2026.09.0` → `2026.09.1` |
| `packages/frontend` | `2026.09.0` → `2026.09.1` |
| `packages/backend` | `2026.09.0` → `2026.09.1` |
| `packages/pa-demo` | `2026.08.30` → `2026.09.1` |
| `packages/public-site` | `2026.08.29` → `2026.09.1` |
| `packages/shared` | `2026.09.0` → `2026.09.1` — changed, and versioned in lockstep |
| `package-lock.json` | top-level, `packages[""]`, six workspace entries |

`pa-demo` and `public-site` jump several versions because they were legitimately lagging at the last release that changed them, and this one does.

**`packages/pa-cockpit` stays at `1.0.0`.** It is compiled into frontend and pa-demo, deployed on its own by neither, and has never been versioned in lockstep the way `shared` is. It contributes to the scope without being a bump target.

Versions were hand-edited rather than set with `npm version`, which coerces to strict SemVer and would silently write `2026.9.1`. `npm ci --dry-run` re-verified that the lockfile resolves.

## Endpoint map

No edit needed: **17 routes mounted, 17 advertised**, nothing missing or stale. `validsign` was the gap and `v2026.09.0` closed it.

## What ships

Seven commits, newest first:

| | |
| --- | --- |
| `c2906dd` fix | The RIP ladder gets the 28 roles its models address work to |
| `c614cfb` fix | Rollen & rechten describes roles that exist |
| `035d393` feat | The RIP ladder is complete: R5.1, R5.2, R5.4 and R6.1 |
| `489bdcb` fix | The Ongefilterd count reads as a cap, not a total |
| `efd39d6` feat | Browse each signaalbron's raw feed unfiltered |
| `c561d48` feat | R2.3 through R4.1 adopted in the phase catalogue |
| `046a7ab` chore | vite 5 → 6 (security) |

Eleven commits were in range. **The four docs and script commits are deliberately unlisted** — the same call made for `a00af7c` last release: tooling that ships no product change is not release-note material. The scope is unaffected by that omission, since it is computed from the diff rather than from the entry.

### The headline

The RIP ladder is complete — eleven modelled phases, R2.1 through R6.1. R5.3 stays unmodelled by design: a real step, named by R5.4's own entry criterion, with no design sheet, no BPMN and no observable exit, so `previousModelledPhase` skips it and R5.4 follows R5.2.

The Keycloak fix is the one worth reading. The models address tasks to 34 candidate groups and the realm defined 6, so **113 of the ladder's 201 user tasks were never returned to the seeded infra user** — not "cannot claim", not listed at all, because `GET /v1/task` passes the caller's realm roles to Operaton as `candidateGroups`. Nothing caught it because the surfaces used most (Faseladder, WIP/Gereed lists) filter on the `municipality` variable and never look at candidate groups.

Note that only the **local seed realm** is changed by this release. ACC and production run their own realms; those were updated separately over the Admin API.

## PR reconciliation

Merged in this order, before any version editing:

1. **#30** first, because it rewrites `package-lock.json` — a bump landing before it would have been reverted or conflicted.
2. **#49** — the RIP ladder work.
3. **#50** — the pa-cockpit Ongefilterd feed.

**#51 and #20 remain open.** #51's failing build was Static Web Apps environment-slot exhaustion rather than anything in its code; three slots are now free, so a re-run should clear it.

## Merge method

**Merge commit, not squash or rebase.** The changelog entry names each commit by SHA, and both alternatives rewrite those hashes — squashing collapses them, rebasing replays them as new commits while deceptively preserving the count. Either leaves the entry pointing at commits that do not exist on `acc`.

Merging redeploys frontend, pa-demo and public-site, and the backend too, since `packages/backend/**` and `packages/shared/**` both changed.

## Checks

`npm run format`, `npm run lint` and `npm run type-check` clean. `ChangelogPanel` 15/15 with the new entry rendering.
