### PR TITLE
ci(audit): run the supply-chain audit on every pull request

### DIFF
--- a/.github/workflows/zizmor.yml
+++ b/.github/workflows/zizmor.yml
@@ -1,10 +1,27 @@
 name: Supply-chain audit
 
 on:
+  # No `branches:` filter here, deliberately, unlike the push trigger below.
+  #
+  # A pull request opened against a FEATURE branch -- a stacked PR -- matches
+  # no filtered trigger, so it accumulates no audit at all. It then reports
+  # mergeStateStatus CLEAN with zero checks: ready-looking, and not ready.
+  # When its parent merges and GitHub retargets it to acc, the required audit
+  # is missing and it blocks permanently, because retargeting emits no
+  # pull_request event either. Closing and reopening the pull request is the
+  # only way out, `reopened` being one of the default trigger types.
+  #
+  # That is not hypothetical: it cost four rounds of manual intervention in
+  # linked-data-explorer and blocked #45 here. The audit is read-only and
+  # cheap, so running it on every pull request regardless of base costs
+  # little and removes the hole entirely.
+  #
+  # Do NOT copy this to azure-frontend-acc.yml. That workflow carries the
+  # same filter for the opposite reason -- it rations Static Web Apps staging
+  # environments against a three-environment ceiling, which five open pull
+  # requests exhausted on 2026-08-28 and again on 2026-09-02. Identical
+  # syntax, opposite consequence when removed.
   pull_request:
-    branches:
-      - acc
-      - main
   push:
     branches:
       - acc


### PR DESCRIPTION
A stacked pull request currently gets **no supply-chain audit at all**, then blocks permanently the moment its parent merges. This removes the cause.

## The failure

`zizmor.yml`'s `pull_request` trigger was filtered to `acc` and `main`:

```yaml
on:
  pull_request:
    branches: [acc, main]
```

A pull request opened against a **feature** branch matches no trigger, so no audit runs. GitHub then reports `mergeStateStatus: CLEAN` with zero checks — which reads as ready and is not.

The damage lands later. When the parent merges and GitHub retargets the stacked PR to `acc`, the required `audit` check is missing, and **retargeting emits no `pull_request` event**, so nothing ever runs it. The PR is blocked with no way forward from inside itself. Closing and reopening fixes it in seconds, because `reopened` is one of the default trigger types — but you have to know that.

Not hypothetical. It cost four rounds of manual intervention in `linked-data-explorer`, and it blocked #45 in this repository this morning, which is how it was found.

## The change

Three lines removed. The `pull_request` trigger is now unfiltered; `push` keeps its filter, since there is no reason to audit a push to a feature branch.

The audit is read-only and cheap, so running it on every pull request regardless of base costs little and removes the hole rather than working around it.

## Why the comment is longer than the change

The **same three lines appear in `azure-frontend-acc.yml` for the opposite reason**, and copying this fix there would cause an outage rather than prevent one:

> Mirrors the push filter above. Without it every pull request to acc deployed all three sites, each holding a Static Web Apps staging environment — three apps against a three-environment ceiling, which five open pull requests exhausted on 2026-08-28.

That ceiling was hit again today: #51's build failure was slot exhaustion, not its code. So the deploy filters stay exactly as they are, and the comment says so explicitly, because the next person to read this file will see the identical pattern in the workflow next to it.

Same syntax, opposite consequence when removed. That distinction is the whole reason this is a targeted change rather than a blanket one.

## What this does not do

The deploy workflows keep their filters, so a stacked pull request will now show `audit` **and nothing else**. An all-green stacked PR is therefore not evidence that it builds — worth knowing before reading one that way.

## Testing

`zizmor.yml` parses correctly after the edit: `pull_request` unfiltered, `push` still filtered to `acc` and `main`, job and all four steps intact. YAML is outside this repository's prettier scope (`ts,tsx,json,md`), so nothing was reformatted.

This PR cannot demonstrate its own fix — it is based on `acc`, so it gets its audit under the current rules either way. The fix only shows itself on the next pull request opened against a feature branch.
