### PR TITLE
test: hold every workspace to an 80% per-file branch floor

### DIFF
--- a/packages/backend/src/pa-monitoring/sources/tk.client.test.ts
+++ b/packages/backend/src/pa-monitoring/sources/tk.client.test.ts
@@ -194,4 +194,112 @@ describe('fetchTkFeed', () => {
     mockFetch.mockRejectedValue(new Error('ECONNRESET'));
     await expect(fetchTkFeed('q')).rejects.toThrow('ECONNRESET');
   });
+  it('omits the subject clause entirely for a blanco query', async () => {
+    // fetchTkFeed() with no arguments is the shape the search band uses for an
+    // empty query and the curation cycle uses for its unfiltered sweep. The
+    // filter must still exclude deleted documents, but must not carry a
+    // contains() clause -- an empty one matches nothing on TK OData.
+    mockFetch.mockResolvedValue({ ok: true, json: async () => ({ value: [], '@odata.count': 0 }) });
+
+    await fetchTkFeed();
+
+    const url = mockFetch.mock.calls[0][0] as string;
+    expect(url).toContain('Verwijderd eq false');
+    expect(url).not.toContain('contains(Onderwerp');
+  });
+
+  it('treats a whitespace-only query as blanco', async () => {
+    mockFetch.mockResolvedValue({ ok: true, json: async () => ({ value: [], '@odata.count': 0 }) });
+
+    await fetchTkFeed('   ');
+
+    expect(mockFetch.mock.calls[0][0] as string).not.toContain('contains(Onderwerp');
+  });
+
+  it('falls back to an empty id for an item TK returned without one', async () => {
+    mockFetch.mockResolvedValue({
+      ok: true,
+      json: async () => ({ value: [{ Onderwerp: 'Geen Id' }], '@odata.count': 1 }),
+    });
+
+    const res = await fetchTkFeed('stikstof');
+
+    expect(res.items[0].id).toBe('');
+  });
+
+  it('reports a missing value array and a missing count as empty rather than throwing', async () => {
+    // TK answers a filter that matches nothing with a bare object on some
+    // deployments -- no `value`, no `@odata.count`.
+    mockFetch.mockResolvedValue({ ok: true, json: async () => ({}) });
+
+    const res = await fetchTkFeed('stikstof');
+
+    expect(res.items).toEqual([]);
+    expect(res.total).toBeNull();
+  });
+
+  it('rethrows a non-Error rejection from the single-term path unchanged', async () => {
+    // undici rejects with a bare string on some socket failures, so the
+    // `instanceof Error` guard in the catch is not decorative.
+    mockFetch.mockRejectedValue('socket hang up');
+
+    await expect(fetchTkFeed('stikstof')).rejects.toBe('socket hang up');
+  });
+
+  it('aborts a request that outruns the timeout', async () => {
+    jest.useFakeTimers();
+    mockFetch.mockImplementation(
+      (_url: string, init: { signal: AbortSignal }) =>
+        new Promise((_resolve, reject) => {
+          init.signal.addEventListener('abort', () =>
+            reject(new Error('The operation was aborted'))
+          );
+        })
+    );
+
+    const pending = fetchTkFeed('stikstof');
+    // Assert the rejection before advancing, so an unhandled-rejection warning
+    // cannot race the timer.
+    const assertion = expect(pending).rejects.toThrow('aborted');
+    await jest.advanceTimersByTimeAsync(15_000);
+    await assertion;
+
+    jest.useRealTimers();
+  });
+
+  describe('multi-term OR, further cases', () => {
+    const page = (items: Record<string, unknown>[]) => ({
+      ok: true,
+      json: async () => ({ value: items }),
+    });
+
+    it('wraps a non-Error rejection when every term fails', async () => {
+      mockFetch.mockRejectedValue('socket hang up');
+
+      await expect(fetchTkFeed('a OR b')).rejects.toThrow('TK API error');
+    });
+
+    it('tolerates a fulfilled page that carries no value array', async () => {
+      mockFetch
+        .mockResolvedValueOnce({ ok: true, json: async () => ({}) })
+        .mockResolvedValueOnce(page([{ Id: 'ok', Onderwerp: 'Survivor' }]));
+
+      const res = await fetchTkFeed('a OR b');
+
+      expect(res.items.map((i) => i.id)).toEqual(['ok']);
+    });
+
+    it('sorts undated items last without throwing', async () => {
+      mockFetch
+        .mockResolvedValueOnce(page([{ Id: 'undated', Onderwerp: 'No date' }]))
+        .mockResolvedValueOnce(
+          page([{ Id: 'dated', Onderwerp: 'Dated', GewijzigdOp: '2026-07-01' }])
+        );
+
+      const res = await fetchTkFeed('a OR b');
+
+      expect(res.items.map((i) => i.id)).toEqual(['dated', 'undated']);
+      expect(res.items[1].date).toBeNull();
+    });
+  });
 });

--- a/packages/backend/src/routes/validsign.routes.test.ts
+++ b/packages/backend/src/routes/validsign.routes.test.ts
@@ -28,13 +28,19 @@ jest.mock('@auth/jwt.middleware', () => ({
     if (req.headers['x-test-no-user']) return next();
     if (!req.headers['x-test-auth'])
       return res.status(401).json({ success: false, error: { code: 'MISSING_TOKEN' } });
+    // Keycloak realms differ in which name claims they map. `x-test-claims`
+    // selects the shape under test: 'full' (the default) is every claim
+    // present, 'username-only' drops given_name so the preferred_username
+    // fallback is what names the signer, and 'nameless' drops all three so
+    // the last-resort empty strings are.
+    const claims = (req.headers['x-test-claims'] as string | undefined) ?? 'full';
     req.user = {
       userId: 'u1',
       tenantId: 'flevoland',
       email: (req.headers['x-test-email'] as string | undefined) ?? 'signer@flevoland.nl',
-      givenName: 'Jan',
-      familyName: 'van der Berg',
-      preferredUsername: 'jvdberg',
+      ...(claims === 'full' ? { givenName: 'Jan' } : {}),
+      ...(claims === 'nameless' ? {} : { familyName: 'van der Berg' }),
+      ...(claims === 'nameless' ? {} : { preferredUsername: 'jvdberg' }),
     } as Request['user'];
     next();
   },
@@ -82,6 +88,7 @@ import helmet from 'helmet';
 import request from 'supertest';
 import validsignRouter, {
   callbackRouter,
+  deriveBoardHandOverUrl,
   isCallbackPath,
   resetCallbackLimiterForTests,
 } from './validsign.routes';
@@ -153,12 +160,20 @@ app.use('/v1/validsign', validsignRouter);
 
 const authHeader = { 'x-test-auth': '1' };
 
-const mockConfig = config as unknown as { corsOrigin: string[] };
+const mockConfig = config as unknown as {
+  // Deliberately `unknown`, not `string[]`: corsOriginList() reads this
+  // defensively because the real config permits a comma-separated string as
+  // well as an array, and the tests below drive both -- plus the
+  // neither-shape case that the normalisation exists to survive.
+  corsOrigin: unknown;
+  validsign: { callbackSecret: string; senderEmail: string };
+};
 
 beforeEach(async () => {
   jest.clearAllMocks();
   mockValidsign.isStub = true;
   mockConfig.corsOrigin = ['http://localhost:5173', 'http://localhost:3000'];
+  mockConfig.validsign.senderEmail = 'sender@flevoland.nl';
   mockGetTask.mockResolvedValue({
     id: 'task-1',
     processInstanceId: 'pi-1',
@@ -872,5 +887,229 @@ describe('stub ceremony framing headers (iframe embed from a different origin)',
     expect(res.status).toBe(200);
     expect(res.headers['x-frame-options']).toBe('SAMEORIGIN');
     expect(res.headers['content-security-policy']).toContain("frame-ancestors 'self'");
+  });
+});
+
+describe('corsOrigin normalisation', () => {
+  // corsOriginList() is the single reader of config.corsOrigin for both the
+  // ceremony's frame-ancestors header and deriveBoardHandOverUrl. The real
+  // config permits a comma-separated string as well as an array, and an unset
+  // value reaches here as neither, so all three shapes are exercised through
+  // an observable route rather than against the helper directly.
+  const cspOf = async (): Promise<string> => {
+    mockValidsign.stubSignerName.mockReturnValue('Jan van der Berg');
+    const res = await request(app).get('/v1/validsign/stub/ceremony/pkg-1');
+    return res.headers['content-security-policy'] as string;
+  };
+
+  it('splits a comma-separated string into separate origins', async () => {
+    mockConfig.corsOrigin = 'https://ronl.flevoland.nl, https://acc.ronl.flevoland.nl';
+    expect(await cspOf()).toContain(
+      'frame-ancestors https://ronl.flevoland.nl https://acc.ronl.flevoland.nl'
+    );
+  });
+
+  it('falls back to self when corsOrigin is neither an array nor a string', async () => {
+    mockConfig.corsOrigin = undefined;
+    expect(await cspOf()).toContain("frame-ancestors 'self'");
+  });
+
+  it('derives the handOver URL from a comma-separated string too', () => {
+    mockConfig.corsOrigin = 'https://ronl.flevoland.nl,https://acc.ronl.flevoland.nl';
+    expect(deriveBoardHandOverUrl()).toBe('https://ronl.flevoland.nl/dashboard/infra-board');
+  });
+
+  it('omits the handOver URL when the first origin is not a parseable URL', () => {
+    mockConfig.corsOrigin = ['not a url'];
+    expect(deriveBoardHandOverUrl()).toBeUndefined();
+  });
+});
+
+describe('deriveBoardHandOverUrl private-network guard', () => {
+  // A real ceremony's handOver link is followed by the signer's own browser on
+  // the public internet, where Private Network Access blocks navigation to any
+  // private address outright -- stranding the signer on a browser error page
+  // immediately after a legally recorded signature. Every private range must
+  // therefore resolve to "omit", not to a URL.
+  const privateOrigins = [
+    ['loopback by name', 'http://localhost:5173'],
+    ['IPv6 loopback', 'http://[::1]:5173'],
+    ['a bare hostname with no dot', 'http://backend:3000'],
+    ['127.0.0.0/8', 'http://127.0.0.1:3000'],
+    ['10.0.0.0/8', 'http://10.1.2.3'],
+    ['172.16.0.0/12, low end', 'http://172.16.0.1'],
+    ['172.16.0.0/12, high end', 'http://172.31.255.254'],
+    ['192.168.0.0/16', 'http://192.168.1.10'],
+    ['169.254.0.0/16 link-local', 'http://169.254.1.1'],
+  ] as const;
+
+  it.each(privateOrigins)('omits the handOver URL for %s', (_label, origin) => {
+    mockConfig.corsOrigin = [origin];
+    expect(deriveBoardHandOverUrl()).toBeUndefined();
+  });
+
+  // Adjacent to, but outside, the private ranges above -- these must NOT be
+  // swept up by the octet checks.
+  const publicOrigins = [
+    [
+      'a public hostname',
+      'https://ronl.flevoland.nl',
+      'https://ronl.flevoland.nl/dashboard/infra-board',
+    ],
+    [
+      '172.15.x, just below the private block',
+      'http://172.15.0.1',
+      'http://172.15.0.1/dashboard/infra-board',
+    ],
+    ['172.32.x, just above it', 'http://172.32.0.1', 'http://172.32.0.1/dashboard/infra-board'],
+    ['192.167.x', 'http://192.167.1.1', 'http://192.167.1.1/dashboard/infra-board'],
+    ['169.253.x', 'http://169.253.1.1', 'http://169.253.1.1/dashboard/infra-board'],
+    ['a public IPv4', 'http://8.8.8.8', 'http://8.8.8.8/dashboard/infra-board'],
+  ] as const;
+
+  it.each(publicOrigins)('derives the handOver URL for %s', (_label, origin, expected) => {
+    mockConfig.corsOrigin = [origin];
+    expect(deriveBoardHandOverUrl()).toBe(expected);
+  });
+});
+
+describe('ceremony framing headers with no CSP already on the response', () => {
+  // index.ts mounts helmet, so in production there is always a CSP string to
+  // rewrite. The header rewriter must not assume that: a deployment that drops
+  // helmet, or any ordering that puts this router first, hands it none.
+  const bareApp = express();
+  bareApp.use(express.json());
+  // The stub ceremony lives on callbackRouter -- it is unauthenticated by
+  // design, so it is registered alongside the callback rather than behind the
+  // jwt/tenant middleware the authenticated router carries.
+  bareApp.use('/v1/validsign', callbackRouter);
+
+  it('sets frame-ancestors even when no CSP header exists yet', async () => {
+    mockValidsign.stubSignerName.mockReturnValue('Jan van der Berg');
+    const res = await request(bareApp).get('/v1/validsign/stub/ceremony/pkg-1');
+    expect(res.status).toBe(200);
+    expect(res.headers['content-security-policy']).toBe(
+      'frame-ancestors http://localhost:5173 http://localhost:3000'
+    );
+  });
+});
+
+describe('the stub ceremony page escapes what it interpolates', () => {
+  it('escapes a signer name carrying HTML metacharacters', async () => {
+    // stubSignerName comes from the token that created the package, so it is
+    // caller-influenced input rendered into an unauthenticated HTML page.
+    mockValidsign.stubSignerName.mockReturnValue(
+      "Jan <script>alert('x')</script> & co" +
+        String.fromCharCode(34) +
+        'quoted' +
+        String.fromCharCode(34)
+    );
+
+    const res = await request(app).get('/v1/validsign/stub/ceremony/pkg-1');
+
+    expect(res.status).toBe(200);
+    expect(res.text).not.toContain('<script>alert');
+    expect(res.text).toContain('&lt;script&gt;');
+    expect(res.text).toContain('&amp;');
+    expect(res.text).toContain('&quot;');
+    expect(res.text).toContain('&#39;');
+  });
+});
+
+describe('POST /v1/validsign/task/:taskId/package, further cases', () => {
+  const specStubs = (): void => {
+    mockGetTaskSignatureSpec.mockResolvedValue({
+      templateId: 'tpl-1',
+      template: { name: 'Uitgangspunten VO-fase' },
+    });
+    mockGetTaskVariables.mockResolvedValue({});
+    mockRenderTemplate.mockReturnValue({ templateId: 'tpl-1', zones: [] });
+    mockToPdf.mockResolvedValue({ bytes: Buffer.from('pdf'), signatureFields: [] });
+    mockValidsign.createPackage.mockResolvedValue({ packageId: 'pkg-1', roleId: 'role-1' });
+    mockValidsign.getSigningUrl.mockResolvedValue('/v1/validsign/stub/ceremony/pkg-1');
+  };
+
+  it('401s when the request carries no authenticated user', async () => {
+    const res = await request(app)
+      .post('/v1/validsign/task/task-1/package')
+      .set('x-test-no-user', '1');
+    expect(res.status).toBe(401);
+    expect(res.body.error.code).toBe('UNAUTHORIZED');
+    expect(mockValidsign.createPackage).not.toHaveBeenCalled();
+  });
+
+  it('falls back to the signer as sender when no sender email is configured', async () => {
+    specStubs();
+    mockConfig.validsign.senderEmail = '';
+
+    const res = await request(app).post('/v1/validsign/task/task-1/package').set(authHeader);
+
+    expect(res.status).toBe(200);
+    expect(mockValidsign.createPackage.mock.calls[0][0].senderEmail).toBe('signer@flevoland.nl');
+  });
+
+  it('names the signer from preferred_username when the token has no given_name', async () => {
+    specStubs();
+
+    const res = await request(app)
+      .post('/v1/validsign/task/task-1/package')
+      .set(authHeader)
+      .set('x-test-claims', 'username-only');
+
+    expect(res.status).toBe(200);
+    expect(mockValidsign.createPackage.mock.calls[0][0].signer).toEqual({
+      email: 'signer@flevoland.nl',
+      firstName: 'jvdberg',
+      lastName: 'van der Berg',
+    });
+  });
+
+  it('sends empty name fields rather than undefined when the token carries no name claims', async () => {
+    // ValidSign rejects a role whose signer is missing firstName/lastName
+    // outright; empty strings are accepted and show the email instead.
+    specStubs();
+
+    const res = await request(app)
+      .post('/v1/validsign/task/task-1/package')
+      .set(authHeader)
+      .set('x-test-claims', 'nameless');
+
+    expect(res.status).toBe(200);
+    expect(mockValidsign.createPackage.mock.calls[0][0].signer).toEqual({
+      email: 'signer@flevoland.nl',
+      firstName: '',
+      lastName: '',
+    });
+  });
+});
+
+describe('POST /v1/validsign/callback, body edge cases', () => {
+  it('treats a callback with no packageId as an empty id rather than throwing', async () => {
+    mockCompleteSignature.mockResolvedValue('unknown');
+
+    const res = await request(app)
+      .post('/v1/validsign/callback')
+      .set('x-validsign-secret', 'secret')
+      .send({ name: 'PACKAGE_COMPLETE' });
+
+    expect(res.status).toBe(200);
+    expect(mockCompleteSignature).toHaveBeenCalledWith('');
+  });
+
+  it('rejects a body over the 16kb callback limit in the API envelope', async () => {
+    // The callback is exempted from the app-wide JSON parser precisely so an
+    // oversized body fails inside this router, where its own error handler can
+    // answer in the API envelope instead of Express' default HTML page. It
+    // answers 400 rather than body-parser's own 413 deliberately: a caller
+    // that is not ValidSign learns nothing about the limit from it.
+    const res = await request(app)
+      .post('/v1/validsign/callback')
+      .set('x-validsign-secret', 'secret')
+      .set('content-type', 'application/json')
+      .send(JSON.stringify({ packageId: 'pkg-1', pad: 'x'.repeat(20 * 1024) }));
+
+    expect(res.status).toBe(400);
+    expect(res.body.error.code).toBe('INVALID_BODY');
+    expect(mockCompleteSignature).not.toHaveBeenCalled();
   });
 });

--- a/packages/backend/src/services/document/renderTemplate.test.ts
+++ b/packages/backend/src/services/document/renderTemplate.test.ts
@@ -80,4 +80,153 @@ describe('renderTemplate', () => {
     );
     expect(out.zones.map((z) => z.id)).toEqual(['letterhead', 'signOff']);
   });
+  it('skips a zone key that is neither canonical nor a known alias', () => {
+    const out = renderTemplate(
+      template({
+        sidebar: { blocks: [{ id: 'x', type: 'text', content: doc('Should not render') }] },
+        body: { blocks: [{ id: 'b', type: 'text', content: doc('Kept') }] },
+      }),
+      {}
+    );
+    expect(out.zones.map((z) => z.id)).toEqual(['body']);
+  });
+
+  it('skips a zone whose value is null', () => {
+    // DocumentTemplate.zones is typed `DocumentZone | null | undefined` --
+    // deployed fixtures do carry null entries for zones the author cleared.
+    const out = renderTemplate(template({ body: null, closing: undefined }), {});
+    expect(out.zones).toEqual([]);
+  });
+
+  it('omits a zone whose blocks all render to nothing', () => {
+    const out = renderTemplate(template({ body: { blocks: [{ id: 'i', type: 'image' }] } }), {});
+    expect(out.zones).toEqual([]);
+  });
+
+  it('renders separator and spacer blocks without runs', () => {
+    const out = renderTemplate(
+      template({
+        body: {
+          blocks: [
+            { id: 's', type: 'separator' },
+            { id: 'p', type: 'spacer' },
+          ],
+        },
+      }),
+      {}
+    );
+    const body = out.zones.find((z) => z.id === 'body')!;
+    expect(body.blocks).toEqual([
+      { kind: 'separator', runs: [] },
+      { kind: 'spacer', runs: [] },
+    ]);
+  });
+
+  it('skips unsupported block types rather than throwing', () => {
+    const out = renderTemplate(
+      template({
+        body: {
+          blocks: [
+            { id: 'i', type: 'image' },
+            { id: 'v', type: 'variable' },
+            { id: 't', type: 'text', content: doc('Survives') },
+          ],
+        },
+      }),
+      {}
+    );
+    const body = out.zones.find((z) => z.id === 'body')!;
+    expect(body.blocks).toHaveLength(1);
+    expect(body.blocks[0].runs[0].text).toBe('Survives');
+  });
+
+  it('treats a text block with no content as empty', () => {
+    const out = renderTemplate(
+      template({
+        body: {
+          blocks: [
+            { id: 'empty', type: 'text' },
+            { id: 't', type: 'text', content: doc('Only me') },
+          ],
+        },
+      }),
+      {}
+    );
+    const body = out.zones.find((z) => z.id === 'body')!;
+    expect(body.blocks).toHaveLength(1);
+  });
+
+  it('defaults a heading node with no level attribute to level 1', () => {
+    const out = renderTemplate(
+      template({
+        body: {
+          blocks: [
+            {
+              id: 'h',
+              type: 'text',
+              content: {
+                type: 'doc',
+                content: [
+                  { type: 'heading', content: [{ type: 'text', text: 'No attrs' }] },
+                  {
+                    type: 'heading',
+                    attrs: { level: 3 },
+                    content: [{ type: 'text', text: 'Level three' }],
+                  },
+                ],
+              },
+            },
+          ],
+        },
+      }),
+      {}
+    );
+    const body = out.zones.find((z) => z.id === 'body')!;
+    expect(body.blocks.map((b) => b.level)).toEqual([1, 3]);
+  });
+
+  it('ignores node types that are neither heading nor paragraph', () => {
+    const out = renderTemplate(
+      template({
+        body: {
+          blocks: [
+            {
+              id: 'h',
+              type: 'text',
+              content: {
+                type: 'doc',
+                content: [
+                  { type: 'bulletList', content: [{ type: 'text', text: 'item' }] },
+                  { type: 'paragraph', content: [{ type: 'text', text: 'Kept' }] },
+                ],
+              },
+            },
+          ],
+        },
+      }),
+      {}
+    );
+    const body = out.zones.find((z) => z.id === 'body')!;
+    expect(body.blocks).toHaveLength(1);
+    expect(body.blocks[0].runs[0].text).toBe('Kept');
+  });
+
+  it('merges an alias key into the canonical zone it already populated', () => {
+    // signOff and signoff both resolve to signOff; the second one to be
+    // visited must append to the first's blocks, not replace them.
+    const out = renderTemplate(
+      template({
+        signOff: { blocks: [{ id: 'a', type: 'text', content: doc('First') }] },
+        signoff: { blocks: [{ id: 'b', type: 'text', content: doc('Second') }] },
+      }),
+      {}
+    );
+    const signOff = out.zones.find((z) => z.id === 'signOff')!;
+    expect(signOff.blocks.map((b) => b.runs[0].text)).toEqual(['First', 'Second']);
+  });
+
+  it('returns no zones for a template with no zones object at all', () => {
+    const bare = { id: 'rip-pdp', bindings: [] } as unknown as DocumentTemplate;
+    expect(renderTemplate(bare, {})).toEqual({ templateId: 'rip-pdp', zones: [] });
+  });
 });

--- a/packages/backend/src/services/document/toMarkdown.test.ts
+++ b/packages/backend/src/services/document/toMarkdown.test.ts
@@ -154,4 +154,37 @@ describe('toMarkdown', () => {
     });
     expect(md).toBe('First\n\nSecond\n');
   });
+  it('defaults a heading with no level to a single hash', () => {
+    const md = toMarkdown({
+      templateId: 'test',
+      zones: [
+        {
+          id: 'letterhead',
+          blocks: [{ kind: 'heading', runs: [{ text: 'No level', bold: false }] }],
+        },
+      ],
+    });
+    expect(md).toContain('# No level');
+    expect(md).not.toContain('## No level');
+  });
+
+  it('leaves a multi-line bold run unmarked rather than emitting a broken marker', () => {
+    // The whitespace-relocating regex is single-line: `.` does not cross a
+    // newline and `$` is not multiline, so `exec` returns null for any run
+    // containing one. The `?? []` fallback then leaves core empty and the run
+    // is emitted escaped-but-unbolded. Emphasis is lost, which is the
+    // deliberate trade: a `**` split across a line break renders as literal
+    // asterisks in CommonMark, which is worse than plain text.
+    const md = toMarkdown({
+      templateId: 'test',
+      zones: [
+        {
+          id: 'letterhead',
+          blocks: [{ kind: 'paragraph', runs: [{ text: 'line one\nline two', bold: true }] }],
+        },
+      ],
+    });
+    expect(md).toBe('line one\nline two\n');
+    expect(md).not.toContain('**');
+  });
 });

--- a/packages/backend/src/services/document/toPdf.test.ts
+++ b/packages/backend/src/services/document/toPdf.test.ts
@@ -1,6 +1,6 @@
 import PDFDocument from 'pdfkit';
 import { toPdf } from './toPdf';
-import type { RenderedDocument } from './renderTemplate';
+import type { RenderedBlock, RenderedDocument } from './renderTemplate';
 
 // Mirrors the MARGIN constant in toPdf.ts. Not imported (not exported) — kept
 // here so the deterministic-geometry helper below can replicate the emitter's
@@ -124,5 +124,58 @@ describe('toPdf', () => {
     // derived from font metrics, so asserting the exact value is not
     // fragile the way asserting an exact mid-page y would be.
     expect(signatureFields[0].y).toBe(MARGIN);
+  });
+
+  // The signature field's y is the emitter's only externally observable
+  // cursor position, so it doubles as a probe: render `blocks` in a body zone
+  // ahead of a one-line signOff zone and the field's y reports exactly how far
+  // those blocks advanced the cursor. That turns "does a spacer take up
+  // vertical space?" into an assertion about output rather than about a call
+  // count on a mock.
+  const signOffTopAfter = async (blocks: RenderedBlock[]): Promise<number> => {
+    const { signatureFields } = await toPdf({
+      templateId: 'probe',
+      zones: [
+        { id: 'body', blocks },
+        {
+          id: 'signOff',
+          blocks: [{ kind: 'paragraph', runs: [{ text: 'Sign here', bold: false }] }],
+        },
+      ],
+    });
+    return signatureFields[0].y;
+  };
+
+  const heading = (level?: number): RenderedBlock => ({
+    kind: 'heading',
+    ...(level === undefined ? {} : { level }),
+    runs: [{ text: 'Kop', bold: false }],
+  });
+
+  it('advances the cursor for a spacer block', async () => {
+    expect(await signOffTopAfter([{ kind: 'spacer', runs: [] }])).toBeGreaterThan(
+      await signOffTopAfter([])
+    );
+  });
+
+  it('advances the cursor for a separator block', async () => {
+    expect(await signOffTopAfter([{ kind: 'separator', runs: [] }])).toBeGreaterThan(
+      await signOffTopAfter([])
+    );
+  });
+
+  it('sizes headings down by level', async () => {
+    // 18pt / 14pt / 12pt: each level occupies strictly less vertical space
+    // than the one above it, so the following zone starts progressively
+    // higher on the page.
+    const h1 = await signOffTopAfter([heading(1)]);
+    const h2 = await signOffTopAfter([heading(2)]);
+    const h3 = await signOffTopAfter([heading(3)]);
+    expect(h1).toBeGreaterThan(h2);
+    expect(h2).toBeGreaterThan(h3);
+  });
+
+  it('treats a heading with no level as level 1', async () => {
+    expect(await signOffTopAfter([heading()])).toBe(await signOffTopAfter([heading(1)]));
   });
 });

--- a/packages/backend/src/services/validsign.service.test.ts
+++ b/packages/backend/src/services/validsign.service.test.ts
@@ -447,3 +447,169 @@ describe('the live REST path', () => {
     expect(serializedCalls).not.toContain('headers');
   });
 });
+
+describe('stub-mode edge cases', () => {
+  beforeEach(() => {
+    mockConfig.validsign.stubMode = true;
+    mockConfig.validsign.liveTiers = [];
+  });
+
+  it('omits the signer lines from a stub PDF for a package it has never seen', async () => {
+    // The stub download deliberately does not requireStub: a ceremony URL is a
+    // capability, and a caller holding an id for a package this process no
+    // longer has (a restart clears the in-memory map) gets a valid placeholder
+    // rather than a 500. It just cannot name a signer or a signing moment.
+    const svc = new ValidsignService();
+
+    const signed = pdfText(await svc.downloadSignedDocument('stub-gone', 'doc-1'));
+    expect(signed).toContain('Pakket: stub-gone');
+    expect(signed).not.toContain('Ondertekenaar:');
+    expect(signed).not.toContain('Ondertekend op:');
+
+    const evidence = pdfText(await svc.downloadEvidenceSummary('stub-gone'));
+    expect(evidence).toContain('Pakket: stub-gone');
+    expect(evidence).not.toContain('Ondertekenaar:');
+    expect(evidence).not.toContain('Ondertekend op:');
+    // Its own generation moment is not conditional, so it is still there.
+    expect(evidence).toContain('Samenvatting gegenereerd op:');
+  });
+
+  it('reports an unknown package id distinguishably', () => {
+    expect(() => new ValidsignService().stubSignerName('stub-nope')).toThrow(
+      /VALIDSIGN_UNKNOWN_PACKAGE: stub-nope/
+    );
+  });
+
+  it('names the signer of a package it does hold', async () => {
+    const svc = new ValidsignService();
+    const { packageId } = await svc.createPackage(input);
+    expect(svc.stubSignerName(packageId)).toContain('Leider');
+  });
+});
+
+describe('stub-only entry points in live mode', () => {
+  beforeEach(() => {
+    mockConfig.validsign.stubMode = false;
+    mockConfig.validsign.apiKey = 'test-key';
+    mockConfig.validsign.liveTiers = ['development'];
+    mockConfig.deploymentEnv = 'development';
+  });
+
+  it('refuses to drive the ceremony from the stub endpoint', () => {
+    // The stub ceremony route is mounted unconditionally; this is the guard
+    // that stops it from mutating a real ValidSign package's status.
+    expect(() => new ValidsignService().stubSign('pkg-1', 'COMPLETED')).toThrow(
+      'stubSign called outside stub mode'
+    );
+  });
+});
+
+describe('the live REST path, further cases', () => {
+  beforeEach(() => {
+    mockConfig.validsign.stubMode = false;
+    mockConfig.validsign.apiKey = 'test-key';
+    mockConfig.validsign.liveTiers = ['development'];
+    mockConfig.deploymentEnv = 'development';
+    mockClient.post.mockReset();
+    mockClient.get.mockReset();
+    mockFormAppend.mockClear();
+    mockLogger.error.mockClear();
+  });
+
+  it('throws a distinguishable error when the readback carries no SIGNER role', async () => {
+    mockClient.post.mockResolvedValue({ data: { id: 'pkg-1' } });
+    mockClient.get.mockResolvedValue({ data: { roles: [{ id: 'role-1', type: 'SENDER' }] } });
+
+    await expect(new ValidsignService().createPackage(input)).rejects.toThrow(
+      /VALIDSIGN_NO_SIGNER_ROLE: pkg-1/
+    );
+  });
+
+  it('rethrows and logs safely when the readback itself fails', async () => {
+    mockClient.post.mockResolvedValue({ data: { id: 'pkg-1' } });
+    const readbackError = {
+      isAxiosError: true,
+      message: 'Request failed with status code 404',
+      response: { status: 404, statusText: 'Not Found', data: { code: 'NOT_FOUND' } },
+      config: { url: '/packages/pkg-1', method: 'get', headers: { Authorization: 'Basic key' } },
+    };
+    mockClient.get.mockRejectedValue(readbackError);
+
+    await expect(new ValidsignService().createPackage(input)).rejects.toBe(readbackError);
+    expect(JSON.stringify(mockLogger.error.mock.calls)).not.toContain('Authorization');
+  });
+
+  it('logs a transport failure that never produced a response, without its config', async () => {
+    // A timeout or socket reset rejects with no `.response`, so the branch that
+    // reads e.response.status would throw on it. Everything but `.message` is
+    // still unsafe to log: `.config.headers` carries the account-wide key.
+    const transportError = {
+      isAxiosError: true,
+      message: 'socket hang up',
+      config: { url: '/packages', method: 'post', headers: { Authorization: 'Basic secret-key' } },
+    };
+    mockClient.post.mockRejectedValue(transportError);
+
+    await expect(new ValidsignService().createPackage(input)).rejects.toBe(transportError);
+
+    const serialized = JSON.stringify(mockLogger.error.mock.calls);
+    expect(serialized).toContain('socket hang up');
+    expect(serialized).toContain('/packages');
+    expect(serialized).not.toContain('secret-key');
+    expect(serialized).not.toContain('Authorization');
+  });
+  it('sends a package by putting SENT upstream', async () => {
+    mockClient.put.mockResolvedValue({ data: {} });
+
+    await new ValidsignService().sendPackage('pkg-1');
+
+    expect(mockClient.put).toHaveBeenCalledWith('/packages/pkg-1', { status: 'SENT' });
+  });
+
+  it('asks ValidSign for the signing URL rather than composing one', async () => {
+    // The real ceremony URL is a signed, single-use link ValidSign mints; it
+    // cannot be derived from the package and role ids.
+    mockClient.get.mockResolvedValue({ data: { url: 'https://my.validsign.eu/ceremony/abc' } });
+
+    const url = await new ValidsignService().getSigningUrl('pkg-1', 'role-1');
+
+    expect(mockClient.get).toHaveBeenCalledWith('/packages/pkg-1/roles/role-1/signingUrl');
+    expect(url).toBe('https://my.validsign.eu/ceremony/abc');
+  });
+
+  it('reads the package status back from upstream', async () => {
+    mockClient.get.mockResolvedValue({ data: { status: 'COMPLETED' } });
+
+    expect(await new ValidsignService().getPackageStatus('pkg-1')).toBe('COMPLETED');
+  });
+
+  it('returns the signed document as a Buffer of the raw response bytes', async () => {
+    // responseType: 'arraybuffer' means axios hands back an ArrayBuffer, not a
+    // string -- Buffer.from must be given it verbatim or the PDF is corrupted.
+    const bytes = Buffer.from('%PDF-1.7 signed');
+    mockClient.get.mockResolvedValue({
+      data: bytes.buffer.slice(bytes.byteOffset, bytes.byteOffset + bytes.byteLength),
+    });
+
+    const out = await new ValidsignService().downloadSignedDocument('pkg-1', 'doc-1');
+
+    expect(mockClient.get).toHaveBeenCalledWith('/packages/pkg-1/documents/doc-1/pdf', {
+      responseType: 'arraybuffer',
+    });
+    expect(out.toString()).toBe('%PDF-1.7 signed');
+  });
+
+  it('returns the evidence summary as a Buffer of the raw response bytes', async () => {
+    const bytes = Buffer.from('%PDF-1.7 evidence');
+    mockClient.get.mockResolvedValue({
+      data: bytes.buffer.slice(bytes.byteOffset, bytes.byteOffset + bytes.byteLength),
+    });
+
+    const out = await new ValidsignService().downloadEvidenceSummary('pkg-1');
+
+    expect(mockClient.get).toHaveBeenCalledWith('/packages/pkg-1/evidence/summary', {
+      responseType: 'arraybuffer',
+    });
+    expect(out.toString()).toBe('%PDF-1.7 evidence');
+  });
+});

--- a/packages/frontend/src/App.test.tsx
+++ b/packages/frontend/src/App.test.tsx
@@ -1,8 +1,8 @@
 // @vitest-environment jsdom
 import { beforeEach, describe, expect, it, vi } from 'vitest';
-import { render, screen } from '@testing-library/react';
+import { render, screen, waitFor } from '@testing-library/react';
 import { MemoryRouter, Route, Routes } from 'react-router-dom';
-import { ProtectedRoute } from './App';
+import App, { ProtectedRoute } from './App';
 
 const mockKeycloak = vi.hoisted(() => ({
   authenticated: false,
@@ -112,5 +112,83 @@ describe('ProtectedRoute', () => {
 
     expect(screen.queryByText('citizen-dashboard')).not.toBeInTheDocument();
     expect(screen.queryByText('login-choice')).not.toBeInTheDocument();
+  });
+  it('lets a matching role through', async () => {
+    mockInitializeKeycloak.mockResolvedValue(true);
+    mockKeycloak.authenticated = true;
+    mockKeycloak.tokenParsed = { realm_access: { roles: ['caseworker'] } };
+
+    renderAt('/dashboard/caseworker');
+
+    expect(await screen.findByText('caseworker-dashboard')).toBeInTheDocument();
+  });
+
+  it('treats a token with no realm roles as a citizen rather than throwing', async () => {
+    // A token minted by a client with no realm-role mapper has no
+    // realm_access at all; reading .roles off it directly would throw before
+    // any redirect could happen.
+    mockInitializeKeycloak.mockResolvedValue(true);
+    mockKeycloak.authenticated = true;
+    mockKeycloak.tokenParsed = {};
+
+    renderAt('/dashboard/citizen');
+
+    expect(await screen.findByText('citizen-dashboard')).toBeInTheDocument();
+  });
+
+  it('still decides once check-sso itself fails', async () => {
+    // A dead Keycloak must not leave the route rendering nothing forever; the
+    // guard falls through to "not authenticated" and sends the user to /.
+    mockInitializeKeycloak.mockRejectedValue(new Error('keycloak unreachable'));
+
+    renderAt('/dashboard/citizen');
+
+    expect(await screen.findByText('login-choice')).toBeInTheDocument();
+  });
+});
+
+describe('the legacy /dashboard redirect', () => {
+  // Kept for bookmarks and links minted before the role-specific routes
+  // existed. It reads the token directly rather than going through
+  // ProtectedRoute, so it needs its own coverage.
+  const at = (path: string) => {
+    window.history.pushState({}, '', path);
+    render(<App />);
+  };
+
+  beforeEach(() => {
+    mockKeycloak.authenticated = false;
+    mockKeycloak.tokenParsed = null;
+    mockInitializeKeycloak.mockReset().mockResolvedValue(true);
+  });
+
+  it('sends a caseworker to the caseworker dashboard', async () => {
+    mockKeycloak.authenticated = true;
+    mockKeycloak.tokenParsed = { realm_access: { roles: ['caseworker'] } };
+
+    at('/dashboard');
+
+    await waitFor(() => expect(window.location.pathname).toBe('/dashboard/caseworker'));
+  });
+
+  it('sends any other signed-in user to the citizen dashboard', async () => {
+    mockKeycloak.authenticated = true;
+    mockKeycloak.tokenParsed = { realm_access: { roles: ['citizen'] } };
+
+    at('/dashboard');
+
+    await waitFor(() => expect(window.location.pathname).toBe('/dashboard/citizen'));
+  });
+
+  it('sends an anonymous visitor to the login page', async () => {
+    at('/dashboard');
+
+    await waitFor(() => expect(window.location.pathname).toBe('/'));
+  });
+
+  it('sends an unknown path to the login page too', async () => {
+    at('/geen-idee');
+
+    await waitFor(() => expect(window.location.pathname).toBe('/'));
   });
 });

--- a/packages/frontend/src/components/CaseworkerDashboard/ArchiefSection.test.tsx
+++ b/packages/frontend/src/components/CaseworkerDashboard/ArchiefSection.test.tsx
@@ -141,3 +141,123 @@ describe('ArchiefSection', () => {
     expect(mockBusinessApi.process.historicVariables).toHaveBeenCalledTimes(1);
   });
 });
+
+describe('ArchiefSection task rows', () => {
+  it('keeps every board-tagged task when no board is named', async () => {
+    // The shared archive view (no boardId) is the caseworker's own list: a
+    // task tagged for a board must still show there, not be filtered out.
+    mockBusinessApi.task.history.mockResolvedValue({
+      success: true,
+      data: [
+        makeTask({ id: 'a', name: 'Van infra-board', boardOwner: 'infra' }),
+        makeTask({ id: 'b', name: 'Van woo-board', boardOwner: 'woo' }),
+      ],
+    });
+
+    render(<ArchiefSection />);
+
+    expect(await screen.findByText('Van infra-board')).toBeInTheDocument();
+    expect(screen.getByText('Van woo-board')).toBeInTheDocument();
+  });
+
+  it('drops an untagged task whose process key is not on the allow list', async () => {
+    mockBusinessApi.task.history.mockResolvedValue({
+      success: true,
+      data: [
+        makeTask({ id: 'a', name: 'Toegestaan', processDefinitionKey: 'ProcA' }),
+        makeTask({ id: 'b', name: 'Niet toegestaan', processDefinitionKey: 'ProcB' }),
+      ],
+    });
+
+    render(<ArchiefSection allowProcessKeys={new Set(['ProcA'])} />);
+
+    expect(await screen.findByText('Toegestaan')).toBeInTheDocument();
+    expect(screen.queryByText('Niet toegestaan')).not.toBeInTheDocument();
+  });
+
+  it('groups an untagged task with no process key under its task key instead', async () => {
+    // Historic tasks from an older engine version carry no
+    // processDefinitionKey; grouping them under `undefined` would collapse
+    // unrelated processes into one card.
+    mockBusinessApi.task.history.mockResolvedValue({
+      success: true,
+      data: [makeTask({ id: 'a', name: 'Zonder proceskey', processDefinitionKey: null })],
+    });
+
+    render(<ArchiefSection />);
+
+    expect(await screen.findByText('Zonder proceskey')).toBeInTheDocument();
+  });
+
+  it('falls back to the task key when the task has no display name', async () => {
+    mockBusinessApi.task.history.mockResolvedValue({
+      success: true,
+      data: [makeTask({ id: 'a', name: '', taskDefinitionKey: 'Task_Review' })],
+    });
+
+    render(<ArchiefSection />);
+
+    expect(await screen.findAllByText(/Task_Review/)).not.toHaveLength(0);
+  });
+
+  it('shows a business key when the process has one', async () => {
+    mockBusinessApi.task.history.mockResolvedValue({
+      success: true,
+      data: [makeTask({ id: 'a', businessKey: 'ZAAK-2026-001' })],
+    });
+
+    render(<ArchiefSection />);
+
+    expect(await screen.findByText('ZAAK-2026-001')).toBeInTheDocument();
+  });
+
+  it('shows a human assignee but hides a raw user id and a worker account', async () => {
+    // A bare Keycloak UUID and the external-task worker account are machine
+    // identities; printing them in the archive tells the reader nothing and
+    // looks like leaked internals.
+    mockBusinessApi.task.history.mockResolvedValue({
+      success: true,
+      data: [
+        makeTask({ id: 'a', name: 'Mens', assignee: 'w.demeer' }),
+        makeTask({
+          id: 'b',
+          name: 'UUID',
+          assignee: '3f1a2b4c-5d6e-4f70-8a9b-0c1d2e3f4a5b',
+        }),
+        makeTask({ id: 'c', name: 'Worker', assignee: 'ronl-worker-rip' }),
+      ],
+    });
+
+    render(<ArchiefSection />);
+
+    expect(await screen.findByText('w.demeer')).toBeInTheDocument();
+    expect(screen.queryByText('3f1a2b4c-5d6e-4f70-8a9b-0c1d2e3f4a5b')).not.toBeInTheDocument();
+    expect(screen.queryByText('ronl-worker-rip')).not.toBeInTheDocument();
+  });
+
+  it('renders each variable value by its type, with an em dash for an empty one', async () => {
+    mockBusinessApi.task.history.mockResolvedValue({
+      success: true,
+      data: [makeTask({ id: 'a', name: 'Met variabelen' })],
+    });
+    mockBusinessApi.process.historicVariables.mockResolvedValue({
+      success: true,
+      data: {
+        tekst: 'waarde',
+        getal: 42,
+        leeg: null,
+        ontbreekt: undefined,
+        object: { a: 1 },
+      },
+    });
+    const user = userEvent.setup();
+
+    render(<ArchiefSection />);
+    await user.click(await screen.findByText('Met variabelen'));
+
+    expect(await screen.findByText('waarde')).toBeInTheDocument();
+    expect(screen.getByText('42')).toBeInTheDocument();
+    expect(screen.getAllByText('—').length).toBeGreaterThan(0);
+    expect(screen.getByText('{"a":1}')).toBeInTheDocument();
+  });
+});

--- a/packages/frontend/src/components/CaseworkerDashboard/CapacityClaimDocumentsViewer.test.tsx
+++ b/packages/frontend/src/components/CaseworkerDashboard/CapacityClaimDocumentsViewer.test.tsx
@@ -116,3 +116,122 @@ describe('CapacityClaimDocumentsViewer', () => {
     expect(screen.queryByText('Gemeente Almere')).not.toBeInTheDocument();
   });
 });
+
+// Exercises every arm of the TipTap renderer and the block switch in one
+// document: each of the three viewers carries its own copy of this renderer,
+// so each needs its own pass over it.
+const richZone = {
+  blocks: [
+    {
+      type: 'text',
+      content: {
+        type: 'doc',
+        content: [
+          {
+            type: 'heading',
+            attrs: { level: 2 },
+            content: [{ type: 'text', text: 'Kop met niveau' }],
+          },
+          { type: 'heading', content: [{ type: 'text', text: 'Kop zonder niveau' }] },
+          {
+            type: 'paragraph',
+            content: [
+              { type: 'text', text: 'vet', marks: [{ type: 'bold' }] },
+              { type: 'text', text: 'cursief', marks: [{ type: 'italic' }] },
+              { type: 'text', text: 'onderstreept', marks: [{ type: 'underline' }] },
+              { type: 'text', text: 'alles', marks: [{ type: 'bold' }, { type: 'italic' }] },
+            ],
+          },
+          { type: 'paragraph' },
+          {
+            type: 'bulletList',
+            content: [{ type: 'listItem', content: [{ type: 'text', text: 'bullet' }] }],
+          },
+          {
+            type: 'orderedList',
+            content: [{ type: 'listItem', content: [{ type: 'text', text: 'genummerd' }] }],
+          },
+          { type: 'paragraph', content: [{ type: 'hardBreak' }] },
+          { type: 'blockquote', content: [{ type: 'text', text: 'onbekend nodetype' }] },
+          { type: 'text' },
+          {
+            type: 'paragraph',
+            content: [{ type: 'text', text: 'Beste {{naam}}, ref {{ontbreekt}}.' }],
+          },
+        ],
+      },
+    },
+    { type: 'variable', variableKey: 'naam' },
+    { type: 'variable', variableKey: 'ontbreekt' },
+    { type: 'variable' },
+    { type: 'separator' },
+    { type: 'spacer' },
+    { type: 'image', assetUrl: 'https://cdn.example/logo.png' },
+    { type: 'image' },
+    { type: 'text' },
+    { type: 'onbekend' },
+  ],
+};
+
+const richTemplate = {
+  id: 'rich',
+  name: 'Rich template',
+  zones: {
+    letterhead: { blocks: [] },
+    contactInformation: { blocks: [] },
+    reference: { blocks: [] },
+    body: richZone,
+    closing: { blocks: [] },
+    signOff: { blocks: [] },
+    annex: null,
+  },
+};
+
+describe('CapacityClaimDocumentsViewer document rendering', () => {
+  it('renders every block type, node type and text mark the composer can emit', async () => {
+    mockBusinessApi.capacityClaim.documents.mockResolvedValue({
+      success: true,
+      data: {
+        variables: { naam: 'Sanne' },
+        boardDecisionNotification: richTemplate,
+        capacityClaimHandover: null,
+      },
+    });
+    const user = userEvent.setup();
+    const { container } = render(<CapacityClaimDocumentsViewer instanceId="pi-1" />);
+    await user.click(await screen.findByText('Board of Directors — decision notification'));
+
+    // Marks nest rather than replace one another.
+    expect(container.querySelector('strong')).toHaveTextContent('vet');
+    expect(container.querySelector('em')).toHaveTextContent('cursief');
+    expect(container.querySelector('u')).toHaveTextContent('onderstreept');
+    // Marks apply in source order, so bold wraps first and italic wraps that.
+    expect(container.querySelector('em strong')).toHaveTextContent('alles');
+
+    // Headings honour their level and default to h1 without one.
+    expect(container.querySelector('h2')).toHaveTextContent('Kop met niveau');
+    expect(container.querySelector('h1')).toHaveTextContent('Kop zonder niveau');
+
+    // Lists and their items.
+    expect(container.querySelector('ul.list-disc li')).toHaveTextContent('bullet');
+    expect(container.querySelector('ol.list-decimal li')).toHaveTextContent('genummerd');
+
+    // An empty paragraph keeps its vertical space with a <br>, and a hardBreak
+    // renders one too.
+    expect(container.querySelectorAll('br').length).toBeGreaterThanOrEqual(2);
+
+    // A node type the renderer does not know still shows its children rather
+    // than dropping the text on the floor.
+    expect(container).toHaveTextContent('onbekend nodetype');
+
+    // Placeholder substitution, including a variable the process never set.
+    expect(container).toHaveTextContent('Beste Sanne, ref .');
+
+    // Separator, spacer and image blocks.
+    expect(container.querySelector('hr')).not.toBeNull();
+    expect(container.querySelector('div.h-4')).not.toBeNull();
+    const imgs = container.querySelectorAll('img');
+    expect(imgs).toHaveLength(1);
+    expect(imgs[0]).toHaveAttribute('src', 'https://cdn.example/logo.png');
+  });
+});

--- a/packages/frontend/src/components/CaseworkerDashboard/GereedschapSection.test.tsx
+++ b/packages/frontend/src/components/CaseworkerDashboard/GereedschapSection.test.tsx
@@ -91,3 +91,96 @@ describe('GereedschapSection', () => {
     );
   });
 });
+
+describe('GereedschapSection status badges', () => {
+  const cardFor = (name: string) => screen.getByText(name).closest('div.bg-white') as HTMLElement;
+
+  it('shows eDOCS online, with its library and latency', async () => {
+    mockBusinessApi.edocs.status.mockResolvedValue({
+      success: true,
+      data: { status: 'up', library: 'ProductieLib', latencyMs: 42 },
+    });
+
+    render(<GereedschapSection user={{ sub: '1', roles: [] } as never} />);
+
+    const card = cardFor('eDOCS');
+    expect(await within(card).findByText('Online')).toBeInTheDocument();
+    expect(within(card).getByText('Library: ProductieLib')).toBeInTheDocument();
+    expect(within(card).getByText('42 ms')).toBeInTheDocument();
+  });
+
+  it('shows eDOCS offline, with no library or latency to report', async () => {
+    mockBusinessApi.edocs.status.mockResolvedValue({ success: true, data: { status: 'down' } });
+
+    render(<GereedschapSection user={{ sub: '1', roles: [] } as never} />);
+
+    const card = cardFor('eDOCS');
+    expect(await within(card).findByText('Offline')).toBeInTheDocument();
+    expect(within(card).queryByText(/Library:/)).not.toBeInTheDocument();
+    expect(within(card).queryByText(/ ms/)).not.toBeInTheDocument();
+  });
+
+  it('says the eDOCS status is unavailable when the call fails', async () => {
+    // "Status niet beschikbaar" is a different claim from "Offline": the first
+    // says this dashboard could not ask, the second says eDOCS answered no.
+    mockBusinessApi.edocs.status.mockRejectedValue(new Error('network'));
+
+    render(<GereedschapSection user={{ sub: '1', roles: [] } as never} />);
+
+    const card = cardFor('eDOCS');
+    expect(await within(card).findByText('Status niet beschikbaar')).toBeInTheDocument();
+  });
+
+  it('shows Operaton offline with its latency', async () => {
+    mockBusinessApi.health.mockResolvedValue({
+      dependencies: { operaton: { status: 'down', latency: 900 } },
+    });
+
+    render(<GereedschapSection user={{ sub: '1', roles: ['admin'] } as never} />);
+
+    const card = cardFor('Operaton Cockpit');
+    expect(await within(card).findByText('Offline')).toBeInTheDocument();
+    expect(within(card).getByText('900 ms')).toBeInTheDocument();
+  });
+
+  it('says the Operaton status is unavailable when the health call fails', async () => {
+    mockBusinessApi.health.mockRejectedValue(new Error('network'));
+
+    render(<GereedschapSection user={{ sub: '1', roles: ['admin'] } as never} />);
+
+    const card = cardFor('Operaton Cockpit');
+    expect(await within(card).findByText('Status niet beschikbaar')).toBeInTheDocument();
+  });
+
+  it('shows an external dependency as offline', async () => {
+    mockBusinessApi.externalStatus.mockResolvedValue({
+      success: true,
+      data: { lde: { status: 'down', latency: 1200 } },
+    });
+
+    render(<GereedschapSection user={{ sub: '1', roles: [] } as never} />);
+
+    const card = cardFor('Linked Data Explorer');
+    expect(await within(card).findByText('Offline')).toBeInTheDocument();
+    expect(within(card).getByText('1200 ms')).toBeInTheDocument();
+  });
+
+  it('says an external status is unavailable when that dependency is absent from the response', async () => {
+    mockBusinessApi.externalStatus.mockResolvedValue({
+      success: true,
+      data: { lde: { status: 'up', latency: 30 } },
+    });
+
+    render(<GereedschapSection user={{ sub: '1', roles: [] } as never} />);
+
+    await within(cardFor('Linked Data Explorer')).findByText('Online');
+    expect(within(cardFor('TriplyDB')).getByText('Status niet beschikbaar')).toBeInTheDocument();
+  });
+
+  it('treats a user with no roles at all the same as a user with an empty role list', async () => {
+    // `user` is null on a route rendered before the token is parsed.
+    render(<GereedschapSection user={null as never} />);
+    expect(await screen.findByText('CPSV Editor')).toBeInTheDocument();
+    expect(screen.queryByText('Operaton Cockpit')).not.toBeInTheDocument();
+  });
+});

--- a/packages/frontend/src/components/CaseworkerDashboard/RipFase1WipViewer.test.tsx
+++ b/packages/frontend/src/components/CaseworkerDashboard/RipFase1WipViewer.test.tsx
@@ -86,3 +86,123 @@ describe('RipFase1WipViewer', () => {
     expect(screen.queryByText('steps-timeline-pi-1')).not.toBeInTheDocument();
   });
 });
+
+// Exercises every arm of the TipTap renderer and the block switch in one
+// document: each of the three viewers carries its own copy of this renderer,
+// so each needs its own pass over it.
+const richZone = {
+  blocks: [
+    {
+      type: 'text',
+      content: {
+        type: 'doc',
+        content: [
+          {
+            type: 'heading',
+            attrs: { level: 2 },
+            content: [{ type: 'text', text: 'Kop met niveau' }],
+          },
+          { type: 'heading', content: [{ type: 'text', text: 'Kop zonder niveau' }] },
+          {
+            type: 'paragraph',
+            content: [
+              { type: 'text', text: 'vet', marks: [{ type: 'bold' }] },
+              { type: 'text', text: 'cursief', marks: [{ type: 'italic' }] },
+              { type: 'text', text: 'onderstreept', marks: [{ type: 'underline' }] },
+              { type: 'text', text: 'alles', marks: [{ type: 'bold' }, { type: 'italic' }] },
+            ],
+          },
+          { type: 'paragraph' },
+          {
+            type: 'bulletList',
+            content: [{ type: 'listItem', content: [{ type: 'text', text: 'bullet' }] }],
+          },
+          {
+            type: 'orderedList',
+            content: [{ type: 'listItem', content: [{ type: 'text', text: 'genummerd' }] }],
+          },
+          { type: 'paragraph', content: [{ type: 'hardBreak' }] },
+          { type: 'blockquote', content: [{ type: 'text', text: 'onbekend nodetype' }] },
+          { type: 'text' },
+          {
+            type: 'paragraph',
+            content: [{ type: 'text', text: 'Beste {{naam}}, ref {{ontbreekt}}.' }],
+          },
+        ],
+      },
+    },
+    { type: 'variable', variableKey: 'naam' },
+    { type: 'variable', variableKey: 'ontbreekt' },
+    { type: 'variable' },
+    { type: 'separator' },
+    { type: 'spacer' },
+    { type: 'image', assetUrl: 'https://cdn.example/logo.png' },
+    { type: 'image' },
+    { type: 'text' },
+    { type: 'onbekend' },
+  ],
+};
+
+const richTemplate = {
+  id: 'rich',
+  name: 'Rich template',
+  zones: {
+    letterhead: { blocks: [] },
+    contactInformation: { blocks: [] },
+    reference: { blocks: [] },
+    body: richZone,
+    closing: { blocks: [] },
+    signOff: { blocks: [] },
+    annex: null,
+  },
+};
+
+describe('RipFase1WipViewer document rendering', () => {
+  it('renders every block type, node type and text mark the composer can emit', async () => {
+    mockBusinessApi.rip.instanceDocuments.mockResolvedValue({
+      success: true,
+      data: {
+        variables: { naam: 'Sanne' },
+        intakeReport: richTemplate,
+        psuReport: null,
+        pdp: null,
+      },
+    });
+    const user = userEvent.setup();
+    const { container } = render(<RipFase1WipViewer instanceId="pi-1" />);
+    await user.click(await screen.findByText('Intakeverslag (Kolom 2)'));
+
+    // Marks nest rather than replace one another.
+    expect(container.querySelector('strong')).toHaveTextContent('vet');
+    expect(container.querySelector('em')).toHaveTextContent('cursief');
+    expect(container.querySelector('u')).toHaveTextContent('onderstreept');
+    // Marks apply in source order, so bold wraps first and italic wraps that.
+    expect(container.querySelector('em strong')).toHaveTextContent('alles');
+
+    // Headings honour their level and default to h1 without one.
+    expect(container.querySelector('h2')).toHaveTextContent('Kop met niveau');
+    expect(container.querySelector('h1')).toHaveTextContent('Kop zonder niveau');
+
+    // Lists and their items.
+    expect(container.querySelector('ul.list-disc li')).toHaveTextContent('bullet');
+    expect(container.querySelector('ol.list-decimal li')).toHaveTextContent('genummerd');
+
+    // An empty paragraph keeps its vertical space with a <br>, and a hardBreak
+    // renders one too.
+    expect(container.querySelectorAll('br').length).toBeGreaterThanOrEqual(2);
+
+    // A node type the renderer does not know still shows its children rather
+    // than dropping the text on the floor.
+    expect(container).toHaveTextContent('onbekend nodetype');
+
+    // Placeholder substitution, including a variable the process never set.
+    expect(container).toHaveTextContent('Beste Sanne, ref .');
+
+    // Separator, spacer and image blocks.
+    expect(container.querySelector('hr')).not.toBeNull();
+    expect(container.querySelector('div.h-4')).not.toBeNull();
+    const imgs = container.querySelectorAll('img');
+    expect(imgs).toHaveLength(1);
+    expect(imgs[0]).toHaveAttribute('src', 'https://cdn.example/logo.png');
+  });
+});

--- a/packages/frontend/src/components/CaseworkerDashboardV2/AssistantDock.test.tsx
+++ b/packages/frontend/src/components/CaseworkerDashboardV2/AssistantDock.test.tsx
@@ -1,6 +1,6 @@
 // @vitest-environment jsdom
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
-import { render, screen } from '@testing-library/react';
+import { fireEvent, render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import AssistantDock from './AssistantDock';
 
@@ -62,5 +62,107 @@ describe('AssistantDock', () => {
     await user.click(screen.getByRole('button', { name: 'Sluiten' }));
 
     expect(onClose).toHaveBeenCalled();
+  });
+});
+
+describe('AssistantDock storage and drag resize', () => {
+  it('restores a stored conversation', () => {
+    sessionStorage.setItem(
+      'cwdV2.assistant.messages',
+      JSON.stringify([{ role: 'user', content: 'Hallo' }])
+    );
+    expect(() => render(<AssistantDock user={null} onClose={vi.fn()} />)).not.toThrow();
+  });
+
+  it('starts empty when the stored conversation is not valid JSON', () => {
+    // sessionStorage is shared with anything else on this origin and survives
+    // a deploy; a half-written or stale value must not take the dock down.
+    sessionStorage.setItem('cwdV2.assistant.messages', 'niet-json');
+    expect(() => render(<AssistantDock user={null} onClose={vi.fn()} />)).not.toThrow();
+  });
+
+  it('falls back to the default width when the stored width is not a number', () => {
+    sessionStorage.setItem('cwdV2.assistant.width', 'breed');
+    const { container } = render(<AssistantDock user={null} onClose={vi.fn()} />);
+    expect(container.querySelector('.v2-dock')).toHaveStyle({ width: '360px' });
+  });
+
+  it('survives sessionStorage being unavailable entirely', () => {
+    // Private-browsing modes and locked-down enterprise profiles throw on
+    // access rather than returning null.
+    const getItem = vi.spyOn(Storage.prototype, 'getItem').mockImplementation(() => {
+      throw new Error('blocked');
+    });
+    const setItem = vi.spyOn(Storage.prototype, 'setItem').mockImplementation(() => {
+      throw new Error('blocked');
+    });
+    try {
+      const { container } = render(<AssistantDock user={null} onClose={vi.fn()} />);
+      expect(container.querySelector('.v2-dock')).toHaveStyle({ width: '360px' });
+    } finally {
+      getItem.mockRestore();
+      setItem.mockRestore();
+    }
+  });
+
+  it('resizes by dragging the handle, and stops on pointer release', () => {
+    const { container } = render(<AssistantDock user={null} onClose={vi.fn()} />);
+    const handle = screen.getByRole('separator');
+
+    fireEvent.pointerDown(handle);
+    expect(handle.className).toContain('dragging');
+    // The dock is right-anchored, so its width is the distance from the
+    // pointer to the right edge of the window.
+    fireEvent.pointerMove(window, { clientX: window.innerWidth - 420 });
+    expect(container.querySelector('.v2-dock')).toHaveStyle({ width: '420px' });
+
+    fireEvent.pointerUp(window);
+    expect(handle.className).not.toContain('dragging');
+
+    // After release the handle no longer tracks the pointer.
+    fireEvent.pointerMove(window, { clientX: window.innerWidth - 500 });
+    expect(container.querySelector('.v2-dock')).toHaveStyle({ width: '420px' });
+  });
+
+  it('abandons a drag that the browser cancels', () => {
+    render(<AssistantDock user={null} onClose={vi.fn()} />);
+    const handle = screen.getByRole('separator');
+
+    fireEvent.pointerDown(handle);
+    fireEvent.pointerCancel(window);
+
+    expect(handle.className).not.toContain('dragging');
+  });
+
+  it('clamps a drag to the minimum and maximum width', () => {
+    const { container } = render(<AssistantDock user={null} onClose={vi.fn()} />);
+    fireEvent.pointerDown(screen.getByRole('separator'));
+
+    fireEvent.pointerMove(window, { clientX: window.innerWidth });
+    expect(container.querySelector('.v2-dock')).toHaveStyle({ width: '320px' });
+
+    fireEvent.pointerMove(window, { clientX: -5000 });
+    const max = Math.min(720, Math.round(window.innerWidth * 0.6));
+    expect(container.querySelector('.v2-dock')).toHaveStyle({ width: `${max}px` });
+  });
+
+  it('ignores a key on the handle that is not a horizontal arrow', () => {
+    const { container } = render(<AssistantDock user={null} onClose={vi.fn()} />);
+    const before = (container.querySelector('.v2-dock') as HTMLElement).style.width;
+
+    fireEvent.keyDown(screen.getByRole('separator'), { key: 'ArrowUp' });
+
+    expect((container.querySelector('.v2-dock') as HTMLElement).style.width).toBe(before);
+  });
+
+  it('restores the document cursor when the dock unmounts mid-drag', () => {
+    const { unmount } = render(<AssistantDock user={null} onClose={vi.fn()} />);
+    fireEvent.pointerDown(screen.getByRole('separator'));
+    expect(document.body.style.cursor).toBe('col-resize');
+
+    unmount();
+
+    expect(document.body.style.cursor).toBe('');
+    expect(document.body.style.userSelect).toBe('');
   });
 });

--- a/packages/frontend/src/components/CaseworkerDashboardV2/RegelSimulatie.test.tsx
+++ b/packages/frontend/src/components/CaseworkerDashboardV2/RegelSimulatie.test.tsx
@@ -1,6 +1,6 @@
 // @vitest-environment jsdom
-import { describe, it, expect, afterEach } from 'vitest';
-import { render, screen } from '@testing-library/react';
+import { describe, it, expect, afterEach, vi } from 'vitest';
+import { fireEvent, render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import RegelSimulatie from './RegelSimulatie';
 
@@ -65,5 +65,117 @@ describe('per-user day persistence', () => {
     localStorage.setItem('sim-thuisbatterij-v2:day:user-a', '10');
     render(<RegelSimulatie user={{ sub: 'user-b' } as never} />);
     expect(screen.getByText(/dag 1\//)).toBeInTheDocument();
+  });
+});
+
+describe('RegelSimulatie stored scenario', () => {
+  afterEach(() => localStorage.clear());
+
+  it('starts from the defaults when the stored scenario is not valid JSON', () => {
+    localStorage.setItem('sim-thuisbatterij-v2', '{ niet json');
+    expect(() => render(<RegelSimulatie user={{ sub: 'user-1' } as never} />)).not.toThrow();
+  });
+
+  it('clamps a stored parameter that is outside its own range', () => {
+    // The stored blob is user-editable and survives a deploy that narrows a
+    // range; feeding an out-of-range value straight into the engine produces
+    // nonsense rather than an error.
+    localStorage.setItem(
+      'sim-thuisbatterij-v2',
+      JSON.stringify({ cfg: { populatie: 999999, bezwaarKans: -5, doorlooptijdGem: NaN } })
+    );
+
+    render(<RegelSimulatie user={{ sub: 'user-1' } as never} />);
+
+    expect(
+      screen.getByRole('heading', { level: 1, name: 'Regelsimulatie — Subsidie thuisbatterij' })
+    ).toBeInTheDocument();
+  });
+
+  it('ignores a stored day that is not a number', () => {
+    localStorage.setItem('sim-thuisbatterij-v2:day:user-1', 'gisteren');
+    render(<RegelSimulatie user={{ sub: 'user-1' } as never} />);
+    expect(screen.getByText(/dag 1\//)).toBeInTheDocument();
+  });
+
+  it('starts at day 0 when no user is signed in, and stores nothing per user', () => {
+    render(<RegelSimulatie user={null} />);
+    expect(screen.getByText(/dag 1\//)).toBeInTheDocument();
+  });
+
+  it('survives localStorage being unavailable, on read and on write', () => {
+    const getItem = vi.spyOn(Storage.prototype, 'getItem').mockImplementation(() => {
+      throw new Error('blocked');
+    });
+    const setItem = vi.spyOn(Storage.prototype, 'setItem').mockImplementation(() => {
+      throw new Error('blocked');
+    });
+    try {
+      expect(() => render(<RegelSimulatie user={{ sub: 'user-1' } as never} />)).not.toThrow();
+    } finally {
+      getItem.mockRestore();
+      setItem.mockRestore();
+    }
+  });
+});
+
+describe('RegelSimulatie playback', () => {
+  afterEach(() => localStorage.clear());
+
+  const scrubTo = (day: number) => {
+    const slider = screen.getByLabelText('Tijdlijn') as HTMLInputElement;
+    fireEvent.change(slider, { target: { value: String(day) } });
+    return slider;
+  };
+
+  it('offers a replay once the timeline is parked on the last day', () => {
+    render(<RegelSimulatie user={{ sub: 'user-1' } as never} />);
+    const slider = screen.getByLabelText('Tijdlijn') as HTMLInputElement;
+
+    scrubTo(Number(slider.max));
+
+    expect(screen.getByRole('button', { name: /Opnieuw/ })).toBeInTheDocument();
+  });
+
+  it('restarts from day 0 when replayed from the end', async () => {
+    const user = userEvent.setup();
+    render(<RegelSimulatie user={{ sub: 'user-1' } as never} />);
+    const slider = screen.getByLabelText('Tijdlijn') as HTMLInputElement;
+    scrubTo(Number(slider.max));
+
+    await user.click(screen.getByRole('button', { name: /Opnieuw/ }));
+
+    expect(screen.getByText(/dag 1\//)).toBeInTheDocument();
+  });
+
+  it('plays and pauses from the same control', async () => {
+    const user = userEvent.setup();
+    render(<RegelSimulatie user={{ sub: 'user-1' } as never} />);
+
+    await user.click(screen.getByRole('button', { name: /Speel af/ }));
+    expect(screen.getByRole('button', { name: /Pauze/ })).toBeInTheDocument();
+
+    await user.click(screen.getByRole('button', { name: /Pauze/ }));
+    expect(screen.getByRole('button', { name: /Speel af/ })).toBeInTheDocument();
+  });
+
+  it('names which ceiling regime the current day falls under', () => {
+    render(<RegelSimulatie user={{ sub: 'user-1' } as never} />);
+    const slider = screen.getByLabelText('Tijdlijn') as HTMLInputElement;
+    const last = Number(slider.max);
+
+    // The pots are split until 1 October and bundled afterwards, and a day
+    // outside the application window belongs to neither.
+    const seen = new Set<string>();
+    for (const day of [0, Math.round(last * 0.25), Math.round(last * 0.6), last]) {
+      scrubTo(day);
+      const pill = document.querySelector('.sim-modepill');
+      if (pill?.textContent) seen.add(pill.textContent.trim());
+    }
+
+    expect(seen.size).toBeGreaterThan(1);
+    for (const label of seen) {
+      expect(['Gesplitst plafond', 'Gebundeld plafond', 'Buiten periode']).toContain(label);
+    }
   });
 });

--- a/packages/frontend/src/components/CaseworkerDashboardV2/TakenInbox.test.tsx
+++ b/packages/frontend/src/components/CaseworkerDashboardV2/TakenInbox.test.tsx
@@ -1,6 +1,6 @@
 // @vitest-environment jsdom
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
-import { render, screen, waitFor } from '@testing-library/react';
+import { render, screen, waitFor, within } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import TakenInbox from './TakenInbox';
 import type { Task } from '@ronl/shared';
@@ -164,5 +164,249 @@ describe('TakenInbox', () => {
     await waitFor(() =>
       expect(screen.getByText('Selecteer een taak om de details te bekijken.')).toBeInTheDocument()
     );
+  });
+});
+
+describe('TakenInbox deadline filters', () => {
+  const iso = (ms: number) => new Date(Date.now() + ms).toISOString();
+  const DAY = 24 * 60 * 60 * 1000;
+
+  // Noon today rather than "a minute from now": the latter lands on tomorrow
+  // when the suite happens to run just before midnight, which made the
+  // "Vandaag" case fail on the clock rather than on the code.
+  const noonToday = () => {
+    const d = new Date();
+    d.setHours(12, 0, 0, 0);
+    return d.toISOString();
+  };
+
+  const dated = () => [
+    makeTask({ id: 'laat', name: 'Al te laat', due: iso(-2 * DAY) }),
+    makeTask({ id: 'vandaag', name: 'Vandaag af', due: noonToday() }),
+    makeTask({ id: 'week', name: 'Deze week af', due: iso(3 * DAY) }),
+    makeTask({ id: 'later', name: 'Volgende maand', due: iso(30 * DAY) }),
+    makeTask({ id: 'geen', name: 'Zonder deadline' }),
+  ];
+
+  // The filter labels also appear on the task rows ("Te laat — <datum>"), so
+  // scope the lookup to the filter rail rather than the whole document.
+  const openFilter = async (label: string) => {
+    const user = userEvent.setup();
+    mockBusinessApi.task.list.mockResolvedValue({ success: true, data: dated() });
+    render(<TakenInbox user={{ sub: 'u1' } as never} onCountChange={vi.fn()} />);
+    await screen.findByText('Al te laat');
+    const rail = screen.getByLabelText('Taakfilters');
+    await user.click(within(rail).getByRole('button', { name: new RegExp(label) }));
+    return user;
+  };
+
+  it('"Te laat" holds only tasks whose deadline has passed', async () => {
+    await openFilter('Te laat');
+    expect(screen.getByText('Al te laat')).toBeInTheDocument();
+    expect(screen.queryByText('Deze week af')).not.toBeInTheDocument();
+    expect(screen.queryByText('Volgende maand')).not.toBeInTheDocument();
+    expect(screen.queryByText('Zonder deadline')).not.toBeInTheDocument();
+  });
+
+  it('"Vandaag" holds only tasks due on the current calendar day', async () => {
+    await openFilter('Vandaag');
+    expect(screen.getByText('Vandaag af')).toBeInTheDocument();
+    expect(screen.queryByText('Deze week af')).not.toBeInTheDocument();
+    expect(screen.queryByText('Zonder deadline')).not.toBeInTheDocument();
+  });
+
+  it('"Deze week" spans the next seven days and excludes what is already late', async () => {
+    await openFilter('Deze week');
+    expect(screen.getByText('Deze week af')).toBeInTheDocument();
+    // Whether noon-today is still ahead depends on the time of day, so it is
+    // deliberately not asserted here; what the window must exclude is fixed.
+    expect(screen.queryByText('Al te laat')).not.toBeInTheDocument();
+    expect(screen.queryByText('Volgende maand')).not.toBeInTheDocument();
+  });
+
+  it('sorts by deadline, soonest first, with undated tasks last', async () => {
+    mockBusinessApi.task.list.mockResolvedValue({ success: true, data: dated() });
+    render(<TakenInbox user={{ sub: 'u1' } as never} onCountChange={vi.fn()} />);
+    await screen.findByText('Al te laat');
+
+    const names = Array.from(document.querySelectorAll('.v2-taken-item-name')).map(
+      (el) => el.textContent
+    );
+    expect(names).toEqual([
+      'Al te laat',
+      'Vandaag af',
+      'Deze week af',
+      'Volgende maand',
+      'Zonder deadline',
+    ]);
+  });
+
+  it('breaks a deadline tie by newest first', async () => {
+    // Two tasks can share a deadline (a batch created by one process); the
+    // list still has to be deterministic rather than following fetch order.
+    const due = iso(2 * DAY);
+    mockBusinessApi.task.list.mockResolvedValue({
+      success: true,
+      data: [
+        makeTask({ id: 'oud', name: 'Ouder', due, created: '2026-07-01T00:00:00Z' }),
+        makeTask({ id: 'nieuw', name: 'Nieuwer', due, created: '2026-07-05T00:00:00Z' }),
+      ],
+    });
+    render(<TakenInbox user={{ sub: 'u1' } as never} onCountChange={vi.fn()} />);
+    await screen.findByText('Nieuwer');
+
+    const names = Array.from(document.querySelectorAll('.v2-taken-item-name')).map(
+      (el) => el.textContent
+    );
+    expect(names).toEqual(['Nieuwer', 'Ouder']);
+  });
+
+  it('says the filter is empty rather than showing a blank column', async () => {
+    mockBusinessApi.task.list.mockResolvedValue({
+      success: true,
+      data: [makeTask({ id: 'geen', name: 'Zonder deadline' })],
+    });
+    const user = userEvent.setup();
+    render(<TakenInbox user={{ sub: 'u1' } as never} onCountChange={vi.fn()} />);
+    await screen.findByText('Zonder deadline');
+
+    await user.click(
+      within(screen.getByLabelText('Taakfilters')).getByRole('button', { name: /Te laat/ })
+    );
+    expect(screen.getByText('Geen taken in dit filter.')).toBeInTheDocument();
+  });
+});
+
+describe('TakenInbox task rows and detail pane', () => {
+  const iso = (ms: number) => new Date(Date.now() + ms).toISOString();
+  const DAY = 24 * 60 * 60 * 1000;
+
+  it('marks a claimed task and an open one differently, and flags a passed deadline', async () => {
+    mockBusinessApi.task.list.mockResolvedValue({
+      success: true,
+      data: [
+        makeTask({ id: 'a', name: 'Geclaimde taak', assignee: 'u1', due: iso(-DAY) }),
+        makeTask({ id: 'b', name: 'Open taak', due: iso(DAY) }),
+      ],
+    });
+
+    render(<TakenInbox user={{ sub: 'u1' } as never} onCountChange={vi.fn()} />);
+
+    expect(await screen.findByText('Geclaimd')).toBeInTheDocument();
+    expect(screen.getByText('Open')).toBeInTheDocument();
+    expect(screen.getByText(/^Te laat —/)).toBeInTheDocument();
+    expect(screen.getByText(/^Deadline /)).toBeInTheDocument();
+  });
+
+  it('falls back to the process definition id when the task carries no key', async () => {
+    mockBusinessApi.task.list.mockResolvedValue({
+      success: true,
+      data: [makeTask({ id: 'a', processDefinitionKey: undefined })],
+    });
+
+    render(<TakenInbox user={{ sub: 'u1' } as never} onCountChange={vi.fn()} />);
+
+    expect(await screen.findByText('Proc:1:def')).toBeInTheDocument();
+  });
+
+  it('shows the description and the deadline in the detail pane', async () => {
+    const user = userEvent.setup();
+    mockBusinessApi.task.list.mockResolvedValue({
+      success: true,
+      data: [
+        makeTask({
+          id: 'a',
+          name: 'Met omschrijving',
+          description: 'Beoordeel de aanvraag binnen de termijn.',
+          due: iso(-DAY),
+        }),
+      ],
+    });
+
+    render(<TakenInbox user={{ sub: 'u1' } as never} onCountChange={vi.fn()} />);
+    await user.click(await screen.findByText('Met omschrijving'));
+
+    expect(screen.getByText('Beoordeel de aanvraag binnen de termijn.')).toBeInTheDocument();
+    expect(screen.getByText('Deadline')).toBeInTheDocument();
+    expect(document.querySelector('.v2-taken-overdue')).not.toBeNull();
+  });
+
+  it('reports a failed claim rather than pretending it worked', async () => {
+    const user = userEvent.setup();
+    mockBusinessApi.task.list.mockResolvedValue({
+      success: true,
+      data: [makeTask({ id: 'a', name: 'Te claimen' })],
+    });
+    mockBusinessApi.task.claim.mockResolvedValue({ success: false });
+
+    render(<TakenInbox user={{ sub: 'u1' } as never} onCountChange={vi.fn()} />);
+    await user.click(await screen.findByText('Te claimen'));
+    await user.click(await screen.findByRole('button', { name: 'Taak claimen' }));
+
+    expect(await screen.findByText('Claimen mislukt.')).toBeInTheDocument();
+  });
+
+  it('reports a claim that never reached the backend the same way', async () => {
+    const user = userEvent.setup();
+    mockBusinessApi.task.list.mockResolvedValue({
+      success: true,
+      data: [makeTask({ id: 'a', name: 'Te claimen' })],
+    });
+    mockBusinessApi.task.claim.mockRejectedValue(new Error('network'));
+
+    render(<TakenInbox user={{ sub: 'u1' } as never} onCountChange={vi.fn()} />);
+    await user.click(await screen.findByText('Te claimen'));
+    await user.click(await screen.findByRole('button', { name: 'Taak claimen' }));
+
+    expect(await screen.findByText('Claimen mislukt.')).toBeInTheDocument();
+  });
+
+  it('marks each process step as running, cancelled or done', async () => {
+    const user = userEvent.setup();
+    mockBusinessApi.task.list.mockResolvedValue({
+      success: true,
+      data: [makeTask({ id: 'a', name: 'Met stappen' })],
+    });
+    mockBusinessApi.process.activityHistory.mockResolvedValue({
+      success: true,
+      data: [
+        {
+          id: 'act1',
+          activityId: 'Start',
+          activityName: 'Start',
+          activityType: 'startEvent',
+          startTime: '2026-07-01T09:00:00Z',
+          endTime: '2026-07-01T09:00:01Z',
+          canceled: false,
+        },
+        {
+          id: 'act2',
+          activityId: 'Service',
+          activityName: null,
+          activityType: 'serviceTask',
+          startTime: '2026-07-01T09:00:02Z',
+          endTime: null,
+          canceled: false,
+        },
+        {
+          id: 'act3',
+          activityId: 'Afgebroken',
+          activityName: 'Afgebroken stap',
+          activityType: 'userTask',
+          startTime: '2026-07-01T09:00:03Z',
+          endTime: '2026-07-01T09:00:04Z',
+          canceled: true,
+        },
+      ],
+    });
+
+    render(<TakenInbox user={{ sub: 'u1' } as never} onCountChange={vi.fn()} />);
+    await user.click(await screen.findByText('Met stappen'));
+
+    expect(await screen.findByText('Afgerond')).toBeInTheDocument();
+    expect(screen.getByText('Loopt nog')).toBeInTheDocument();
+    expect(screen.getByText('Afgebroken')).toBeInTheDocument();
+    // A step with no display name falls back to its activity id.
+    expect(screen.getByText('Service')).toBeInTheDocument();
   });
 });

--- a/packages/frontend/src/components/CaseworkerDashboardV2/regelsimulatie/SimMissedPanel.test.tsx
+++ b/packages/frontend/src/components/CaseworkerDashboardV2/regelsimulatie/SimMissedPanel.test.tsx
@@ -4,7 +4,7 @@ import { render, screen, fireEvent } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import SimMissedPanel from './SimMissedPanel';
 import { run } from './simEngine';
-import type { SimConfig } from './types';
+import type { SimApp, SimConfig, SimResult } from './types';
 
 const DEFAULT_CFG: SimConfig = {
   seed: 20260112,
@@ -80,5 +80,109 @@ describe('SimMissedPanel', () => {
     render(<SimMissedPanel result={result} day={0} />);
     // At day 0 nothing has been decided yet, so nothing has "missed out".
     expect(screen.getByText(/Nog niets misgelopen|In dit scenario/)).toBeInTheDocument();
+  });
+});
+
+describe('SimMissedPanel, why an application went unpaid', () => {
+  // The engine's own output happens not to produce every combination of the
+  // two "why" flags in one run, and the panel's whole job is to name the
+  // reason. Synthesising the applications from a real one keeps every other
+  // field consistent with what the engine actually emits.
+  const template = result.apps.find((a) => a.missedDueToRFI || a.missedDueToBeroep)!;
+  const app = (over: Partial<SimApp>): SimApp => ({ ...template, ...over });
+  const withApps = (apps: SimApp[]): SimResult => ({ ...result, apps });
+  const lastDay = result.days.length - 1;
+
+  it('names both causes when an application lost out to a shift and an appeal', () => {
+    render(
+      <SimMissedPanel
+        result={withApps([
+          app({ id: 9001, missedDueToRFI: true, missedDueToBeroep: true, beroepDisplacerId: 42 }),
+        ])}
+        day={lastDay}
+      />
+    );
+
+    // The cause tag is part of the "Alle onbetaalde" view, where the reason
+    // is what distinguishes one row from the next.
+    fireEvent.click(screen.getByRole('button', { name: /Alle onbetaalde/ }));
+    expect(screen.getAllByText(/RFI \+ beroep/).length).toBeGreaterThan(0);
+  });
+
+  it('names the appeal alone when that is the only cause', () => {
+    render(
+      <SimMissedPanel
+        result={withApps([
+          app({ id: 9002, missedDueToRFI: false, missedDueToBeroep: true, beroepDisplacerId: 43 }),
+        ])}
+        day={lastDay}
+      />
+    );
+
+    fireEvent.click(screen.getByRole('button', { name: /Alle onbetaalde/ }));
+    expect(screen.getAllByText(/door beroep/).length).toBeGreaterThan(0);
+  });
+
+  it('falls back to "budget op" when neither cause applies', () => {
+    // A valid application can simply arrive after the pot is empty; that is
+    // not a displacement and must not be reported as one.
+    render(
+      <SimMissedPanel
+        result={withApps([
+          app({
+            id: 9003,
+            missedDueToRFI: false,
+            missedDueToBeroep: false,
+            beroepDisplacerId: null,
+            blockedById: null,
+          }),
+        ])}
+        day={lastDay}
+      />
+    );
+
+    fireEvent.click(screen.getByRole('button', { name: /Alle onbetaalde/ }));
+    expect(screen.getAllByText(/budget op/).length).toBeGreaterThan(0);
+  });
+
+  it('says so plainly when a filter matches nothing in the whole scenario', () => {
+    render(
+      <SimMissedPanel
+        result={withApps([app({ id: 9004, missedDueToRFI: false, missedDueToBeroep: false })])}
+        day={lastDay}
+      />
+    );
+
+    // The default RFI filter has no members at all here -- a different message
+    // from "not yet, keep playing".
+    expect(screen.getByText(/verliest geen enkele geldige aanvraag/)).toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole('button', { name: /Door succesvol beroep/ }));
+    expect(screen.getByText(/verdringt geen enkel succesvol beroep/)).toBeInTheDocument();
+  });
+
+  it('omits an application that has not been decided yet at the current day', () => {
+    render(
+      <SimMissedPanel
+        result={withApps([app({ id: 9005, missedDueToRFI: true, decisionDay: lastDay + 50 })])}
+        day={0}
+      />
+    );
+
+    expect(screen.getByText(/Nog niets misgelopen/)).toBeInTheDocument();
+  });
+
+  it('names the appeal that took the budget', () => {
+    render(
+      <SimMissedPanel
+        result={withApps([
+          app({ id: 9006, missedDueToRFI: false, missedDueToBeroep: true, beroepDisplacerId: 77 }),
+        ])}
+        day={lastDay}
+      />
+    );
+
+    fireEvent.click(screen.getByRole('button', { name: /Door succesvol beroep/ }));
+    expect(screen.getAllByText(/#77/).length).toBeGreaterThan(0);
   });
 });

--- a/packages/frontend/src/components/CaseworkerDashboardV2/regelsimulatie/SimPot.test.tsx
+++ b/packages/frontend/src/components/CaseworkerDashboardV2/regelsimulatie/SimPot.test.tsx
@@ -29,4 +29,43 @@ describe('SimPot', () => {
     const { container } = render(<SimPot name="Eigenaren" total={437500} used={437500} />);
     expect(container.querySelector('.sim-bar.exhausted')).toBeInTheDocument();
   });
+  it('shows the overspend as its own segment, a ceiling mark and a figure', () => {
+    // Going over budget is the outcome the simulator exists to surface, so it
+    // gets its own bar segment past the ceiling rather than a full bar.
+    const { container } = render(<SimPot name="Eigenaren" total={100000} used={160000} />);
+
+    expect(container.querySelector('.sim-seg.over')).toBeInTheDocument();
+    expect(container.querySelector('.sim-ceilmark')).toBeInTheDocument();
+    expect(container.textContent).toContain('over budget');
+  });
+
+  it('leaves a segment unlabelled when it is too narrow for its own figure', () => {
+    // A label wider than its segment overflows into the neighbouring one and
+    // reads as belonging to the wrong pot.
+    const { container } = render(<SimPot name="Eigenaren" total={100000} used={101000} />);
+
+    const over = container.querySelector('.sim-seg.over');
+    expect(over).toBeInTheDocument();
+    expect(over).toHaveTextContent('');
+  });
+
+  it('labels a free segment only when it is wide enough', () => {
+    const { container } = render(<SimPot name="Eigenaren" total={100000} used={10000} />);
+    expect(container.querySelector('.sim-seg.free')).toHaveTextContent('vrij');
+
+    const tight = render(<SimPot name="Krap" total={100000} used={95000} />);
+    expect(tight.container.querySelector('.sim-seg.free')).toHaveTextContent('');
+  });
+
+  it('renders an entirely empty pot without dividing by zero', () => {
+    // A scenario can zero out a pot completely; a NaN width would collapse the
+    // whole bar rather than showing an empty one.
+    const { container } = render(<SimPot name="Leeg" total={0} used={0} />);
+
+    const segments = container.querySelectorAll('.sim-seg');
+    expect(segments.length).toBeGreaterThan(0);
+    segments.forEach((seg) => {
+      expect((seg as HTMLElement).style.width).not.toContain('NaN');
+    });
+  });
 });

--- a/packages/frontend/src/components/CaseworkerDashboardV2/regelsimulatie/SimTweak.test.tsx
+++ b/packages/frontend/src/components/CaseworkerDashboardV2/regelsimulatie/SimTweak.test.tsx
@@ -1,42 +1,102 @@
 // @vitest-environment jsdom
 import { describe, it, expect, vi } from 'vitest';
-import { render, screen } from '@testing-library/react';
-import { fireEvent } from '@testing-library/react';
+import { render, screen, fireEvent } from '@testing-library/react';
 import SimTweak from './SimTweak';
 
+function renderTweak(overrides: Partial<Parameters<typeof SimTweak>[0]> = {}) {
+  const onChange = vi.fn();
+  render(
+    <SimTweak
+      label="Drempel"
+      value={5}
+      display="5 punten"
+      min={0}
+      max={10}
+      step={1}
+      onChange={onChange}
+      {...overrides}
+    />
+  );
+  return { onChange, slider: screen.getByRole('slider') as HTMLInputElement };
+}
+
 describe('SimTweak', () => {
-  it('renders the label and current display value', () => {
-    render(
-      <SimTweak
-        label="Omvang doelgroep"
-        value={3150}
-        display="3.150 aanvragen"
-        min={400}
-        max={5000}
-        step={100}
-        onChange={() => {}}
-      />
-    );
-    expect(screen.getByText('Omvang doelgroep')).toBeInTheDocument();
-    expect(screen.getByText('3.150 aanvragen')).toBeInTheDocument();
-    expect(screen.getByLabelText(/Omvang doelgroep/)).toBeInTheDocument();
+  it('shows the committed value and its parent-computed display text', () => {
+    const { slider } = renderTweak();
+    expect(slider.value).toBe('5');
+    expect(screen.getByText('5 punten')).toBeInTheDocument();
   });
 
-  it('calls onChange with a parsed number when the slider is released after moving', async () => {
-    const onChange = vi.fn();
-    render(
-      <SimTweak label="X" value={5} display="5" min={0} max={10} step={1} onChange={onChange} />
-    );
-    const slider = screen.getByRole('slider');
-    fireEventChange(slider, '7');
-    expect(onChange).not.toHaveBeenCalled(); // not committed yet — still dragging
+  it('moves the thumb during a drag without committing', () => {
+    // A commit per drag step would fire a full engine run() per step, and at
+    // extreme settings one run() takes seconds -- the tab freezes mid-drag.
+    const { onChange, slider } = renderTweak();
+
+    fireEvent.change(slider, { target: { value: '8' } });
+
+    expect(slider.value).toBe('8');
+    expect(onChange).not.toHaveBeenCalled();
+  });
+
+  it('commits once when the pointer is released', () => {
+    const { onChange, slider } = renderTweak();
+
+    fireEvent.change(slider, { target: { value: '8' } });
+    fireEvent.change(slider, { target: { value: '9' } });
     fireEvent.pointerUp(slider);
-    expect(onChange).toHaveBeenCalledWith(7);
+
+    expect(onChange).toHaveBeenCalledTimes(1);
+    expect(onChange).toHaveBeenCalledWith(9);
+  });
+
+  it('does not commit a release that followed no movement', () => {
+    // Clicking the thumb without dragging must not queue an engine run for a
+    // value that did not change.
+    const { onChange, slider } = renderTweak();
+
+    fireEvent.pointerUp(slider);
+
+    expect(onChange).not.toHaveBeenCalled();
+  });
+
+  it.each(['ArrowLeft', 'ArrowRight', 'ArrowUp', 'ArrowDown', 'Home', 'End', 'PageUp', 'PageDown'])(
+    'commits a completed keyboard step with %s',
+    (key) => {
+      const { onChange, slider } = renderTweak();
+
+      fireEvent.change(slider, { target: { value: '7' } });
+      fireEvent.keyUp(slider, { key });
+
+      expect(onChange).toHaveBeenCalledWith(7);
+    }
+  );
+
+  it('ignores a key that does not move the slider', () => {
+    // Tabbing away mid-drag is not a change of intent; the pointer release or
+    // an actual arrow step is.
+    const { onChange, slider } = renderTweak();
+
+    fireEvent.change(slider, { target: { value: '7' } });
+    fireEvent.keyUp(slider, { key: 'Tab' });
+
+    expect(onChange).not.toHaveBeenCalled();
+  });
+
+  it('returns to the parent value after a commit', () => {
+    const { onChange, slider } = renderTweak();
+
+    fireEvent.change(slider, { target: { value: '2' } });
+    fireEvent.pointerUp(slider);
+    expect(onChange).toHaveBeenCalledWith(2);
+
+    // The parent owns the committed value; with the same `value` prop still
+    // supplied, the local drag state must have been cleared rather than
+    // pinning the thumb at 2 forever.
+    expect(slider.value).toBe('5');
+  });
+
+  it('labels the slider so it is reachable by its name', () => {
+    renderTweak({ label: 'Maximale looptijd' });
+    expect(screen.getByLabelText(/Maximale looptijd/)).toBeInTheDocument();
   });
 });
-
-// fireEvent.change avoids userEvent's per-keystroke typing on a range input,
-// which doesn't reflect how a real drag interaction fires a single change.
-function fireEventChange(el: Element, value: string) {
-  fireEvent.change(el, { target: { value } });
-}

--- a/packages/frontend/src/components/DecisionViewer.test.tsx
+++ b/packages/frontend/src/components/DecisionViewer.test.tsx
@@ -134,3 +134,116 @@ describe('DecisionViewer', () => {
     );
   });
 });
+
+// Exercises every arm of the TipTap renderer and the block switch in one
+// document: each of the three viewers carries its own copy of this renderer,
+// so each needs its own pass over it.
+const richZone = {
+  blocks: [
+    {
+      type: 'text',
+      content: {
+        type: 'doc',
+        content: [
+          {
+            type: 'heading',
+            attrs: { level: 2 },
+            content: [{ type: 'text', text: 'Kop met niveau' }],
+          },
+          { type: 'heading', content: [{ type: 'text', text: 'Kop zonder niveau' }] },
+          {
+            type: 'paragraph',
+            content: [
+              { type: 'text', text: 'vet', marks: [{ type: 'bold' }] },
+              { type: 'text', text: 'cursief', marks: [{ type: 'italic' }] },
+              { type: 'text', text: 'onderstreept', marks: [{ type: 'underline' }] },
+              { type: 'text', text: 'alles', marks: [{ type: 'bold' }, { type: 'italic' }] },
+            ],
+          },
+          { type: 'paragraph' },
+          {
+            type: 'bulletList',
+            content: [{ type: 'listItem', content: [{ type: 'text', text: 'bullet' }] }],
+          },
+          {
+            type: 'orderedList',
+            content: [{ type: 'listItem', content: [{ type: 'text', text: 'genummerd' }] }],
+          },
+          { type: 'paragraph', content: [{ type: 'hardBreak' }] },
+          { type: 'blockquote', content: [{ type: 'text', text: 'onbekend nodetype' }] },
+          { type: 'text' },
+          {
+            type: 'paragraph',
+            content: [{ type: 'text', text: 'Beste {{naam}}, ref {{ontbreekt}}.' }],
+          },
+        ],
+      },
+    },
+    { type: 'variable', variableKey: 'naam' },
+    { type: 'variable', variableKey: 'ontbreekt' },
+    { type: 'variable' },
+    { type: 'separator' },
+    { type: 'spacer' },
+    { type: 'image', assetUrl: 'https://cdn.example/logo.png' },
+    { type: 'image' },
+    { type: 'text' },
+    { type: 'onbekend' },
+  ],
+};
+
+const richTemplate = {
+  id: 'rich',
+  name: 'Rich template',
+  zones: {
+    letterhead: { blocks: [] },
+    contactInformation: { blocks: [] },
+    reference: { blocks: [] },
+    body: richZone,
+    closing: { blocks: [] },
+    signOff: { blocks: [] },
+    annex: null,
+  },
+};
+
+describe('DecisionViewer document rendering', () => {
+  it('renders every block type, node type and text mark the composer can emit', async () => {
+    mockHistoricVariables.mockResolvedValue({ success: true, data: { naam: 'Sanne' } });
+    mockDecisionDocument.mockResolvedValue({ success: true, template: richTemplate });
+
+    const { container } = render(<DecisionViewer processInstanceId="p1" />);
+    await waitFor(() => expect(container.querySelector('h2')).not.toBeNull());
+
+    // Marks nest rather than replace one another.
+    expect(container.querySelector('strong')).toHaveTextContent('vet');
+    expect(container.querySelector('em')).toHaveTextContent('cursief');
+    expect(container.querySelector('u')).toHaveTextContent('onderstreept');
+    // Marks apply in source order, so bold wraps first and italic wraps that.
+    expect(container.querySelector('em strong')).toHaveTextContent('alles');
+
+    // Headings honour their level and default to h1 without one.
+    expect(container.querySelector('h2')).toHaveTextContent('Kop met niveau');
+    expect(container.querySelector('h1')).toHaveTextContent('Kop zonder niveau');
+
+    // Lists and their items.
+    expect(container.querySelector('ul.list-disc li')).toHaveTextContent('bullet');
+    expect(container.querySelector('ol.list-decimal li')).toHaveTextContent('genummerd');
+
+    // An empty paragraph keeps its vertical space with a <br>, and a hardBreak
+    // renders one too.
+    expect(container.querySelectorAll('br').length).toBeGreaterThanOrEqual(2);
+
+    // A node type the renderer does not know still shows its children rather
+    // than dropping the text on the floor.
+    expect(container).toHaveTextContent('onbekend nodetype');
+
+    // Placeholder substitution, including a variable the process never set.
+    expect(container).toHaveTextContent('Beste Sanne, ref .');
+
+    // Separator, spacer and image blocks.
+    expect(container.querySelector('hr')).not.toBeNull();
+    expect(container.querySelector('div.h-4')).not.toBeNull();
+    const imgs = container.querySelectorAll('img');
+    expect(imgs).toHaveLength(1);
+    expect(imgs[0]).toHaveAttribute('src', 'https://cdn.example/logo.png');
+  });
+});

--- a/packages/frontend/src/components/InfraBoardDashboard/FaseladderOverview.test.tsx
+++ b/packages/frontend/src/components/InfraBoardDashboard/FaseladderOverview.test.tsx
@@ -126,3 +126,51 @@ describe('FaseladderOverview', () => {
     expect(row?.textContent).toContain(String(mockCounts['R5.3'].geparkeerd));
   });
 });
+
+describe('FaseladderOverview before the live data arrives', () => {
+  it('renders the ladder from mock counts alone while both hooks are still empty', () => {
+    // Both hooks return { data: undefined } on the first render and after a
+    // failed fetch. The ladder is the board's landing view, so it has to draw
+    // itself from the mock baseline rather than blanking or throwing.
+    mockUseDeployedProcessKeys.mockReturnValue({
+      data: undefined,
+      loading: true,
+      error: false,
+      reload: vi.fn(),
+    });
+    mockUseLivePhaseCounts.mockReturnValue({
+      data: undefined,
+      loading: true,
+      error: false,
+      reload: vi.fn(),
+    });
+
+    render(<FaseladderOverview onOpenPhase={vi.fn()} />);
+
+    for (const stage of RIP_STAGES) {
+      expect(screen.getByText(stage.name)).toBeInTheDocument();
+    }
+    // Nothing is deployed, so no sub-process is deployable yet.
+    expect(kpiValue('Deelprocessen inzetbaar')).toBe(`0 / ${RIP_PHASES.length}`);
+  });
+
+  it('treats a phase the live feed says nothing about as zero, not blank', () => {
+    mockUseDeployedProcessKeys.mockReturnValue({
+      data: { deployedKeys: [] },
+      loading: false,
+      error: false,
+      reload: vi.fn(),
+    });
+    mockUseLivePhaseCounts.mockReturnValue({
+      data: { counts: {} },
+      loading: false,
+      error: false,
+      reload: vi.fn(),
+    });
+
+    const { container } = render(<FaseladderOverview onOpenPhase={vi.fn()} />);
+
+    expect(container.textContent).not.toContain('NaN');
+    expect(container.textContent).not.toContain('undefined');
+  });
+});

--- a/packages/frontend/src/components/PADashboardV2/PADock.test.tsx
+++ b/packages/frontend/src/components/PADashboardV2/PADock.test.tsx
@@ -1,6 +1,6 @@
 // @vitest-environment jsdom
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
-import { render, screen } from '@testing-library/react';
+import { fireEvent, render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import PADock from './PADock';
 
@@ -68,5 +68,107 @@ describe('PADock', () => {
     await user.click(screen.getByRole('button', { name: 'Sluiten' }));
 
     expect(onClose).toHaveBeenCalled();
+  });
+});
+
+describe('PADock storage and drag resize', () => {
+  it('restores a stored conversation', () => {
+    sessionStorage.setItem(
+      'paV2.assistant.messages',
+      JSON.stringify([{ role: 'user', content: 'Hallo' }])
+    );
+    expect(() => render(<PADock user={null} onClose={vi.fn()} />)).not.toThrow();
+  });
+
+  it('starts empty when the stored conversation is not valid JSON', () => {
+    // sessionStorage is shared with anything else on this origin and survives
+    // a deploy; a half-written or stale value must not take the dock down.
+    sessionStorage.setItem('paV2.assistant.messages', 'niet-json');
+    expect(() => render(<PADock user={null} onClose={vi.fn()} />)).not.toThrow();
+  });
+
+  it('falls back to the default width when the stored width is not a number', () => {
+    sessionStorage.setItem('paV2.assistant.width', 'breed');
+    const { container } = render(<PADock user={null} onClose={vi.fn()} />);
+    expect(container.querySelector('.pac-dock')).toHaveStyle({ width: '360px' });
+  });
+
+  it('survives sessionStorage being unavailable entirely', () => {
+    // Private-browsing modes and locked-down enterprise profiles throw on
+    // access rather than returning null.
+    const getItem = vi.spyOn(Storage.prototype, 'getItem').mockImplementation(() => {
+      throw new Error('blocked');
+    });
+    const setItem = vi.spyOn(Storage.prototype, 'setItem').mockImplementation(() => {
+      throw new Error('blocked');
+    });
+    try {
+      const { container } = render(<PADock user={null} onClose={vi.fn()} />);
+      expect(container.querySelector('.pac-dock')).toHaveStyle({ width: '360px' });
+    } finally {
+      getItem.mockRestore();
+      setItem.mockRestore();
+    }
+  });
+
+  it('resizes by dragging the handle, and stops on pointer release', () => {
+    const { container } = render(<PADock user={null} onClose={vi.fn()} />);
+    const handle = screen.getByRole('separator');
+
+    fireEvent.pointerDown(handle);
+    expect(handle.className).toContain('dragging');
+    // The dock is right-anchored, so its width is the distance from the
+    // pointer to the right edge of the window.
+    fireEvent.pointerMove(window, { clientX: window.innerWidth - 420 });
+    expect(container.querySelector('.pac-dock')).toHaveStyle({ width: '420px' });
+
+    fireEvent.pointerUp(window);
+    expect(handle.className).not.toContain('dragging');
+
+    // After release the handle no longer tracks the pointer.
+    fireEvent.pointerMove(window, { clientX: window.innerWidth - 500 });
+    expect(container.querySelector('.pac-dock')).toHaveStyle({ width: '420px' });
+  });
+
+  it('abandons a drag that the browser cancels', () => {
+    render(<PADock user={null} onClose={vi.fn()} />);
+    const handle = screen.getByRole('separator');
+
+    fireEvent.pointerDown(handle);
+    fireEvent.pointerCancel(window);
+
+    expect(handle.className).not.toContain('dragging');
+  });
+
+  it('clamps a drag to the minimum and maximum width', () => {
+    const { container } = render(<PADock user={null} onClose={vi.fn()} />);
+    fireEvent.pointerDown(screen.getByRole('separator'));
+
+    fireEvent.pointerMove(window, { clientX: window.innerWidth });
+    expect(container.querySelector('.pac-dock')).toHaveStyle({ width: '320px' });
+
+    fireEvent.pointerMove(window, { clientX: -5000 });
+    const max = Math.min(720, Math.round(window.innerWidth * 0.6));
+    expect(container.querySelector('.pac-dock')).toHaveStyle({ width: `${max}px` });
+  });
+
+  it('ignores a key on the handle that is not a horizontal arrow', () => {
+    const { container } = render(<PADock user={null} onClose={vi.fn()} />);
+    const before = (container.querySelector('.pac-dock') as HTMLElement).style.width;
+
+    fireEvent.keyDown(screen.getByRole('separator'), { key: 'ArrowUp' });
+
+    expect((container.querySelector('.pac-dock') as HTMLElement).style.width).toBe(before);
+  });
+
+  it('restores the document cursor when the dock unmounts mid-drag', () => {
+    const { unmount } = render(<PADock user={null} onClose={vi.fn()} />);
+    fireEvent.pointerDown(screen.getByRole('separator'));
+    expect(document.body.style.cursor).toBe('col-resize');
+
+    unmount();
+
+    expect(document.body.style.cursor).toBe('');
+    expect(document.body.style.userSelect).toBe('');
   });
 });

--- a/packages/frontend/src/components/SessionExpiryWarning.test.tsx
+++ b/packages/frontend/src/components/SessionExpiryWarning.test.tsx
@@ -1,6 +1,6 @@
 // @vitest-environment jsdom
 import { beforeEach, describe, expect, it, vi } from 'vitest';
-import { render, screen } from '@testing-library/react';
+import { fireEvent, render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import SessionExpiryWarning from './SessionExpiryWarning';
 
@@ -59,5 +59,128 @@ describe('SessionExpiryWarning', () => {
     await user.click(screen.getByRole('button', { name: 'Uitloggen' }));
 
     expect(mockKeycloak.logout).toHaveBeenCalledWith({ redirectUri: window.location.origin });
+  });
+
+  it('stays silent for an anonymous visitor', () => {
+    // The component is mounted app-wide, including on the public routes; with
+    // no session there is nothing to warn about.
+    mockKeycloak.authenticated = false;
+    setExpiryInSeconds(10);
+    render(<SessionExpiryWarning />);
+    expect(screen.queryByText(/Sessie verloopt binnenkort/)).not.toBeInTheDocument();
+  });
+
+  it('stays silent when the adapter has no parsed token yet', () => {
+    // Between init() and the first token exchange, keycloak.authenticated can
+    // already be true while tokenParsed is still undefined.
+    const saved = mockKeycloak.tokenParsed;
+    (mockKeycloak as { tokenParsed?: { exp: number } }).tokenParsed = undefined;
+    try {
+      render(<SessionExpiryWarning />);
+      expect(screen.queryByText(/Sessie verloopt binnenkort/)).not.toBeInTheDocument();
+    } finally {
+      mockKeycloak.tokenParsed = saved;
+    }
+  });
+
+  it('says the session has expired once the countdown passes zero', () => {
+    setExpiryInSeconds(-30);
+    render(<SessionExpiryWarning />);
+    expect(screen.getByText(/Uw sessie is verlopen\./)).toBeInTheDocument();
+    expect(screen.queryByText(/verloopt over/)).not.toBeInTheDocument();
+  });
+
+  it('counts down in minutes and zero-padded seconds', () => {
+    setExpiryInSeconds(65);
+    render(<SessionExpiryWarning />);
+    expect(screen.getByText(/verloopt over 1:0\d\./)).toBeInTheDocument();
+  });
+
+  it('sends the user to the login page when the forced refresh fails', async () => {
+    // The refresh token or the SSO session is gone; re-authenticating is the
+    // only thing "Sessie verlengen" can still mean.
+    const user = userEvent.setup();
+    mockKeycloak.updateToken.mockRejectedValue(new Error('refresh token expired'));
+    setExpiryInSeconds(90);
+    render(<SessionExpiryWarning />);
+
+    await user.click(screen.getByRole('button', { name: 'Sessie verlengen' }));
+
+    expect(mockKeycloak.login).toHaveBeenCalled();
+    expect(screen.getByText(/Sessie verloopt binnenkort/)).toBeInTheDocument();
+  });
+});
+
+describe('SessionExpiryWarning silent refresh on activity', () => {
+  beforeEach(() => {
+    mockKeycloak.authenticated = true;
+    mockKeycloak.updateToken.mockReset().mockResolvedValue(true);
+    mockKeycloak.login.mockReset();
+    mockKeycloak.logout.mockReset();
+  });
+
+  it('refreshes the token on real interaction, so an active user never sees the modal', () => {
+    // Filling in a long form makes no API calls, so without this the token
+    // expires under someone who is plainly still working.
+    setExpiryInSeconds(600);
+    render(<SessionExpiryWarning />);
+
+    fireEvent.keyDown(window, { key: 'a' });
+
+    expect(mockKeycloak.updateToken).toHaveBeenCalledWith(180);
+  });
+
+  it('throttles to one refresh attempt however many events fire', () => {
+    setExpiryInSeconds(600);
+    render(<SessionExpiryWarning />);
+
+    fireEvent.mouseMove(window);
+    fireEvent.mouseMove(window);
+    fireEvent.scroll(window);
+    fireEvent.pointerDown(window);
+
+    expect(mockKeycloak.updateToken).toHaveBeenCalledTimes(1);
+  });
+
+  it('ignores activity once the modal is up, so the dialog cannot be yanked away', () => {
+    // Merely moving the mouse toward "Sessie verlengen" would otherwise
+    // auto-refresh and unmount the dialog before the click lands.
+    setExpiryInSeconds(90);
+    render(<SessionExpiryWarning />);
+    expect(screen.getByText(/Sessie verloopt binnenkort/)).toBeInTheDocument();
+
+    fireEvent.mouseMove(window);
+
+    expect(mockKeycloak.updateToken).not.toHaveBeenCalled();
+  });
+
+  it('ignores activity from an anonymous visitor', () => {
+    mockKeycloak.authenticated = false;
+    render(<SessionExpiryWarning />);
+
+    fireEvent.mouseMove(window);
+
+    expect(mockKeycloak.updateToken).not.toHaveBeenCalled();
+  });
+
+  it('swallows a failed silent refresh rather than redirecting mid-typing', () => {
+    // The countdown and the modal own re-authentication; a redirect fired from
+    // a mousemove would discard whatever the user was filling in.
+    mockKeycloak.updateToken.mockRejectedValue(new Error('sso session gone'));
+    setExpiryInSeconds(600);
+    render(<SessionExpiryWarning />);
+
+    expect(() => fireEvent.mouseMove(window)).not.toThrow();
+    expect(mockKeycloak.login).not.toHaveBeenCalled();
+  });
+
+  it('unsubscribes from every activity event on unmount', () => {
+    setExpiryInSeconds(600);
+    const { unmount } = render(<SessionExpiryWarning />);
+    unmount();
+
+    fireEvent.mouseMove(window);
+
+    expect(mockKeycloak.updateToken).not.toHaveBeenCalled();
   });
 });

--- a/packages/frontend/src/components/TimeLine.test.tsx
+++ b/packages/frontend/src/components/TimeLine.test.tsx
@@ -194,4 +194,54 @@ describe('Timeline', () => {
 
     expect(onDateChange).toHaveBeenCalledWith(events[0].date);
   });
+  it('highlights the "Vandaag" button only while today is the selected date', () => {
+    const { rerender } = render(
+      <Timeline
+        events={[]}
+        minDate={minDate}
+        maxDate={new Date(2100, 0, 1)}
+        selectedDate={new Date()}
+        onDateChange={vi.fn()}
+      />
+    );
+    expect(screen.getByRole('button', { name: 'Vandaag' })).toHaveClass('text-white');
+
+    rerender(
+      <Timeline
+        events={[]}
+        minDate={minDate}
+        maxDate={new Date(2100, 0, 1)}
+        selectedDate={new Date(2005, 5, 5)}
+        onDateChange={vi.fn()}
+      />
+    );
+    expect(screen.getByRole('button', { name: 'Vandaag' })).toHaveClass('bg-gray-200');
+  });
+
+  it('highlights the jump button of the event the timeline is parked on', () => {
+    // The marker on the track and the jump button below it share the event
+    // label; the jump button is the last one in the document.
+    const jumpButton = () => screen.getAllByRole('button', { name: 'Geboren' }).at(-1)!;
+    const { rerender } = render(
+      <Timeline
+        events={events}
+        minDate={minDate}
+        maxDate={maxDate}
+        selectedDate={events[0].date}
+        onDateChange={vi.fn()}
+      />
+    );
+    expect(jumpButton()).toHaveClass('text-white');
+
+    rerender(
+      <Timeline
+        events={events}
+        minDate={minDate}
+        maxDate={maxDate}
+        selectedDate={new Date(2015, 0, 1)}
+        onDateChange={vi.fn()}
+      />
+    );
+    expect(jumpButton()).toHaveClass('bg-gray-200');
+  });
 });

--- a/packages/frontend/src/components/WooDashboard/Register.test.tsx
+++ b/packages/frontend/src/components/WooDashboard/Register.test.tsx
@@ -61,4 +61,71 @@ describe('Register', () => {
     await user.click(resetButtons[resetButtons.length - 1]);
     expect(onReset).toHaveBeenCalled();
   });
+  it('gives each status its own pill class', () => {
+    render(
+      <Register
+        rows={[
+          makeRow({ id: 'A', status: 'Gesloten' }),
+          makeRow({ id: 'B', status: 'Over termijn' }),
+          makeRow({ id: 'C', status: 'In behandeling' }),
+        ]}
+        filters={wooDefaultFilters()}
+        onReset={vi.fn()}
+      />
+    );
+
+    expect(screen.getByText('Gesloten')).toHaveClass('klaar');
+    expect(screen.getByText('Over termijn')).toHaveClass('laat');
+    expect(screen.getByText('In behandeling')).toHaveClass('open');
+  });
+
+  it('marks a request that is past the statutory term in red', () => {
+    // 42 days is the Woo term; past it the number is the point of the row.
+    const { container } = render(
+      <Register
+        rows={[makeRow({ id: 'A', dagen: 43 }), makeRow({ id: 'B', dagen: 42 })]}
+        filters={wooDefaultFilters()}
+        onReset={vi.fn()}
+      />
+    );
+
+    const nums = container.querySelectorAll('td.num');
+    expect(nums[0]).toHaveStyle({ fontWeight: '700' });
+    expect(nums[1].getAttribute('style')).toBeNull();
+  });
+
+  it('shows an objection and a deferral as set, and an em dash when not', () => {
+    const { container } = render(
+      <Register
+        rows={[
+          makeRow({ id: 'A', bezwaar: true, verdaagd: true }),
+          makeRow({ id: 'B', bezwaar: false, verdaagd: false }),
+        ]}
+        filters={wooDefaultFilters()}
+        onReset={vi.fn()}
+      />
+    );
+
+    const flags = container.querySelectorAll('.w-flagdot');
+    expect(flags[0]).toHaveTextContent('ja');
+    expect(flags[0]).toHaveClass('on');
+    expect(flags[1]).toHaveTextContent('ja');
+    expect(flags[2]).toHaveTextContent('—');
+    expect(flags[2]).not.toHaveClass('on');
+  });
+
+  it('does not treat the default year as an active filter chip', () => {
+    // 2026 is the register's own default year, not something the reader
+    // narrowed to; showing it as a chip would imply a filter is on.
+    const { container } = render(
+      <Register
+        rows={[makeRow()]}
+        filters={{ ...wooDefaultFilters(), jaar: '2026' }}
+        onReset={vi.fn()}
+      />
+    );
+
+    expect(screen.queryByText('Wis filters')).not.toBeInTheDocument();
+    expect(container.querySelector('.w-peil')).toHaveTextContent('alle regels');
+  });
 });

--- a/packages/frontend/src/hooks/useProfielData.test.ts
+++ b/packages/frontend/src/hooks/useProfielData.test.ts
@@ -63,4 +63,18 @@ describe('useProfielData', () => {
     expect(result.current.data).toBeNull();
     expect(result.current.loading).toBe(false);
   });
+  it('records an explicit null when the profile succeeds but carries no record', async () => {
+    // `undefined` means "not looked up yet" in this hook's contract, and the
+    // caller renders a placeholder for it. A successful lookup that found
+    // nothing has to collapse to null so the empty state shows instead.
+    mockProfile.mockResolvedValue({ success: true });
+
+    const { result } = renderHook(() => useProfielData('emp-1'));
+    await act(async () => {
+      await result.current.load('emp-1');
+    });
+
+    expect(result.current.data).toBeNull();
+    expect(result.current.error).toBeNull();
+  });
 });

--- a/packages/frontend/src/pages/CaseworkerDashboardV2.test.tsx
+++ b/packages/frontend/src/pages/CaseworkerDashboardV2.test.tsx
@@ -15,12 +15,13 @@ const mockKeycloak = vi.hoisted(() => ({
 const mockGetUser = vi.hoisted(() => vi.fn());
 vi.mock('../services/keycloak', () => ({ default: mockKeycloak, getUser: mockGetUser }));
 
-vi.mock('../services/tenant', () => ({
+const mockTenant = vi.hoisted(() => ({
   initializeTenantTheme: vi.fn().mockResolvedValue(true),
   loadTenantConfigs: vi.fn().mockResolvedValue({}),
   getTenantConfig: vi.fn().mockReturnValue(null),
   getDefaultTenantConfig: vi.fn().mockReturnValue(null),
 }));
+vi.mock('../services/tenant', () => mockTenant);
 
 vi.mock('../components/CaseworkerDashboardV2/SectionRouter', () => ({
   default: function MockSectionRouter({
@@ -127,5 +128,105 @@ describe('CaseworkerDashboardV2', () => {
     expect(screen.queryByTestId('palette')).not.toBeInTheDocument();
     await user.click(screen.getByRole('button', { name: 'Snel navigeren' }));
     expect(screen.getByTestId('palette')).toBeInTheDocument();
+  });
+});
+
+describe('CaseworkerDashboardV2 identity chrome', () => {
+  beforeEach(() => {
+    mockKeycloak.authenticated = true;
+    mockTenant.initializeTenantTheme.mockClear().mockResolvedValue(true);
+    mockTenant.loadTenantConfigs.mockClear().mockResolvedValue({});
+    mockTenant.getTenantConfig.mockClear().mockReturnValue(null);
+    mockTenant.getDefaultTenantConfig.mockClear().mockReturnValue(null);
+  });
+
+  afterEach(() => vi.clearAllMocks());
+
+  it('shows the assurance level when the token carries one', () => {
+    mockGetUser.mockReturnValue({ sub: '1', name: 'Test User', roles: [], loa: 'hoog' });
+    render(<CaseworkerDashboardV2 />);
+    expect(screen.getByText('LOA hoog')).toBeInTheDocument();
+  });
+
+  it('falls back from name to preferred_username, then to a generic label', () => {
+    mockGetUser.mockReturnValue({ sub: '1', preferred_username: 'w.demeer', roles: [] });
+    const { unmount } = render(<CaseworkerDashboardV2 />);
+    expect(screen.getByText('w.demeer')).toBeInTheDocument();
+    unmount();
+
+    mockGetUser.mockReturnValue({ sub: '1', roles: [] });
+    render(<CaseworkerDashboardV2 />);
+    expect(screen.getByText('Medewerker')).toBeInTheDocument();
+  });
+
+  it('themes for the signed-in municipality and labels the tenant', async () => {
+    mockGetUser.mockReturnValue({
+      sub: '1',
+      name: 'Test User',
+      roles: [],
+      municipality: 'flevoland',
+    });
+    mockTenant.getTenantConfig.mockReturnValue({ displayName: 'Provincie Flevoland' });
+
+    render(<CaseworkerDashboardV2 />);
+
+    expect(await screen.findByText('Provincie Flevoland')).toBeInTheDocument();
+    expect(mockTenant.initializeTenantTheme).toHaveBeenCalledWith('flevoland');
+    expect(mockTenant.getDefaultTenantConfig).not.toHaveBeenCalled();
+  });
+
+  it('falls back to the default tenant for a token with no municipality claim', async () => {
+    mockGetUser.mockReturnValue({ sub: '1', name: 'Test User', roles: [] });
+    mockTenant.getDefaultTenantConfig.mockReturnValue({ displayName: 'RONL' });
+
+    render(<CaseworkerDashboardV2 />);
+
+    expect(await screen.findByText('RONL')).toBeInTheDocument();
+    expect(mockTenant.initializeTenantTheme).not.toHaveBeenCalled();
+  });
+
+  it('routes an anonymous logout attempt back to the dashboard instead of calling Keycloak', async () => {
+    // The avatar control is rendered before the adapter is initialised on a
+    // cold load; keycloak.logout() would throw there.
+    mockKeycloak.authenticated = false;
+    mockGetUser.mockReturnValue(null);
+    render(<CaseworkerDashboardV2 />);
+
+    // Nothing to log out of, so no Keycloak call is made at all.
+    expect(mockKeycloak.logout).not.toHaveBeenCalled();
+  });
+});
+
+describe('CaseworkerDashboardV2 shell controls', () => {
+  beforeEach(() => {
+    mockKeycloak.authenticated = true;
+    mockGetUser.mockReturnValue({ sub: '1', name: 'Test User', roles: [] });
+  });
+
+  afterEach(() => vi.clearAllMocks());
+
+  it('opens and closes the command palette with the keyboard shortcut', async () => {
+    const user = userEvent.setup();
+    render(<CaseworkerDashboardV2 />);
+
+    expect(screen.queryByTestId('palette')).toBeNull();
+    await user.keyboard('{Control>}k{/Control}');
+    expect(screen.getByTestId('palette')).toBeInTheDocument();
+    await user.keyboard('{Meta>}k{/Meta}');
+    expect(screen.queryByTestId('palette')).toBeNull();
+  });
+
+  it('opens the assistant dock and remembers that across a remount', async () => {
+    const user = userEvent.setup();
+    const { unmount } = render(<CaseworkerDashboardV2 />);
+
+    await user.click(screen.getByRole('button', { name: /assistent/i }));
+    expect(screen.getByTestId('dock')).toBeInTheDocument();
+    unmount();
+
+    // The open state is persisted to sessionStorage, so a route change and
+    // back must not close a dock the user deliberately opened.
+    render(<CaseworkerDashboardV2 />);
+    expect(screen.getByTestId('dock')).toBeInTheDocument();
   });
 });

--- a/packages/frontend/src/pages/ChangelogPanel.variants.test.tsx
+++ b/packages/frontend/src/pages/ChangelogPanel.variants.test.tsx
@@ -1,0 +1,215 @@
+// @vitest-environment jsdom
+/**
+ * Display variants of the changelog panel, driven by a synthetic changelog.
+ *
+ * Separate from ChangelogPanel.test.tsx on purpose: that file asserts against
+ * the project's real release history (60+ entries), which is exactly what
+ * makes it unable to reach the shapes the history happens not to contain
+ * right now — an "Upcoming" release, a commit type with no icon mapping, a
+ * legacy section with an unknown icon colour, an empty version list. Mocking
+ * changelog-data there would take the real-history assertions with it, so the
+ * fixtures live here instead.
+ */
+import { describe, expect, it, vi } from 'vitest';
+import { render, screen, within } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+
+const mockChangelog = vi.hoisted(() => ({
+  changelog: { versions: [] as unknown[] },
+}));
+vi.mock('./changelog-data', async (importActual) => ({
+  ...(await importActual<typeof import('./changelog-data')>()),
+  get changelog() {
+    return mockChangelog.changelog;
+  },
+}));
+
+import ChangelogPanel from './ChangelogPanel';
+
+const feedback = [
+  { type: 'feedback' as const, iid: 12, title: 'Trage takenlijst', url: 'https://git/12' },
+  { type: 'usecase' as const, iid: 34, title: 'Vergunning aanvragen', url: 'https://git/34' },
+];
+
+function setVersions(versions: unknown[]) {
+  mockChangelog.changelog = { versions };
+}
+
+describe('ChangelogPanel with an empty changelog', () => {
+  it('opens without expanding anything, rather than throwing on a missing first entry', () => {
+    setVersions([]);
+    render(<ChangelogPanel isOpen onClose={vi.fn()} />);
+    expect(screen.getByRole('dialog')).toBeInTheDocument();
+  });
+});
+
+describe('ChangelogPanel per-commit entries', () => {
+  it('marks only the first release as Latest and renders each status in its own colour', async () => {
+    setVersions([
+      {
+        format: 'commits',
+        version: '9.9.9',
+        status: 'Released',
+        date: '1 sep 2026',
+        scope: ['backend'],
+        commits: [{ sha: 'aaa1111', author: 'Steven Gort', type: 'feat', subject: 'Nieuw ding' }],
+      },
+      {
+        format: 'commits',
+        version: '9.9.8',
+        status: 'Upcoming',
+        date: '2 sep 2026',
+        scope: ['frontend'],
+        commits: [{ sha: 'bbb2222', author: 'Steven Gort', type: 'fix', subject: 'Reparatie' }],
+      },
+      {
+        format: 'commits',
+        version: '9.9.7',
+        status: 'Ingetrokken',
+        date: '3 sep 2026',
+        scope: ['ci'],
+        commits: [{ sha: 'ccc3333', author: 'Steven Gort', type: 'chore', subject: 'Opruimen' }],
+      },
+    ]);
+
+    render(<ChangelogPanel isOpen onClose={vi.fn()} />);
+
+    expect(screen.getAllByText('Latest')).toHaveLength(1);
+    expect(screen.getByText('Released')).toBeInTheDocument();
+    expect(screen.getByText('Upcoming')).toBeInTheDocument();
+    expect(screen.getByText('Ingetrokken')).toBeInTheDocument();
+
+    // Only the newest release starts open.
+    expect(screen.getByText('Nieuw ding')).toBeInTheDocument();
+    expect(screen.queryByText('Reparatie')).not.toBeInTheDocument();
+
+    const user = userEvent.setup();
+    await user.click(screen.getByRole('button', { name: /v9\.9\.8/ }));
+    expect(screen.getByText('Reparatie')).toBeInTheDocument();
+  });
+
+  it('gives a commit type it has no icon for the neutral fallback rather than nothing', () => {
+    setVersions([
+      {
+        format: 'commits',
+        version: '9.9.9',
+        status: 'Released',
+        date: '1 sep 2026',
+        scope: ['backend'],
+        commits: [
+          {
+            sha: 'ddd4444',
+            author: 'Steven Gort',
+            type: 'wip',
+            subject: 'Onbekend committype',
+            details: ['Waarom dit nodig was.'],
+          },
+        ],
+      },
+    ]);
+
+    render(<ChangelogPanel isOpen onClose={vi.fn()} />);
+
+    expect(screen.getByText('Onbekend committype')).toBeInTheDocument();
+    expect(screen.getByText('Waarom dit nodig was.')).toBeInTheDocument();
+  });
+
+  it('lists resolved work items as chip links, labelled by kind', () => {
+    setVersions([
+      {
+        format: 'commits',
+        version: '9.9.9',
+        status: 'Released',
+        date: '1 sep 2026',
+        scope: ['backend'],
+        commits: [{ sha: 'eee5555', author: 'Steven Gort', type: 'feat', subject: 'Iets' }],
+        feedback,
+      },
+    ]);
+
+    render(<ChangelogPanel isOpen onClose={vi.fn()} />);
+
+    expect(screen.getByText('Feedback / use case handled')).toBeInTheDocument();
+    // The chip carries the kind and the work-item number together.
+    expect(screen.getByText('Feedback #12')).toBeInTheDocument();
+    expect(screen.getByText('Use Case #34')).toBeInTheDocument();
+    expect(screen.getByRole('link', { name: /Trage takenlijst/ })).toHaveAttribute(
+      'href',
+      'https://git/12'
+    );
+    expect(screen.getByRole('link', { name: /Vergunning aanvragen/ })).toHaveAttribute(
+      'href',
+      'https://git/34'
+    );
+  });
+
+  it('omits the work-item block entirely when a release resolved none', () => {
+    setVersions([
+      {
+        format: 'commits',
+        version: '9.9.9',
+        status: 'Released',
+        date: '1 sep 2026',
+        scope: ['backend'],
+        commits: [{ sha: 'fff6666', author: 'Steven Gort', type: 'feat', subject: 'Iets' }],
+        feedback: [],
+      },
+    ]);
+
+    render(<ChangelogPanel isOpen onClose={vi.fn()} />);
+
+    expect(screen.queryByText('Feedback / use case handled')).not.toBeInTheDocument();
+    expect(screen.queryByText(/Use Case #/)).not.toBeInTheDocument();
+  });
+});
+
+describe('ChangelogPanel legacy section entries', () => {
+  it('renders a section with an icon colour it does not recognise', () => {
+    // iconColor comes from hand-written history entries; an unknown value must
+    // fall back to the default rather than dropping the class entirely.
+    setVersions([
+      {
+        version: '9.9.9',
+        status: 'Released',
+        statusColor: 'green',
+        borderColor: 'green',
+        date: '1 sep 2026',
+        sections: [
+          {
+            icon: '🎨',
+            iconColor: 'teal',
+            title: 'Onbekende kleur',
+            items: ['Een gewone regel', feedback[0]],
+          },
+        ],
+      },
+    ]);
+
+    render(<ChangelogPanel isOpen onClose={vi.fn()} />);
+
+    const heading = screen.getByText('Onbekende kleur');
+    expect(heading).toBeInTheDocument();
+    expect(screen.getByText('Een gewone regel')).toBeInTheDocument();
+    // A work item inside a legacy section renders as the same chip link the
+    // per-commit format uses.
+    expect(screen.getByRole('link', { name: /Trage takenlijst/ })).toBeInTheDocument();
+  });
+
+  it('renders a legacy entry with no scope badge at all', () => {
+    setVersions([
+      {
+        version: '9.9.9',
+        status: 'Released',
+        statusColor: 'green',
+        borderColor: 'green',
+        date: '1 sep 2026',
+        sections: [{ icon: '✨', iconColor: 'blue', title: 'Nieuw', items: ['Iets'] }],
+      },
+    ]);
+
+    render(<ChangelogPanel isOpen onClose={vi.fn()} />);
+
+    const header = screen.getByRole('button', { name: /v9\.9\.9/ });
+    expect(within(header).queryByText(/Full-stack|Frontend|Backend/)).not.toBeInTheDocument();
+  });
+});

--- a/packages/frontend/src/pages/Dashboard.test.tsx
+++ b/packages/frontend/src/pages/Dashboard.test.tsx
@@ -23,20 +23,40 @@ vi.mock('../services/api', () => ({
   },
 }));
 
-vi.mock('../services/tenant', () => ({
+const TENANT_UTRECHT = {
+  displayName: 'Gemeente Utrecht',
+  features: {
+    zorgtoeslag: true,
+    vergunningen: true,
+    subsidies: true,
+    meldingen: false,
+    dvtp: false,
+  },
+};
+const mockTenant = vi.hoisted(() => ({
   initializeTenantTheme: vi.fn().mockResolvedValue(true),
   loadTenantConfigs: vi.fn().mockResolvedValue({}),
-  getTenantConfig: vi.fn().mockReturnValue({
-    displayName: 'Gemeente Utrecht',
-    features: {
-      zorgtoeslag: true,
-      vergunningen: true,
-      subsidies: true,
-      meldingen: false,
-      dvtp: false,
-    },
-  }),
+  getTenantConfig: vi.fn(),
   getDefaultTenantConfig: vi.fn().mockReturnValue(null),
+}));
+vi.mock('../services/tenant', () => mockTenant);
+
+const mockBrp = vi.hoisted(() => ({
+  getPersonTimeline: vi.fn(),
+  calculateHistoricalState: vi.fn(() => ({})),
+}));
+vi.mock('../services/brp.timeline', () => mockBrp);
+
+const mockBsn = vi.hoisted(() => ({ getUserBSN: vi.fn() }));
+vi.mock('../services/bsn.mapping', () => mockBsn);
+
+vi.mock('../components/TimeLine', () => ({
+  Timeline: ({ isLoading }: { isLoading?: boolean }) => (
+    <div data-testid="timeline">{isLoading ? 'timeline-loading' : 'timeline-ready'}</div>
+  ),
+}));
+vi.mock('../components/PersonalDataPanel', () => ({
+  PersonalDataPanel: () => <div data-testid="personal-data" />,
 }));
 
 vi.mock('../components/ProcessStartFormViewer', () => ({
@@ -73,6 +93,19 @@ beforeEach(() => {
   });
   mockEvaluateDecision.mockResolvedValue({ success: true, data: [] });
   mockProcessHistory.mockResolvedValue({ success: true, data: [] });
+  mockTenant.getTenantConfig.mockReturnValue(TENANT_UTRECHT);
+  mockTenant.getDefaultTenantConfig.mockReturnValue(null);
+  mockBsn.getUserBSN.mockReturnValue('999993653');
+  mockBrp.getPersonTimeline.mockResolvedValue({
+    currentState: { naam: 'Test' },
+    events: [],
+    earliestDate: new Date(2000, 0, 1),
+    latestDate: new Date(2026, 0, 1),
+  });
+  // Dashboard fetches /timeline-config.json for the panel beside the timeline.
+  global.fetch = vi.fn().mockResolvedValue({
+    json: async () => ({ fields: [] }),
+  }) as unknown as typeof fetch;
 });
 
 afterEach(() => {
@@ -175,5 +208,260 @@ describe('Dashboard', () => {
     await user.click(screen.getByRole('button', { name: 'Uitloggen' }));
 
     expect(mockKeycloak.logout).toHaveBeenCalledWith({ redirectUri: window.location.origin });
+  });
+});
+
+describe('Dashboard header and tabs', () => {
+  it('falls back to the municipality claim when no tenant config resolved', () => {
+    mockTenant.getTenantConfig.mockReturnValue(null);
+    render(<Dashboard />);
+    expect(screen.getByText('Gemeente utrecht')).toBeInTheDocument();
+  });
+
+  it('shows the assurance level and every realm role the token carries', () => {
+    mockGetUser.mockReturnValue({
+      sub: 'user-1',
+      preferred_username: 'test-citizen-utrecht',
+      municipality: 'utrecht',
+      loa: 'substantieel',
+      roles: ['citizen', 'beta-tester'],
+    });
+
+    render(<Dashboard />);
+
+    expect(screen.getByText('LoA: substantieel')).toBeInTheDocument();
+    expect(screen.getByText('citizen')).toBeInTheDocument();
+    expect(screen.getByText('beta-tester')).toBeInTheDocument();
+  });
+
+  it('falls back to a generic label for a token with no username, loa or roles', () => {
+    mockGetUser.mockReturnValue({ sub: 'user-1', municipality: 'utrecht' });
+
+    render(<Dashboard />);
+
+    expect(screen.getByText('Ingelogd')).toBeInTheDocument();
+    expect(screen.queryByText(/LoA:/)).not.toBeInTheDocument();
+  });
+
+  it('does not offer the consent tab to a tenant without dvtp', async () => {
+    render(<Dashboard />);
+    await screen.findByText('Gemeente Utrecht');
+    expect(screen.queryByRole('button', { name: 'Mijn toestemming' })).toBeNull();
+  });
+
+  it('adds the consent tab for a tenant with dvtp enabled', async () => {
+    mockTenant.getTenantConfig.mockReturnValue({
+      ...TENANT_UTRECHT,
+      features: { ...TENANT_UTRECHT.features, dvtp: true },
+    });
+    const user = userEvent.setup();
+    render(<Dashboard />);
+
+    const tab = await screen.findByRole('button', { name: 'Mijn toestemming' });
+    await user.click(tab);
+    expect(tab).toBeInTheDocument();
+  });
+});
+
+describe('Dashboard service forms', () => {
+  it('reports a permit submission that the engine refused', async () => {
+    const user = userEvent.setup();
+    render(<Dashboard />);
+
+    await user.click(await screen.findByText('Vergunningen'));
+    await user.click(screen.getByRole('button', { name: 'simulate-error' }));
+
+    expect(
+      screen.getByText('De aanvraag kon niet worden ingediend. Probeer het opnieuw.')
+    ).toBeInTheDocument();
+  });
+
+  it('starts the subsidy process under its own process key, and reports its failures', async () => {
+    const user = userEvent.setup();
+    render(<Dashboard />);
+
+    await user.click(await screen.findByText('Subsidies'));
+    expect(screen.getByTestId('process-start-form')).toHaveTextContent(
+      'processKey=ThuisbatterijSubsidieAanvraagProcess'
+    );
+
+    await user.click(screen.getByRole('button', { name: 'simulate-error' }));
+    expect(
+      screen.getByText('De aanvraag kon niet worden ingediend. Probeer het opnieuw.')
+    ).toBeInTheDocument();
+  });
+
+  it('confirms a successful subsidy submission with its dossier number', async () => {
+    const user = userEvent.setup();
+    render(<Dashboard />);
+
+    await user.click(await screen.findByText('Subsidies'));
+    await user.click(screen.getByRole('button', { name: 'simulate-success' }));
+
+    expect(screen.getByText(/D-123/)).toBeInTheDocument();
+  });
+});
+
+describe('Dashboard zorgtoeslag calculator', () => {
+  const openCalculator = async () => {
+    const user = userEvent.setup();
+    render(<Dashboard />);
+    await user.click(await screen.findByText('Zorgtoeslag'));
+    return user;
+  };
+
+  it('states plainly that there is no entitlement when the rule says so', async () => {
+    mockEvaluateDecision.mockResolvedValue({
+      success: true,
+      data: [{ eligible: { value: false }, amountYear: { value: 0 } }],
+    });
+    const user = await openCalculator();
+
+    await user.click(screen.getByRole('button', { name: /Bereken/ }));
+
+    expect(await screen.findByText(/Geen recht op zorgtoeslag/)).toBeInTheDocument();
+  });
+
+  it('treats a decision row with neither field as no entitlement', async () => {
+    // A rule table can return a row that matched nothing; defaulting to
+    // "eligible" there would tell a citizen they get money they will not get.
+    mockEvaluateDecision.mockResolvedValue({ success: true, data: [{}] });
+    const user = await openCalculator();
+
+    await user.click(screen.getByRole('button', { name: /Bereken/ }));
+
+    expect(await screen.findByText(/Geen recht op zorgtoeslag/)).toBeInTheDocument();
+  });
+
+  it('reports a refused evaluation as a notice rather than as a decision', async () => {
+    mockEvaluateDecision.mockResolvedValue({
+      success: false,
+      data: null,
+      error: { code: 'X', message: 'boom' },
+    });
+    const user = await openCalculator();
+
+    await user.click(screen.getByRole('button', { name: /Bereken/ }));
+
+    expect(await screen.findByText(/kon niet worden afgerond/)).toBeInTheDocument();
+  });
+
+  it('reports a request that never reached the engine the same way', async () => {
+    mockEvaluateDecision.mockRejectedValue(new Error('network down'));
+    const user = await openCalculator();
+
+    await user.click(screen.getByRole('button', { name: /Bereken/ }));
+
+    expect(await screen.findByText(/kon niet worden afgerond/)).toBeInTheDocument();
+  });
+
+  it('sends a date of death only when one was entered', async () => {
+    const user = await openCalculator();
+
+    await user.click(screen.getByRole('button', { name: /Bereken/ }));
+    await waitFor(() => expect(mockEvaluateDecision).toHaveBeenCalled());
+    expect(mockEvaluateDecision.mock.calls[0][1]).not.toHaveProperty('overlijdensdatum');
+  });
+});
+
+describe('Dashboard timeline tab', () => {
+  it('loads the person timeline for a citizen with a mapped BSN', async () => {
+    const user = userEvent.setup();
+    render(<Dashboard />);
+
+    await user.click(await screen.findByRole('button', { name: 'Tijdlijn' }));
+
+    await waitFor(() => expect(mockBrp.getPersonTimeline).toHaveBeenCalledWith('999993653'));
+    expect(await screen.findByTestId('timeline')).toBeInTheDocument();
+  });
+
+  it('does not call the BRP at all for a citizen with no mapped BSN', async () => {
+    mockBsn.getUserBSN.mockReturnValue(undefined);
+    const user = userEvent.setup();
+    render(<Dashboard />);
+
+    await user.click(await screen.findByRole('button', { name: 'Tijdlijn' }));
+
+    expect(mockBrp.getPersonTimeline).not.toHaveBeenCalled();
+  });
+
+  it('stops loading when the BRP call fails, rather than spinning forever', async () => {
+    mockBrp.getPersonTimeline.mockRejectedValue(new Error('brp down'));
+    const user = userEvent.setup();
+    render(<Dashboard />);
+
+    await user.click(await screen.findByRole('button', { name: 'Tijdlijn' }));
+
+    await waitFor(() => expect(mockBrp.getPersonTimeline).toHaveBeenCalled());
+    expect(screen.queryByText('timeline-loading')).not.toBeInTheDocument();
+  });
+});
+
+describe('Dashboard applications tab', () => {
+  it('lists the applications the process history returned', async () => {
+    mockProcessHistory.mockResolvedValue({
+      success: true,
+      data: [
+        {
+          id: 'pi-1',
+          processDefinitionKey: 'AwbShellProcess',
+          startTime: '2026-07-01T00:00:00Z',
+          endTime: null,
+          state: 'ACTIVE',
+          businessKey: 'D-123',
+        },
+      ],
+    });
+    const user = userEvent.setup();
+    render(<Dashboard />);
+
+    await user.click(await screen.findByRole('button', { name: 'Mijn aanvragen' }));
+
+    expect(await screen.findByText(/D-123/)).toBeInTheDocument();
+  });
+});
+
+describe('Dashboard zorgtoeslag application', () => {
+  const openApplication = async () => {
+    const user = userEvent.setup();
+    render(<Dashboard />);
+    await user.click(await screen.findByText('Zorgtoeslag'));
+    await user.click(screen.getByRole('button', { name: 'Aanvragen' }));
+    return user;
+  };
+
+  it('starts the Awb process for a zorgtoeslag application', async () => {
+    await openApplication();
+
+    expect(screen.getByTestId('process-start-form')).toHaveTextContent(
+      'processKey=AwbZorgtoeslagProcess'
+    );
+    expect(screen.getByText('Zorgtoeslag aanvragen')).toBeInTheDocument();
+  });
+
+  it('confirms a submitted application with its dossier number', async () => {
+    const user = await openApplication();
+
+    await user.click(screen.getByRole('button', { name: 'simulate-success' }));
+
+    expect(screen.getByText('Aanvraag ingediend')).toBeInTheDocument();
+    expect(screen.getByText('D-123')).toBeInTheDocument();
+  });
+
+  it('reports a refused application and clears the notice on the way back', async () => {
+    const user = await openApplication();
+
+    await user.click(screen.getByRole('button', { name: 'simulate-error' }));
+    expect(
+      screen.getByText('De aanvraag kon niet worden ingediend. Probeer het opnieuw.')
+    ).toBeInTheDocument();
+
+    // Going back to the calculator and forward again must not carry the old
+    // failure notice with it.
+    await user.click(screen.getByRole('button', { name: /Terug naar berekening/ }));
+    await user.click(screen.getByRole('button', { name: 'Aanvragen' }));
+    expect(
+      screen.queryByText('De aanvraag kon niet worden ingediend. Probeer het opnieuw.')
+    ).not.toBeInTheDocument();
   });
 });

--- a/packages/frontend/src/pages/PaCockpitRoute.test.tsx
+++ b/packages/frontend/src/pages/PaCockpitRoute.test.tsx
@@ -99,4 +99,17 @@ describe('PaCockpitRoute', () => {
       redirectUri: window.location.origin + '/',
     });
   });
+  it('does not call Keycloak logout when there is no session to end', () => {
+    // The cockpit renders its avatar control whether or not a session is live
+    // (an anonymous visitor sees the login prompt beside it), so onLogout can
+    // be invoked with nothing to log out of. keycloak.logout() on an
+    // uninitialised adapter throws.
+    keycloakMock.exports.default.authenticated = false;
+    try {
+      hostArg().onLogout();
+      expect(keycloakMock.logout).not.toHaveBeenCalled();
+    } finally {
+      keycloakMock.exports.default.authenticated = true;
+    }
+  });
 });

--- a/packages/frontend/src/utils/formatDate.test.ts
+++ b/packages/frontend/src/utils/formatDate.test.ts
@@ -1,0 +1,19 @@
+import { describe, it, expect } from 'vitest';
+import { formatDate } from './formatDate';
+
+describe('formatDate', () => {
+  it('renders an ISO timestamp as a long Dutch date', () => {
+    expect(formatDate('2026-07-08T13:45:00.000Z')).toBe('8 juli 2026');
+  });
+
+  it('accepts a date-only string', () => {
+    expect(formatDate('2026-01-31')).toBe('31 januari 2026');
+  });
+
+  it('returns an empty string for a missing date rather than "Invalid Date"', () => {
+    // Every caller interpolates the result straight into a sentence
+    // ("t/m {…}", "Afgerond op {…}"), so an absent date has to disappear
+    // instead of printing the string "Invalid Date" next to a label.
+    expect(formatDate('')).toBe('');
+  });
+});

--- a/packages/pa-cockpit/src/components/PADashboardV2/PACommandPalette.test.tsx
+++ b/packages/pa-cockpit/src/components/PADashboardV2/PACommandPalette.test.tsx
@@ -108,4 +108,54 @@ describe('PACommandPalette', () => {
     await user.click(container.querySelector('.pac-palette-overlay')!);
     expect(onClose).toHaveBeenCalled();
   });
+  it('walks the list with the arrow keys and opens the highlighted hit with Enter', async () => {
+    // The palette is a keyboard surface first -- a user who reached it with
+    // Cmd+K should never have to move to the mouse to pick a result.
+    const onSelect = vi.fn();
+    const user = userEvent.setup();
+    renderPalette(<PACommandPalette open onClose={vi.fn()} onSelect={onSelect} />);
+
+    await user.keyboard('{ArrowDown}{ArrowDown}{ArrowUp}');
+    await user.keyboard('{Enter}');
+
+    expect(onSelect).toHaveBeenCalledTimes(1);
+    const second = allStaticSections()[1];
+    expect(onSelect).toHaveBeenCalledWith(findPaModeForSection(second.id), second.id);
+  });
+
+  it('does not clamp the highlight past the end of the list', async () => {
+    const onSelect = vi.fn();
+    const user = userEvent.setup();
+    renderPalette(<PACommandPalette open onClose={vi.fn()} onSelect={onSelect} />);
+
+    // Far more presses than there are hits: the highlight must stop at the last
+    // one rather than running off into an undefined entry.
+    await user.keyboard('{ArrowDown>200/}');
+    await user.keyboard('{Enter}');
+
+    expect(onSelect).toHaveBeenCalledTimes(1);
+  });
+
+  it('does not clamp the highlight before the start of the list', async () => {
+    const onSelect = vi.fn();
+    const user = userEvent.setup();
+    renderPalette(<PACommandPalette open onClose={vi.fn()} onSelect={onSelect} />);
+
+    await user.keyboard('{ArrowUp>5/}');
+    await user.keyboard('{Enter}');
+
+    const first = allStaticSections()[0];
+    expect(onSelect).toHaveBeenCalledWith(findPaModeForSection(first.id), first.id);
+  });
+
+  it('Enter does nothing when the query matches no hit', async () => {
+    const onSelect = vi.fn();
+    const user = userEvent.setup();
+    renderPalette(<PACommandPalette open onClose={vi.fn()} onSelect={onSelect} />);
+
+    await user.type(screen.getByRole('textbox'), 'zzzzzzzz');
+    await user.keyboard('{Enter}');
+
+    expect(onSelect).not.toHaveBeenCalled();
+  });
 });

--- a/packages/pa-cockpit/src/components/PADashboardV2/ZoekcriteriaSection.test.tsx
+++ b/packages/pa-cockpit/src/components/PADashboardV2/ZoekcriteriaSection.test.tsx
@@ -170,3 +170,169 @@ describe('ZoekcriteriaSection', () => {
     expect(screen.queryByText('Hoe scoort de cron een document?')).not.toBeInTheDocument();
   });
 });
+
+describe('ZoekcriteriaSection best-case verdicts', () => {
+  // Each card carries a prediction of what the cron will do with the criterion.
+  // The prediction is the whole point of the screen -- a curator writes a
+  // criterion here and gets told, before saving, whether it will ever match.
+  const verdictFor = async (over: Partial<SavedSearch>) => {
+    mockFetchSearches.mockResolvedValue([makeSearch(over)]);
+    const view = render(<ZoekcriteriaSection />);
+    await screen.findByText('Jeugdzorg');
+    return view;
+  };
+
+  it('calls a TK criterion with terms a strong hit', async () => {
+    await verdictFor({ query: { q: 'stikstof', source: ['tk'] } } as Partial<SavedSearch>);
+    expect(screen.getByText('Wordt opgepikt')).toBeInTheDocument();
+    expect(screen.getByText(/sterke treffer/)).toBeInTheDocument();
+  });
+
+  it('calls an EU criterion with terms a strong hit too', async () => {
+    await verdictFor({ query: { q: 'stikstof', source: ['eu'] } } as Partial<SavedSearch>);
+    expect(screen.getByText('Wordt opgepikt')).toBeInTheDocument();
+  });
+
+  it('reaches the threshold for an OB criterion with terms, with no type bump', async () => {
+    // 'ob' gets no zwaartype bump in the engine, so it clears the threshold on
+    // the term matches alone -- a different route to the same verdict.
+    await verdictFor({ query: { q: 'stikstof', source: ['ob'] } } as Partial<SavedSearch>);
+    expect(screen.getByText('Wordt opgepikt')).toBeInTheDocument();
+  });
+
+  it('makes a media criterion conditional on a regional mention', async () => {
+    await verdictFor({ query: { q: 'stikstof', source: ['media'] } } as Partial<SavedSearch>);
+    expect(screen.getByText('Alleen bij regio-match')).toBeInTheDocument();
+    expect(screen.getByText(/zonder Flevoland-context/)).toBeInTheDocument();
+  });
+
+  it('warns that a criterion with no search term will never be picked up', async () => {
+    await verdictFor({ query: { q: '', source: ['tk'] } } as Partial<SavedSearch>);
+    expect(screen.getByText('Wordt niet opgepikt')).toBeInTheDocument();
+    expect(screen.getByText(/geen rake term/)).toBeInTheDocument();
+  });
+
+  it('splits an OR query into separate terms and caps the match bonus', async () => {
+    await verdictFor({
+      query: { q: 'stikstof OR ammoniak OR natuur OR piekbelaster', source: ['tk'] },
+    } as Partial<SavedSearch>);
+    for (const term of ['stikstof', 'ammoniak', 'natuur', 'piekbelaster']) {
+      expect(screen.getByText(term)).toBeInTheDocument();
+    }
+    expect(screen.getByText('Wordt opgepikt')).toBeInTheDocument();
+  });
+
+  it('survives a dossier-watch row that stores no query at all', async () => {
+    // The WatchBell writes a row with an empty query and no source list. It
+    // still has to render here rather than throwing on .includes(undefined).
+    mockFetchSearches.mockResolvedValue([
+      { id: 'w1', dossierId: 'jeugdzorg', scope: 'tenant', tags: [], notify: true, query: {} },
+    ] as unknown as SavedSearch[]);
+
+    render(<ZoekcriteriaSection />);
+
+    expect(await screen.findByText('Jeugdzorg')).toBeInTheDocument();
+    expect(screen.getByText('Wordt niet opgepikt')).toBeInTheDocument();
+  });
+});
+
+describe('ZoekcriteriaSection scoring modal', () => {
+  it('walks all three worked examples and closes on Escape', async () => {
+    const user = userEvent.setup();
+    render(<ZoekcriteriaSection />);
+    await screen.findByText('Jeugdzorg');
+
+    await user.click(screen.getAllByLabelText('Toelichting scoringsmodel')[0]);
+    const dialog = screen.getByRole('dialog');
+    expect(dialog).toBeInTheDocument();
+
+    await user.click(screen.getByRole('tab', { name: 'Media-treffer' }));
+    expect(screen.getByRole('tab', { name: 'Media-treffer' })).toHaveAttribute(
+      'aria-selected',
+      'true'
+    );
+    await user.click(screen.getByRole('tab', { name: 'Geen treffer' }));
+    expect(screen.getByRole('tab', { name: 'Geen treffer' })).toHaveAttribute(
+      'aria-selected',
+      'true'
+    );
+
+    // Clicking inside the box must not close it -- the overlay handler is the
+    // only one that should.
+    await user.click(screen.getByRole('tab', { name: 'Sterke treffer' }));
+    expect(screen.getByRole('dialog')).toBeInTheDocument();
+
+    await user.keyboard('{Escape}');
+    await waitFor(() => expect(screen.queryByRole('dialog')).toBeNull());
+  });
+
+  it('closes on the close button', async () => {
+    const user = userEvent.setup();
+    render(<ZoekcriteriaSection />);
+    await screen.findByText('Jeugdzorg');
+
+    await user.click(screen.getAllByLabelText('Toelichting scoringsmodel')[0]);
+    await user.click(screen.getByLabelText('Sluiten'));
+
+    expect(screen.queryByRole('dialog')).toBeNull();
+  });
+});
+
+describe('ZoekcriteriaSection score simulator', () => {
+  const openEditor = async (over: Partial<SavedSearch>) => {
+    mockFetchSearches.mockResolvedValue([makeSearch(over)]);
+    const user = userEvent.setup();
+    render(<ZoekcriteriaSection />);
+    await screen.findByText('Jeugdzorg');
+    await user.click(screen.getAllByRole('button', { name: /Bewerk/i })[0]);
+    return user;
+  };
+
+  it('names a Tweede Kamer example document and scores it above the threshold', async () => {
+    const user = await openEditor({
+      query: { q: 'stikstof', source: ['tk'] },
+    } as Partial<SavedSearch>);
+
+    expect(screen.getByText(/voorbeelddocument · TK/)).toBeInTheDocument();
+    expect(screen.getByText('Motie')).toBeInTheDocument();
+    expect(screen.getByText(/wordt ingediend bij de Tweede Kamer/)).toBeInTheDocument();
+    expect(screen.getByText(/wordt kandidaat/)).toBeInTheDocument();
+
+    // Turn off the heavy-type bump and the title match: nothing matched, so the
+    // noise floor applies and the document is filtered out.
+    await user.click(screen.getByRole('switch', { name: 'Zwaar documenttype' }));
+    await user.click(screen.getByRole('switch', { name: 'Zoekwoord in de titel' }));
+    expect(screen.getByText(/geen term raak/)).toBeInTheDocument();
+
+    // A tag match alone is enough to lift it off the noise floor, so the
+    // verdict stops citing "no term matched" even though nothing in the title
+    // hit.
+    await user.click(screen.getByRole('switch', { name: 'Tag komt ook voor' }));
+    expect(screen.queryByText(/geen term raak/)).toBeNull();
+  });
+
+  it('names an EU example document', async () => {
+    await openEditor({ query: { q: 'stikstof', source: ['eu'] } } as Partial<SavedSearch>);
+    expect(screen.getByText(/voorbeelddocument · EU/)).toBeInTheDocument();
+  });
+
+  it('swaps the heavy-type toggle for a regional-mention toggle on media', async () => {
+    await openEditor({ query: { q: 'stikstof', source: ['media'] } } as Partial<SavedSearch>);
+
+    expect(screen.getByText(/voorbeelddocument · Media/)).toBeInTheDocument();
+    expect(
+      screen.getByRole('switch', { name: 'Provincie Flevoland gevonden' })
+    ).toBeInTheDocument();
+    expect(screen.getByText('Flevoland-artikel')).toBeInTheDocument();
+    expect(screen.getByText(/verschijnt in het nieuws/)).toBeInTheDocument();
+  });
+
+  it('offers no type toggle at all for an OB criterion', async () => {
+    await openEditor({ query: { q: 'stikstof', source: ['ob'] } } as Partial<SavedSearch>);
+
+    expect(screen.getByText(/voorbeelddocument · OB/)).toBeInTheDocument();
+    expect(screen.getByText('publicatie')).toBeInTheDocument();
+    expect(screen.getByText(/wordt gepubliceerd in de OB/)).toBeInTheDocument();
+    expect(screen.queryByRole('switch', { name: 'Zwaar documenttype' })).toBeNull();
+  });
+});

--- a/packages/pa-cockpit/src/pages/PADashboardV2.test.tsx
+++ b/packages/pa-cockpit/src/pages/PADashboardV2.test.tsx
@@ -338,3 +338,236 @@ describe('PADashboardV2', () => {
     expect(screen.getByText('Vandaag', { selector: '.pac-rail-card' })).toBeInTheDocument();
   });
 });
+
+describe('PADashboardV2 rail badges', () => {
+  beforeEach(() => {
+    __resetPaCockpitHostForTests();
+    configureHost();
+    authState.authenticated = true;
+    authState.user = authorizedUser;
+  });
+
+  afterEach(() => vi.clearAllMocks());
+
+  it('shows an inbox badge beside a monitoring tab that has waiting signals', async () => {
+    mockUsePaData.mockReturnValue(
+      makePaDataStub({
+        dossiers: { data: dossiers, status: 'ok', refetch: vi.fn() },
+        inboxCounts: { politiek: 4, europa: 0, regionaal: 0, media: 0 },
+      })
+    );
+    const user = userEvent.setup();
+    const { container } = render(<PADashboardV2 host={testHost} />);
+    // The signal badges live on the Monitoring rail, so the rail has to be
+    // showing that mode's items for them to exist at all.
+    await user.click(screen.getByRole('button', { name: 'Monitoring' }));
+
+    // Only the tab that actually has waiting signals gets one -- a zero badge
+    // is noise on a rail that is meant to be scanned.
+    const badges = container.querySelectorAll('.pac-rail-inbox');
+    expect(badges).toHaveLength(1);
+    expect(badges[0]).toHaveTextContent('4');
+  });
+
+  it('shows an unseen-count badge on the notification bell', () => {
+    mockUsePaData.mockReturnValue(
+      makePaDataStub({
+        dossiers: { data: dossiers, status: 'ok', refetch: vi.fn() },
+        notifications: { data: { items: [], unseenCount: 3 }, status: 'ok', refetch: vi.fn() },
+      })
+    );
+    render(<PADashboardV2 host={testHost} />);
+
+    expect(screen.getByLabelText('Open meldingen')).toHaveTextContent('3');
+  });
+
+  it('counts only upcoming, non-cancelled agenda items, and flags one that is live now', async () => {
+    const iso = (days: number) => {
+      const d = new Date();
+      d.setUTCDate(d.getUTCDate() + days);
+      return d.toISOString().slice(0, 10);
+    };
+    mockUsePaData.mockReturnValue(
+      makePaDataStub({
+        dossiers: { data: dossiers, status: 'ok', refetch: vi.fn() },
+        agenda: {
+          data: [
+            { iso: iso(1), status: 'gepland', live: 'live' },
+            { iso: iso(2), status: 'gepland', live: null },
+            { iso: iso(3), status: 'geannuleerd', live: null },
+            { iso: iso(-1), status: 'uitgevoerd', live: null },
+          ],
+          status: 'ok',
+          refetch: vi.fn(),
+        },
+      })
+    );
+    const user = userEvent.setup();
+    const { container } = render(<PADashboardV2 host={testHost} />);
+    await user.click(screen.getByRole('button', { name: 'Monitoring' }));
+
+    // Two of the four are upcoming and not cancelled; the live dot is a
+    // separate signal from that count.
+    expect(container.querySelector('.pac-rail-score')).toHaveTextContent('2');
+    expect(container.querySelector('.pac-rail-live')).not.toBeNull();
+  });
+});
+
+describe('PADashboardV2 dossier pointer', () => {
+  beforeEach(() => {
+    __resetPaCockpitHostForTests();
+    configureHost();
+    authState.authenticated = true;
+    authState.user = authorizedUser;
+  });
+
+  afterEach(() => vi.clearAllMocks());
+
+  it('waits for the dossier list rather than pointing at nothing while it loads', () => {
+    mockUsePaData.mockReturnValue(
+      makePaDataStub({ dossiers: { data: [], status: 'loading', refetch: vi.fn() } })
+    );
+    expect(() => render(<PADashboardV2 host={testHost} />)).not.toThrow();
+  });
+
+  it('survives an empty dossier list', () => {
+    mockUsePaData.mockReturnValue(
+      makePaDataStub({ dossiers: { data: [], status: 'ok', refetch: vi.fn() } })
+    );
+    expect(() => render(<PADashboardV2 host={testHost} />)).not.toThrow();
+  });
+
+  it('falls back to the first dossier when none is actief', async () => {
+    // Every dossier sluimerend is a real end state for a small tenant; the
+    // pointer must still land somewhere rather than on an empty string.
+    mockUsePaData.mockReturnValue(
+      makePaDataStub({
+        dossiers: {
+          data: dossiers.map((d) => ({ ...d, status: 'sluimerend' })) as Dossier[],
+          status: 'ok',
+          refetch: vi.fn(),
+        },
+      })
+    );
+    const user = userEvent.setup();
+    render(<PADashboardV2 host={testHost} />);
+
+    await user.click(screen.getByRole('button', { name: 'Dossiers' }));
+    expect(screen.getByTestId('section-router')).toHaveTextContent('section=stikstof');
+  });
+});
+
+describe('PADashboardV2 mode switching', () => {
+  beforeEach(() => {
+    __resetPaCockpitHostForTests();
+    configureHost();
+    authState.authenticated = true;
+    authState.user = authorizedUser;
+    mockUsePaData.mockReturnValue(defaultPaData());
+  });
+
+  afterEach(() => vi.clearAllMocks());
+
+  it('lands each mode on its own default section on first visit', async () => {
+    const user = userEvent.setup();
+    render(<PADashboardV2 host={testHost} />);
+    const router = () => screen.getByTestId('section-router');
+
+    for (const [label, expected] of [
+      ['Dossiers', 'section=stikstof'],
+      ['Monitoring', 'section=politiek'],
+      ['Voortgang', 'section=voortgang'],
+      ['Beheer', 'section=profiel'],
+      ['Vandaag', 'section=vandaag'],
+    ] as const) {
+      await user.click(screen.getByRole('button', { name: label }));
+      expect(router()).toHaveTextContent(expected);
+    }
+  });
+
+  it('opens and closes the command palette with the keyboard shortcut', async () => {
+    const user = userEvent.setup();
+    render(<PADashboardV2 host={testHost} />);
+
+    expect(screen.queryByTestId('palette')).toBeNull();
+    await user.keyboard('{Control>}k{/Control}');
+    expect(screen.getByTestId('palette')).toBeInTheDocument();
+    await user.keyboard('{Meta>}k{/Meta}');
+    expect(screen.queryByTestId('palette')).toBeNull();
+  });
+
+  it('opens the assistant dock and closes it again', async () => {
+    const user = userEvent.setup();
+    render(<PADashboardV2 host={testHost} />);
+
+    await user.click(screen.getByRole('button', { name: 'Vraag de assistent' }));
+    expect(screen.getByTestId('dock')).toBeInTheDocument();
+  });
+});
+
+describe('PADashboardV2 identity chrome', () => {
+  afterEach(() => vi.clearAllMocks());
+
+  const renderAs = (user: Partial<KeycloakUser>) => {
+    __resetPaCockpitHostForTests();
+    configureHost();
+    authState.authenticated = true;
+    authState.user = { ...authorizedUser, ...user } as KeycloakUser;
+    mockUsePaData.mockReturnValue(defaultPaData());
+    return render(<PADashboardV2 host={testHost} />);
+  };
+
+  it('shows the assurance level when the token carries one', () => {
+    renderAs({ loa: 'substantieel' } as Partial<KeycloakUser>);
+    expect(screen.getByText('LOA substantieel')).toBeInTheDocument();
+  });
+
+  it('falls back from name to preferred_username, and then to a generic label', () => {
+    const { unmount } = renderAs({
+      name: undefined,
+      preferred_username: 'm.devries',
+    } as Partial<KeycloakUser>);
+    expect(screen.getByText('m.devries')).toBeInTheDocument();
+    unmount();
+
+    renderAs({ name: undefined, preferred_username: undefined } as Partial<KeycloakUser>);
+    expect(screen.getByText('Medewerker')).toBeInTheDocument();
+  });
+});
+
+describe('PADashboardV2 tenant theming', () => {
+  afterEach(() => vi.clearAllMocks());
+
+  it('themes for the signed-in municipality and shows its display name', async () => {
+    const initializeTenantTheme = vi.fn().mockResolvedValue(true);
+    const loadTenantConfigs = vi.fn().mockResolvedValue({});
+    const getTenantConfig = vi.fn().mockReturnValue({ displayName: 'Provincie Flevoland' });
+    const getDefaultTenantConfig = vi.fn().mockReturnValue(null);
+
+    __resetPaCockpitHostForTests();
+    configurePaCockpit({
+      auth: {
+        authenticated: true,
+        token: 'test-token',
+        getUser: () => ({ ...authorizedUser, municipality: 'flevoland' }) as KeycloakUser,
+        updateToken: async () => false,
+      },
+      tenant: {
+        initializeTenantTheme,
+        loadTenantConfigs,
+        getTenantConfig,
+        getDefaultTenantConfig,
+      },
+    });
+    authState.authenticated = true;
+    authState.user = authorizedUser;
+    mockUsePaData.mockReturnValue(defaultPaData());
+
+    render(<PADashboardV2 host={testHost} />);
+
+    expect(await screen.findByText('Provincie Flevoland')).toBeInTheDocument();
+    expect(initializeTenantTheme).toHaveBeenCalledWith('flevoland');
+    // The signed-in tenant wins; the default is never consulted.
+    expect(getDefaultTenantConfig).not.toHaveBeenCalled();
+  });
+});

--- a/packages/pa-cockpit/src/pages/public-affairs-v2/AgendaView.test.tsx
+++ b/packages/pa-cockpit/src/pages/public-affairs-v2/AgendaView.test.tsx
@@ -167,4 +167,131 @@ describe('AgendaView', () => {
 
     expect(onOpenDossier).toHaveBeenCalledWith('stikstof');
   });
+  it('labels a cancelled item and marks its row, under "Alle periodes"', async () => {
+    mockUsePaData.mockReturnValue(
+      defaultPaData({
+        agenda: {
+          data: [makeItem({ id: 'x', status: 'geannuleerd', titel: 'Afgezegd debat' })],
+          status: 'ok',
+        },
+      })
+    );
+    const user = userEvent.setup();
+    const { container } = render(<AgendaView onOpenDossier={vi.fn()} />);
+    await user.click(screen.getByRole('button', { name: /Alle periodes/ }));
+
+    expect(screen.getByText('Geannuleerd')).toBeInTheDocument();
+    expect(container.querySelector('.pac-ag-item.cancelled')).not.toBeNull();
+  });
+
+  it('marks a past item as past', async () => {
+    mockUsePaData.mockReturnValue(
+      defaultPaData({
+        agenda: {
+          data: [makeItem({ id: 'x', iso: isoOffset(-3), status: 'uitgevoerd' })],
+          status: 'ok',
+        },
+      })
+    );
+    const user = userEvent.setup();
+    const { container } = render(<AgendaView onOpenDossier={vi.fn()} />);
+    await user.click(screen.getByRole('button', { name: /Alle periodes/ }));
+
+    expect(container.querySelector('.pac-ag-item.past')).not.toBeNull();
+    expect(screen.getByText('Geweest')).toBeInTheDocument();
+  });
+
+  it('shows a dash rather than a blank slot for an item with no start time', () => {
+    mockUsePaData.mockReturnValue(
+      defaultPaData({ agenda: { data: [makeItem({ tijd: null })], status: 'ok' } })
+    );
+    render(<AgendaView onOpenDossier={vi.fn()} />);
+    expect(screen.getByText('–')).toBeInTheDocument();
+  });
+
+  it('shows the committee name when the activity has one', () => {
+    mockUsePaData.mockReturnValue(
+      defaultPaData({
+        agenda: { data: [makeItem({ commissie: 'Commissie LNV' })], status: 'ok' },
+      })
+    );
+    render(<AgendaView onOpenDossier={vi.fn()} />);
+    expect(screen.getByText('Commissie LNV')).toBeInTheDocument();
+  });
+
+  it('links a live activity to its stream', () => {
+    mockUsePaData.mockReturnValue(
+      defaultPaData({
+        agenda: {
+          data: [makeItem({ live: 'live', stream: 'https://debatgemist.tweedekamer.nl/x' })],
+          status: 'ok',
+        },
+      })
+    );
+    const { container } = render(<AgendaView onOpenDossier={vi.fn()} />);
+
+    expect(screen.getByText('Nu in de zaal')).toBeInTheDocument();
+    expect(screen.getByRole('link', { name: /Nu in de zaal/ })).toHaveAttribute(
+      'href',
+      'https://debatgemist.tweedekamer.nl/x'
+    );
+    expect(container.querySelector('.pac-ag-item.live')).not.toBeNull();
+  });
+
+  it('still renders a live activity that has no stream URL yet', () => {
+    // The Tweede Kamer feed flags an activity live before the stream URL is
+    // published; a missing href must not produce a link to the current page.
+    mockUsePaData.mockReturnValue(
+      defaultPaData({ agenda: { data: [makeItem({ live: 'live', stream: null })], status: 'ok' } })
+    );
+    render(<AgendaView onOpenDossier={vi.fn()} />);
+    expect(screen.getByRole('link', { name: /Nu in de zaal/ })).toHaveAttribute('href', '#');
+  });
+
+  it('marks an activity that is about to start', () => {
+    mockUsePaData.mockReturnValue(
+      defaultPaData({ agenda: { data: [makeItem({ live: 'binnenkort' })], status: 'ok' } })
+    );
+    render(<AgendaView onOpenDossier={vi.fn()} />);
+    expect(screen.getByText('Straks live')).toBeInTheDocument();
+  });
+
+  it('falls back to the dossier id when the dossier list does not know it', async () => {
+    // The agenda match is computed server-side against dossier ids; a dossier
+    // archived since that run would otherwise render as an empty label.
+    mockUsePaData.mockReturnValue(
+      defaultPaData({
+        agenda: {
+          data: [makeItem({ dossier: 'verdwenen-dossier', matchTerm: 'stikstof' })],
+          status: 'ok',
+        },
+        dossiers: { data: [] as Dossier[], status: 'ok' },
+      })
+    );
+    render(<AgendaView onOpenDossier={vi.fn()} />);
+    expect(screen.getByText(/verdwenen-dossier/)).toBeInTheDocument();
+  });
+
+  it('groups consecutive activities on the same date under one heading', () => {
+    mockUsePaData.mockReturnValue(
+      defaultPaData({
+        agenda: {
+          data: [
+            makeItem({ id: 'a', titel: 'Eerste', tijd: '10:00' }),
+            makeItem({ id: 'b', titel: 'Tweede', tijd: '11:00' }),
+            makeItem({ id: 'c', titel: 'Derde', iso: isoOffset(1), tijd: '09:00' }),
+          ],
+          status: 'ok',
+        },
+      })
+    );
+    const { container } = render(<AgendaView onOpenDossier={vi.fn()} />);
+
+    // Three activities, two dates -- the two same-day items must share one day
+    // block rather than each opening its own.
+    const days = container.querySelectorAll('.pac-ag-day');
+    expect(days).toHaveLength(2);
+    expect(days[0].querySelectorAll('.pac-ag-item')).toHaveLength(2);
+    expect(days[1].querySelectorAll('.pac-ag-item')).toHaveLength(1);
+  });
 });

--- a/packages/pa-cockpit/src/pages/public-affairs-v2/Issuekaart.test.tsx
+++ b/packages/pa-cockpit/src/pages/public-affairs-v2/Issuekaart.test.tsx
@@ -340,3 +340,201 @@ describe('the other sub-tabs render their content', () => {
     expect(screen.getByText('Events')).toBeInTheDocument();
   });
 });
+
+describe('Issuekaart display variants', () => {
+  it('names an empty ritme column instead of leaving it blank', () => {
+    render(<Issuekaart dossier={makeDossier()} />);
+    // Every column is empty in the base fixture; an empty <ul> would read as a
+    // rendering fault rather than "nothing planned".
+    expect(screen.getAllByText('Geen geplande acties').length).toBeGreaterThan(0);
+  });
+
+  it('labels every stakeholder priority and sentiment', () => {
+    render(
+      <Issuekaart
+        dossier={makeDossier({
+          stakeholders: [
+            { naam: 'A', rol: 'Rol A', prio: 'nu', laatste: '2 dgn', senti: 'pos' },
+            { naam: 'B', rol: 'Rol B', prio: 'kort', laatste: '1 wk', senti: 'neg' },
+            { naam: 'C', rol: 'Rol C', prio: 'warm', laatste: '3 wk', senti: 'neu' },
+          ],
+        } as Partial<Dossier>)}
+      />
+    );
+
+    expect(screen.getByText('Nu spreken')).toBeInTheDocument();
+    expect(screen.getByText('Korte termijn')).toBeInTheDocument();
+    expect(screen.getByText('Warm houden')).toBeInTheDocument();
+    expect(screen.getByText('Positief')).toBeInTheDocument();
+    expect(screen.getByText('Kritisch')).toBeInTheDocument();
+    expect(screen.getByText('Neutraal')).toBeInTheDocument();
+  });
+
+  it('marks a planned timeline event and lists its documents', async () => {
+    const user = userEvent.setup();
+    render(
+      <Issuekaart
+        dossier={makeDossier({
+          timeline: [
+            { date: '1 jul 2026', title: 'Gebeurd', desc: 'Beschrijving', docs: [], future: false },
+            {
+              date: '1 sep 2026',
+              title: 'Gepland',
+              desc: 'Beschrijving',
+              docs: ['Notitie.pdf'],
+              future: true,
+            },
+          ],
+        } as Partial<Dossier>)}
+      />
+    );
+    await openTab(user, 'Tijdlijn');
+
+    expect(screen.getByText(/gepland/)).toBeInTheDocument();
+    expect(screen.getByText('Notitie.pdf')).toBeInTheDocument();
+  });
+});
+
+describe('Issuekaart signal rendering', () => {
+  it('distinguishes an AI concept from a rule candidate in the inbox', async () => {
+    paApi.fetchInbox.mockResolvedValue({
+      data: [
+        makeSignal({
+          id: 'i1',
+          status: 'ai_drafted',
+          bron: 'tk',
+          duiding: 'AI-duiding hier',
+          impact: 'kans',
+          impactLabel: 'Kans',
+          ref: { type: 'Motie', nr: '2026Z001', url: 'https://tk.nl/x' },
+        }),
+        makeSignal({ id: 'i2', status: 'candidate', bron: 'ob', duiding: null, impact: null }),
+      ],
+      meta: { total: 2, cap: 100, capped: false },
+    });
+    const user = userEvent.setup();
+    render(<Issuekaart dossier={makeDossier()} />);
+    await openTab(user, 'Monitoring');
+
+    expect(await screen.findByText('✦ AI-concept')).toBeInTheDocument();
+    expect(screen.getByText('Regel-kandidaat')).toBeInTheDocument();
+    expect(screen.getAllByText('Tweede Kamer').length).toBeGreaterThan(0);
+    expect(screen.getAllByText('Off. Bekendmakingen').length).toBeGreaterThan(0);
+    expect(screen.getByText('AI-duiding hier')).toBeInTheDocument();
+    // A rule candidate carries no AI reading, and the panel says so rather than
+    // leaving an empty block that looks like a loading state.
+    expect(screen.getByText(/Handmatige duiding nodig/)).toBeInTheDocument();
+    expect(screen.getByRole('link', { name: /2026Z001/ })).toHaveAttribute(
+      'href',
+      'https://tk.nl/x'
+    );
+    expect(screen.getAllByText('Kans').length).toBeGreaterThan(0);
+  });
+
+  it('leaves the source chip blank for an inbox signal from a source it has no label for', async () => {
+    paApi.fetchInbox.mockResolvedValue({
+      data: [makeSignal({ id: 'i3', status: 'candidate', bron: 'eu' })],
+      meta: { total: 1, cap: 100, capped: false },
+    });
+    const user = userEvent.setup();
+    const { container } = render(<Issuekaart dossier={makeDossier()} />);
+    await openTab(user, 'Monitoring');
+
+    await screen.findByText('Regel-kandidaat');
+    expect(container.querySelector('.pac-bron-eu')).toHaveTextContent('');
+  });
+
+  it('shows the confirming curator and the reference on a curated signal', async () => {
+    paApi.fetchSignals.mockResolvedValue([
+      makeSignal({
+        id: 'c1',
+        bron: 'ob',
+        duiding: 'Handmatige duiding',
+        confirmedBy: 'Sanne Bakker',
+        confirmedAt: '2 jul 2026',
+        ref: { type: 'Besluit', nr: 'stcrt-1', url: 'https://ob.nl/y' },
+      }),
+    ]);
+    const user = userEvent.setup();
+    render(<Issuekaart dossier={makeDossier()} />);
+    await openTab(user, 'Monitoring');
+
+    expect(await screen.findByText(/Bevestigd door Sanne Bakker/)).toBeInTheDocument();
+    expect(screen.getByText('Handmatige duiding')).toBeInTheDocument();
+    expect(screen.getByRole('link', { name: /stcrt-1/ })).toHaveAttribute(
+      'href',
+      'https://ob.nl/y'
+    );
+  });
+});
+
+describe('Issuekaart overlegbox', () => {
+  it('shows the placeholder until the first message is posted', async () => {
+    const user = userEvent.setup();
+    render(<Issuekaart dossier={makeDossier({ overleg: [] } as Partial<Dossier>)} />);
+    await openTab(user, 'OverlegBox');
+
+    const box = screen.getByPlaceholderText(/Schrijf een bericht/);
+    await user.type(box, 'Eerste bericht{Enter}');
+
+    expect(screen.getByText('Eerste bericht')).toBeInTheDocument();
+  });
+
+  it('ignores an empty or whitespace-only message', async () => {
+    const user = userEvent.setup();
+    const { container } = render(
+      <Issuekaart dossier={makeDossier({ overleg: [] } as Partial<Dossier>)} />
+    );
+    await openTab(user, 'OverlegBox');
+
+    const box = screen.getByPlaceholderText(/Schrijf een bericht/);
+    await user.type(box, '   {Enter}');
+    await user.click(screen.getByRole('button', { name: 'Plaats' }));
+
+    expect(container.querySelectorAll('.pac-msg')).toHaveLength(0);
+  });
+
+  it('posts via the button as well as the Enter key', async () => {
+    const user = userEvent.setup();
+    const { container } = render(
+      <Issuekaart dossier={makeDossier({ overleg: [] } as Partial<Dossier>)} />
+    );
+    await openTab(user, 'OverlegBox');
+
+    await user.type(screen.getByPlaceholderText(/Schrijf een bericht/), 'Via de knop');
+    await user.click(screen.getByRole('button', { name: 'Plaats' }));
+
+    expect(container.querySelectorAll('.pac-msg')).toHaveLength(1);
+    expect(screen.getByText('Via de knop')).toBeInTheDocument();
+  });
+});
+
+describe('Issuekaart watch toggle', () => {
+  it('ignores a second click while the first is still in flight', async () => {
+    // The bell is a single control over a network round trip; a double click
+    // would otherwise fire watch and unwatch and settle on the wrong state.
+    let release!: () => void;
+    const watchDossier = vi.fn(
+      () =>
+        new Promise<void>((resolve) => {
+          release = resolve;
+        })
+    );
+    mockUsePaData.mockReturnValue(
+      makePaDataStub({
+        watchDossier,
+        unwatchDossier: vi.fn().mockResolvedValue(undefined),
+      })
+    );
+    const user = userEvent.setup();
+    render(<Issuekaart dossier={makeDossier()} />);
+
+    const bell = await screen.findByRole('button', { name: 'Volgen' });
+    await user.click(bell);
+    await user.click(bell).catch(() => undefined);
+
+    expect(watchDossier).toHaveBeenCalledTimes(1);
+    release();
+    await waitFor(() => expect(screen.getByRole('button', { name: 'Volgend' })).toBeEnabled());
+  });
+});

--- a/packages/pa-cockpit/src/pages/public-affairs-v2/Monitoring.test.tsx
+++ b/packages/pa-cockpit/src/pages/public-affairs-v2/Monitoring.test.tsx
@@ -430,3 +430,279 @@ describe('watchlist signals', () => {
     await waitFor(() => expect(linkSignalDossier).toHaveBeenCalledWith('sig-orphan', 'stikstof'));
   });
 });
+
+describe('Monitoring signal provenance chips', () => {
+  // Every one of these is display-only -- none of it feeds scoring -- but it is
+  // how a curator tells a plenary document from a committee text, or a
+  // provincial news item from a national one, without opening the source.
+  const renderCurated = async (signals: Signal[]) => {
+    paApi.fetchSignals.mockResolvedValue(signals);
+    render(<Monitoring activeTab="politiek" onOpenDossier={vi.fn()} />);
+    await waitFor(() => expect(paApi.fetchSignals).toHaveBeenCalled());
+  };
+
+  it('names each source, and shows no badge at all when the source is unknown', async () => {
+    await renderCurated([
+      makeSignal({ id: 'a', bron: 'tk' }),
+      makeSignal({ id: 'b', bron: 'ob' }),
+      makeSignal({ id: 'c', bron: 'eu' }),
+      makeSignal({ id: 'd', bron: null }),
+    ]);
+
+    expect((await screen.findAllByText('Tweede Kamer')).length).toBeGreaterThan(0);
+    expect(screen.getAllByText('Off. Bekendmakingen').length).toBeGreaterThan(0);
+    expect(screen.getAllByText('Europees Parlement').length).toBeGreaterThan(0);
+  });
+
+  it('shows a source key verbatim when there is no display name for it', async () => {
+    // Deliberately outside the declared union: the fallback exists for signals
+    // persisted under a source key this build no longer knows about, which is
+    // by definition a value the current type forbids.
+    await renderCurated([
+      makeSignal({ id: 'a', bron: 'nieuwe-bron' } as unknown as Partial<Signal>),
+    ]);
+    expect(await screen.findByText('nieuwe-bron')).toBeInTheDocument();
+  });
+
+  it('labels the EP sub-source and names the responsible committee', async () => {
+    await renderCurated([
+      makeSignal({
+        id: 'a',
+        bron: 'eu',
+        subbron: 'ep-rss',
+        commissie: 'ENVI',
+      } as Partial<Signal>),
+      makeSignal({ id: 'b', bron: 'eu', subbron: 'ep-teksten' } as Partial<Signal>),
+    ]);
+
+    expect(await screen.findByText('Plenaire documenten')).toBeInTheDocument();
+    expect(screen.getByText('Ingediende teksten')).toBeInTheDocument();
+    expect(screen.getByText('ENVI')).toBeInTheDocument();
+  });
+
+  it('still labels a press release, the sub-source nothing produces any more', async () => {
+    // The press-release feed was dropped in f355fce -- the EP Open Data API has
+    // no equivalent endpoint -- but signals persisted under 'ep-persbericht'
+    // before that are still in the inbox and must keep their label. The entry
+    // is deliberate backward compatibility, not a leftover: deleting it would
+    // silently downgrade historical rows to a raw key.
+    await renderCurated([
+      makeSignal({ id: 'a', bron: 'eu', subbron: 'ep-persbericht' } as Partial<Signal>),
+    ]);
+    expect(await screen.findByText('Persbericht')).toBeInTheDocument();
+  });
+
+  it('shows an unrecognised EP sub-source key verbatim', async () => {
+    // Signals persisted before a feed changed keep their old key; showing the
+    // raw key beats showing nothing where a label belongs.
+    await renderCurated([
+      makeSignal({ id: 'a', bron: 'eu', subbron: 'ep-nieuw' } as Partial<Signal>),
+    ]);
+    expect(await screen.findByText('ep-nieuw')).toBeInTheDocument();
+  });
+
+  it('carries region and sentiment on a media signal', async () => {
+    await renderCurated([
+      makeSignal({
+        id: 'a',
+        bron: 'media',
+        subbron: 'nieuws-regionaal',
+        regio: 'Flevoland',
+        sentiment: 'negatief',
+      } as Partial<Signal>),
+      makeSignal({
+        id: 'b',
+        bron: 'media',
+        subbron: 'nieuws-nationaal',
+        sentiment: 'positief',
+      } as Partial<Signal>),
+      makeSignal({
+        id: 'c',
+        bron: 'media',
+        subbron: 'social',
+        sentiment: 'neutraal',
+      } as Partial<Signal>),
+    ]);
+
+    expect(await screen.findByText('Regionaal')).toBeInTheDocument();
+    expect(screen.getByText('Landelijk')).toBeInTheDocument();
+    expect(screen.getByText('Sociaal')).toBeInTheDocument();
+    expect(screen.getByText('◎ Flevoland')).toBeInTheDocument();
+    expect(screen.getByText('Negatief')).toBeInTheDocument();
+    expect(screen.getByText('Positief')).toBeInTheDocument();
+    expect(screen.getByText('Neutraal')).toBeInTheDocument();
+  });
+
+  it('shows unrecognised media sub-source and sentiment keys verbatim', async () => {
+    await renderCurated([
+      makeSignal({
+        id: 'a',
+        bron: 'media',
+        subbron: 'podcast',
+        sentiment: 'gemengd',
+      } as unknown as Partial<Signal>),
+    ]);
+    expect(await screen.findByText('podcast')).toBeInTheDocument();
+    expect(screen.getByText('gemengd')).toBeInTheDocument();
+  });
+
+  it('flags a confirmed signal that has no dossier as watchlist work', async () => {
+    await renderCurated([
+      makeSignal({ id: 'a', routing: 'watchlist', dossierId: null } as Partial<Signal>),
+    ]);
+    expect(await screen.findByText(/staat op de watchlist/)).toBeInTheDocument();
+  });
+
+  it('names the curator who confirmed a signal, and links its source reference', async () => {
+    await renderCurated([
+      makeSignal({
+        id: 'a',
+        confirmedBy: 'Sanne Bakker',
+        confirmedAt: '2 jul 2026',
+        ref: { type: 'Motie', nr: '2026Z001', url: 'https://tk.nl/x' },
+      } as Partial<Signal>),
+    ]);
+
+    expect(await screen.findByText(/Bevestigd door Sanne Bakker/)).toBeInTheDocument();
+    expect(screen.getByRole('link', { name: /2026Z001/ })).toHaveAttribute(
+      'href',
+      'https://tk.nl/x'
+    );
+  });
+});
+
+describe('Monitoring inbox rendering', () => {
+  const renderInbox = async (signals: Signal[]) => {
+    paApi.fetchInbox.mockResolvedValue({
+      data: signals,
+      meta: { total: signals.length, cap: 100, capped: false },
+    });
+    const user = userEvent.setup();
+    render(<Monitoring activeTab="politiek" onOpenDossier={vi.fn()} />);
+    await user.click(await screen.findByRole('button', { name: /Inbox/ }));
+    return user;
+  };
+
+  it('separates an AI concept from a rule candidate, and says which needs a human reading', async () => {
+    await renderInbox([
+      makeSignal({
+        id: 'i1',
+        status: 'ai_drafted',
+        duiding: 'AI-duiding',
+        impact: 'risico',
+        impactLabel: 'Risico',
+      }),
+      makeSignal({ id: 'i2', status: 'candidate', duiding: null, impact: null, dossierId: null }),
+    ]);
+
+    expect(await screen.findByText('✦ AI-concept')).toBeInTheDocument();
+    expect(screen.getByText('Regel-kandidaat')).toBeInTheDocument();
+    expect(screen.getByText('AI-duiding')).toBeInTheDocument();
+    expect(screen.getByText('Risico')).toBeInTheDocument();
+    expect(screen.getByText(/Handmatige duiding nodig/)).toBeInTheDocument();
+    // A candidate the rules could not route says so, rather than showing an
+    // empty dossier chip.
+    expect(screen.getByText('⚑ Geen dossier-match')).toBeInTheDocument();
+  });
+
+  it('locks the koppel control while the link is in flight', async () => {
+    // The select and the button both drive one write; leaving either live
+    // during the round trip lets a second pick overwrite the first.
+    const linked = makeSignal({
+      id: 'a',
+      title: 'Zwevend signaal',
+      routing: null,
+      dossierId: 'stikstof',
+    } as Partial<Signal>);
+    let release!: () => void;
+    const linkSignalDossier = vi.fn(
+      () =>
+        new Promise((resolve) => {
+          release = () => resolve(linked);
+        })
+    );
+    mockUsePaData.mockReturnValue(
+      defaultPaData({
+        dossiers: {
+          data: [{ id: 'stikstof', naam: 'Stikstof' }] as never,
+          status: 'ok',
+          refetch: vi.fn(),
+        },
+        linkSignalDossier,
+      })
+    );
+    paApi.fetchSignals.mockResolvedValue([
+      makeSignal({
+        id: 'a',
+        title: 'Zwevend signaal',
+        routing: 'watchlist',
+        dossierId: null,
+      } as Partial<Signal>),
+    ]);
+    const user = userEvent.setup();
+    render(<Monitoring activeTab="politiek" onOpenDossier={vi.fn()} />);
+    await screen.findByText('Zwevend signaal');
+
+    await user.selectOptions(screen.getByRole('combobox'), 'stikstof');
+    await user.click(screen.getByRole('button', { name: 'Koppelen' }));
+
+    expect(screen.getByRole('combobox')).toBeDisabled();
+    expect(screen.getByRole('button', { name: '…' })).toBeDisabled();
+
+    release();
+    await waitFor(() => expect(screen.queryByRole('button', { name: '…' })).toBeNull());
+  });
+});
+
+describe('Monitoring raw feed rendering', () => {
+  const rawItem = (over: Partial<FeedItem> = {}): FeedItem =>
+    ({
+      id: 'r1',
+      title: 'Ruwe treffer',
+      type: 'Motie',
+      number: '2026Z001',
+      date: new Date().toISOString(),
+      url: 'https://tk.nl/x',
+      source: 'tk',
+      ...over,
+    }) as FeedItem;
+
+  const openOngefilterd = async (items: FeedItem[]) => {
+    paApi.fetchFeed.mockResolvedValue({ items, total: items.length });
+    const user = userEvent.setup();
+    render(<Monitoring activeTab="politiek" onOpenDossier={vi.fn()} />);
+    await user.click(await screen.findByRole('button', { name: /Ongefilterd/ }));
+    return user;
+  };
+
+  it('dates each hit relatively, and copes with an undated or unparseable one', async () => {
+    const hoursAgo = (h: number) => new Date(Date.now() - h * 3_600_000).toISOString();
+    await openOngefilterd([
+      rawItem({ id: 'a', date: hoursAgo(0) }),
+      rawItem({ id: 'b', date: hoursAgo(5) }),
+      rawItem({ id: 'c', date: hoursAgo(30) }),
+      rawItem({ id: 'd', date: hoursAgo(24 * 4) }),
+      rawItem({ id: 'e', date: null }),
+      rawItem({ id: 'f', date: 'onbekend' }),
+    ]);
+
+    expect(await screen.findByText(/· nu/)).toBeInTheDocument();
+    expect(screen.getByText(/· 5 u/)).toBeInTheDocument();
+    expect(screen.getByText(/· 1 dg$/)).toBeInTheDocument();
+    expect(screen.getByText(/· 4 dgn/)).toBeInTheDocument();
+    // An unparseable date is shown as-is rather than silently dropped or
+    // rendered as "NaN dgn".
+    expect(screen.getByText(/· onbekend/)).toBeInTheDocument();
+  });
+
+  it('renders a hit with no type and no URL', async () => {
+    await openOngefilterd([rawItem({ id: 'a', type: null, url: null, number: null })]);
+    expect(await screen.findByText('Ruwe treffer')).toBeInTheDocument();
+    expect(screen.queryByRole('link')).toBeNull();
+  });
+
+  it('falls back to the hit id when it carries no document number', async () => {
+    await openOngefilterd([rawItem({ id: 'zonder-nummer', number: null })]);
+    expect(await screen.findByRole('link', { name: /zonder-nummer/ })).toBeInTheDocument();
+  });
+});

--- a/packages/pa-cockpit/src/pages/public-affairs-v2/PaDataProvider.test.tsx
+++ b/packages/pa-cockpit/src/pages/public-affairs-v2/PaDataProvider.test.tsx
@@ -209,6 +209,75 @@ describe('inboxCounts seeding', () => {
     }
   });
 
+  it('gives up after four retries rather than hammering a dead backend', async () => {
+    vi.useFakeTimers();
+    try {
+      mocks.fetchInboxCounts.mockRejectedValue(new Error('backend down'));
+
+      renderHook(() => usePaData(), { wrapper });
+
+      // Backoff is attempt * 2000ms, so the four retries land at 2s, 4s, 6s and
+      // 8s -- 20s covers all of them with room to spare, and anything scheduled
+      // after the cap would fire well inside it.
+      await act(async () => {
+        await vi.advanceTimersByTimeAsync(20_000);
+      });
+
+      // One initial attempt plus MAX_COUNT_RETRIES.
+      expect(mocks.fetchInboxCounts).toHaveBeenCalledTimes(5);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it('stops retrying once the provider unmounts', async () => {
+    vi.useFakeTimers();
+    try {
+      mocks.fetchInboxCounts.mockRejectedValue(new Error('backend down'));
+
+      const { unmount } = renderHook(() => usePaData(), { wrapper });
+      await act(async () => {
+        await vi.advanceTimersByTimeAsync(0);
+      });
+      unmount();
+
+      const callsAtUnmount = mocks.fetchInboxCounts.mock.calls.length;
+      await act(async () => {
+        await vi.advanceTimersByTimeAsync(20_000);
+      });
+
+      // The cleanup flips `cancelled`, which is read inside the catch -- it does
+      // not clearTimeout the retry already scheduled before the unmount. So one
+      // in-flight attempt still fires and is then discarded, and the chain stops
+      // there rather than running out the full budget of five.
+      expect(mocks.fetchInboxCounts.mock.calls.length).toBeLessThanOrEqual(callsAtUnmount + 1);
+      expect(mocks.fetchInboxCounts.mock.calls.length).toBeLessThan(5);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it('does not apply counts that arrive after the provider unmounted', async () => {
+    let resolveCounts!: (v: Record<string, number>) => void;
+    mocks.fetchInboxCounts.mockReturnValue(
+      new Promise((resolve) => {
+        resolveCounts = resolve;
+      })
+    );
+    const errors: unknown[] = [];
+    const spy = vi.spyOn(console, 'error').mockImplementation((...args) => errors.push(args));
+
+    const { unmount } = renderHook(() => usePaData(), { wrapper });
+    unmount();
+    await act(async () => {
+      resolveCounts({ politiek: 3 });
+      await Promise.resolve();
+    });
+
+    expect(errors).toEqual([]);
+    spy.mockRestore();
+  });
+
   it('updateInboxCount sets a single tab count directly', async () => {
     const { result } = renderHook(() => usePaData(), { wrapper });
     await waitFor(() => expect(result.current.signals.status).toBe('ok'));

--- a/packages/pa-cockpit/src/pages/public-affairs-v2/dossierbeheer.data.test.ts
+++ b/packages/pa-cockpit/src/pages/public-affairs-v2/dossierbeheer.data.test.ts
@@ -1,0 +1,179 @@
+// packages/pa-cockpit/src/pages/public-affairs-v2/dossierbeheer.data.test.ts
+import { describe, it, expect } from 'vitest';
+import {
+  DB_BEWAARTERMIJNEN,
+  DB_CLASSIFICATIES,
+  DB_ROLES,
+  bewaartermijnLabel,
+  buildSeedAdminDossiers,
+  classificatieLabel,
+  deriveDossierRole,
+  expandVars,
+  todayLabel,
+  toMarkdown,
+  wordCount,
+} from './dossierbeheer.data';
+import type { Dossier } from '@ronl/shared';
+
+describe('deriveDossierRole', () => {
+  // The three roles are cumulative in practice (an admin's token carries the
+  // lower ones too), so the order of the checks is what decides which
+  // capability set the UI enables. A reversed order would silently demote
+  // every admin to author.
+  it('picks the highest role the token carries', () => {
+    expect(deriveDossierRole(['pa-author', 'pa-editor', 'pa-admin']).id).toBe(DB_ROLES[2].id);
+    expect(deriveDossierRole(['pa-author', 'pa-editor']).id).toBe(DB_ROLES[1].id);
+    expect(deriveDossierRole(['pa-author']).id).toBe(DB_ROLES[0].id);
+  });
+
+  it('falls back to a read-only pseudo-role for a token with none of them', () => {
+    const role = deriveDossierRole(['public-affairs']);
+    expect(role.can.create).toBe(false);
+    expect(role.can.edit).toBe(false);
+    expect(role.note).toMatch(/pa-author, pa-editor of pa-admin/);
+  });
+
+  it('ignores roles from other surfaces entirely', () => {
+    expect(deriveDossierRole([]).can.edit).toBe(false);
+    expect(deriveDossierRole(['realm-admin', 'caseworker']).can.edit).toBe(false);
+  });
+});
+
+describe('archival label lookups', () => {
+  it('resolves a known id to its label', () => {
+    expect(classificatieLabel(DB_CLASSIFICATIES[0].id)).toBe(DB_CLASSIFICATIES[0].label);
+    expect(bewaartermijnLabel(DB_BEWAARTERMIJNEN[0].id)).toBe(DB_BEWAARTERMIJNEN[0].label);
+  });
+
+  it('shows an em dash for an unset or unknown id, never the raw id', () => {
+    // These render straight into the dossier's archival panel; an unrecognised
+    // id leaking through would read as a classification that does not exist.
+    expect(classificatieLabel(undefined)).toBe('—');
+    expect(classificatieLabel('geen-idee')).toBe('—');
+    expect(bewaartermijnLabel(undefined)).toBe('—');
+    expect(bewaartermijnLabel('geen-idee')).toBe('—');
+  });
+});
+
+describe('expandVars', () => {
+  it('substitutes every supplied variable, everywhere it occurs', () => {
+    const out = expandVars('{{today}} — {{currentUser}} ({{department}}) · {{projectName}}', {
+      today: '8 jul 2026',
+      currentUser: 'Sanne Bakker',
+      department: 'Bestuur',
+      projectName: 'Stikstof',
+    });
+    expect(out).toBe('8 jul 2026 — Sanne Bakker (Bestuur) · Stikstof');
+  });
+
+  it('falls back to sensible defaults for an empty context', () => {
+    // A template inserted before the author has typed anything must not leave
+    // literal {{currentUser}} braces in the document.
+    const out = expandVars('[{{today}}][{{currentUser}}][{{department}}][{{projectName}}]', {});
+    expect(out).toBe(`[${todayLabel()}][][Public Affairs][]`);
+    expect(out).not.toContain('{{');
+  });
+
+  it('returns an empty document untouched', () => {
+    expect(expandVars('', { currentUser: 'x' })).toBe('');
+  });
+});
+
+describe('wordCount', () => {
+  it('counts across every field it is given', () => {
+    expect(wordCount('een twee', 'drie')).toBe(3);
+  });
+
+  it('is zero for empty fields', () => {
+    expect(wordCount('', '   ')).toBe(0);
+  });
+});
+
+describe('buildSeedAdminDossiers', () => {
+  it('gives every seeded dossier an owner, a last-edited label and three versions', () => {
+    const items = buildSeedAdminDossiers();
+    expect(items.length).toBeGreaterThan(0);
+    for (const d of items) {
+      expect(d.eigenaar).toBeTruthy();
+      expect(d.bewerkt).toBeTruthy();
+      expect(d.kompas).toBeDefined();
+    }
+  });
+
+  it('deep-copies each kompas so editing one dossier cannot mutate the seed', () => {
+    // The seed is a module-level constant shared by every consumer; a shallow
+    // copy here would make an edit in Dossierbeheer show up in Vandaag's
+    // scoring for the rest of the session.
+    const a = buildSeedAdminDossiers();
+    const b = buildSeedAdminDossiers();
+    expect(a[0].kompas).not.toBe(b[0].kompas);
+    expect(a[0].kompas).toEqual(b[0].kompas);
+  });
+});
+
+describe('toMarkdown', () => {
+  const dossier = (over: Partial<Dossier> = {}): Dossier =>
+    ({
+      id: 'd1',
+      naam: 'Test',
+      onderwerp: 'Test',
+      status: 'actief',
+      momentum: 'flat',
+      waaromNu: 'Omdat het nu speelt.',
+      waarover: 'Over de provinciale inzet.',
+      narratief: { onsVerhaal: 'Ons verhaal.', frames: [], tegenframes: [] },
+      kompas: {},
+      ...over,
+    }) as unknown as Dossier;
+
+  it('gives each filled-in field its own heading', () => {
+    const md = toMarkdown(dossier());
+    expect(md.waaromNu).toBe('## Waarom nu\n\nOmdat het nu speelt.\n');
+    expect(md.waarover).toBe('## Waarover\n\nOver de provinciale inzet.\n');
+    expect(md.onsVerhaal).toBe('## Ons verhaal\n\nOns verhaal.\n');
+  });
+
+  it('emits nothing at all for a field the author has not written yet', () => {
+    // A bare "## Waarom nu" with no body under it looks like content that was
+    // deleted rather than a section that was never started.
+    const md = toMarkdown(
+      dossier({
+        waaromNu: '',
+        waarover: '',
+        narratief: { onsVerhaal: '', frames: [], tegenframes: [] },
+      } as Partial<Dossier>)
+    );
+    expect(md).toEqual({ waaromNu: '', waarover: '', onsVerhaal: '' });
+  });
+
+  it('appends the frame and counter-frame lists under their own subheadings', () => {
+    const md = toMarkdown(
+      dossier({
+        narratief: {
+          onsVerhaal: 'Ons verhaal.',
+          frames: [{ text: 'Boeren betalen', meta: 'LTO, mei 2026', kind: 'frame' as const }],
+          tegenframes: [{ text: 'Natuur eerst', meta: 'NM, jun 2026', kind: 'tegen' as const }],
+        },
+      } as Partial<Dossier>)
+    );
+    expect(md.onsVerhaal).toContain('### Dominante frames');
+    expect(md.onsVerhaal).toContain('- Boeren betalen *(LTO, mei 2026)*');
+    expect(md.onsVerhaal).toContain('### Tegenframes');
+    expect(md.onsVerhaal).toContain('- Natuur eerst *(NM, jun 2026)*');
+  });
+
+  it('carries the frame lists even when there is no ons-verhaal text above them', () => {
+    const md = toMarkdown(
+      dossier({
+        narratief: {
+          onsVerhaal: '',
+          frames: [{ text: 'Boeren betalen', meta: 'LTO', kind: 'frame' as const }],
+          tegenframes: [],
+        },
+      } as Partial<Dossier>)
+    );
+    expect(md.onsVerhaal).toContain('### Dominante frames');
+    expect(md.onsVerhaal).not.toContain('## Ons verhaal');
+    expect(md.onsVerhaal).not.toContain('### Tegenframes');
+  });
+});

--- a/packages/pa-cockpit/src/pages/public-affairs-v2/dossierbeheer.data.ts
+++ b/packages/pa-cockpit/src/pages/public-affairs-v2/dossierbeheer.data.ts
@@ -181,7 +181,17 @@ const SEED_OWNERS: Record<string, string> = {
   oostvaarders: 'Team Omgeving',
 };
 
-function toMarkdown(d: Dossier): DossierMarkdown {
+/**
+ * Renders a dossier's three narrative fields as the Markdown the editor loads.
+ *
+ * Exported only so it can be tested directly. A dossier started from a blank
+ * template has empty strings in all three fields -- that is what the `? :`
+ * arms are for -- but all five MOCK_DOSSIERS carry filled-in text, so those
+ * arms are unreachable through buildSeedAdminDossiers(), the only other
+ * caller. Reaching them by blanking a seed dossier instead would mean editing
+ * shipped fixture data to serve a test.
+ */
+export function toMarkdown(d: Dossier): DossierMarkdown {
   const n = d.narratief ?? { onsVerhaal: '', frames: [], tegenframes: [] };
   let ons = n.onsVerhaal ? `## Ons verhaal\n\n${n.onsVerhaal}\n` : '';
   if (n.frames?.length) {

--- a/packages/pa-cockpit/src/pages/public-affairs-v2/kompas.test.ts
+++ b/packages/pa-cockpit/src/pages/public-affairs-v2/kompas.test.ts
@@ -17,3 +17,12 @@ describe('kompasBand boundaries', () => {
   it('14 → kern', () => expect(kompasBand(14).key).toBe('kern'));
   it('16 → kern', () => expect(kompasBand(16).key).toBe('kern'));
 });
+
+describe('kompasBand outside the scored range', () => {
+  it('falls back to the lowest band for a total below every threshold', () => {
+    // The bands are matched top-down by `total >= b.min`, so nothing matches a
+    // negative total. The fallback keeps a scorer bug from returning undefined
+    // and blanking the advice column instead of showing the mildest advice.
+    expect(kompasBand(-1).key).toBe('niet');
+  });
+});

--- a/packages/pa-cockpit/src/pages/public-affairs-v2/modes.gate.test.ts
+++ b/packages/pa-cockpit/src/pages/public-affairs-v2/modes.gate.test.ts
@@ -1,0 +1,79 @@
+// packages/pa-cockpit/src/pages/public-affairs-v2/modes.gate.test.ts
+import { describe, it, expect } from 'vitest';
+import { isPaItemVisible, type PaGateContext, type PaRailItem } from './modes.config';
+
+// The shell already gates the whole cockpit on the public-affairs realm role
+// and the province org type (see PADashboardV2), so no shipped rail item sets
+// these fields yet. That is exactly why they need their own tests: the gate is
+// the mechanism a future fine-grained item will rely on, and nothing else
+// exercises its three deny paths.
+const ctx = (over: Partial<PaGateContext> = {}): PaGateContext => ({
+  isAuthenticated: true,
+  userRoles: ['public-affairs'],
+  userOrgType: 'province',
+  ...over,
+});
+
+const item = (over: Partial<PaRailItem> = {}): PaRailItem => ({
+  id: 'vandaag',
+  label: 'Vandaag',
+  ...over,
+});
+
+describe('isPaItemVisible', () => {
+  it('shows an ungated item to anyone, signed in or not', () => {
+    expect(isPaItemVisible(item(), ctx())).toBe(true);
+    expect(isPaItemVisible(item(), ctx({ isAuthenticated: false, userRoles: [] }))).toBe(true);
+  });
+
+  it('hides an auth-required item from an anonymous visitor', () => {
+    expect(isPaItemVisible(item({ authRequired: true }), ctx({ isAuthenticated: false }))).toBe(
+      false
+    );
+    expect(isPaItemVisible(item({ authRequired: true }), ctx())).toBe(true);
+  });
+
+  it('requires at least one of the listed roles, not all of them', () => {
+    const gated = item({ requiredRoles: ['pa-admin', 'pa-editor'] });
+    expect(isPaItemVisible(gated, ctx({ userRoles: ['pa-editor'] }))).toBe(true);
+    expect(isPaItemVisible(gated, ctx({ userRoles: ['pa-author'] }))).toBe(false);
+    expect(isPaItemVisible(gated, ctx({ userRoles: [] }))).toBe(false);
+  });
+
+  it('ignores an empty requiredRoles list rather than hiding everything', () => {
+    // An item written with `requiredRoles: []` means "no role gate"; reading it
+    // as "no role satisfies this" would silently blank a rail entry.
+    expect(isPaItemVisible(item({ requiredRoles: [] }), ctx({ userRoles: [] }))).toBe(true);
+  });
+
+  it('requires a matching org type when one is listed', () => {
+    const gated = item({ requiredOrgTypes: ['province', 'national'] });
+    expect(isPaItemVisible(gated, ctx({ userOrgType: 'province' }))).toBe(true);
+    expect(isPaItemVisible(gated, ctx({ userOrgType: 'municipality' }))).toBe(false);
+  });
+
+  it('hides an org-gated item when the org type is unknown', () => {
+    // tenant config can be absent (not loaded, or a token with no org claim).
+    // Unknown must fail closed: showing a province-only surface to an
+    // unidentified tenant is the failure that matters here.
+    const gated = item({ requiredOrgTypes: ['province'] });
+    expect(isPaItemVisible(gated, ctx({ userOrgType: null }))).toBe(false);
+    expect(isPaItemVisible(gated, ctx({ userOrgType: undefined }))).toBe(false);
+  });
+
+  it('ignores an empty requiredOrgTypes list', () => {
+    expect(isPaItemVisible(item({ requiredOrgTypes: [] }), ctx({ userOrgType: null }))).toBe(true);
+  });
+
+  it('applies every gate, not just the first one that passes', () => {
+    const gated = item({
+      authRequired: true,
+      requiredRoles: ['pa-admin'],
+      requiredOrgTypes: ['province'],
+    });
+    expect(isPaItemVisible(gated, ctx({ userRoles: ['pa-admin'] }))).toBe(true);
+    expect(
+      isPaItemVisible(gated, ctx({ userRoles: ['pa-admin'], userOrgType: 'municipality' }))
+    ).toBe(false);
+  });
+});

--- a/packages/pa-cockpit/src/services/pa.api.test.ts
+++ b/packages/pa-cockpit/src/services/pa.api.test.ts
@@ -842,3 +842,198 @@ describe('host configuration', () => {
     await expect(api.fetchDossiers()).rejects.toThrow(/configurePaCockpit/);
   });
 });
+
+describe('authenticated requests', () => {
+  // Every verb goes through its own private helper (paGet / paGetRaw / paPost /
+  // paPatch / paDelete), each repeating the same two steps: refresh a token
+  // that is about to expire, then attach it. The default test state is
+  // anonymous, so without these the authenticated half of all five is never
+  // executed -- and an unauthenticated PA cockpit is not a thing that ships.
+  beforeEach(() => {
+    authState.authenticated = true;
+    authState.token = 'test-token';
+  });
+
+  const bearerOf = (req: Request) => req.headers.get('authorization');
+
+  it('refreshes and attaches the token on a GET', async () => {
+    let seen: string | null = null;
+    server.use(
+      http.get('*/pa/dossiers', ({ request }) => {
+        seen = bearerOf(request);
+        return HttpResponse.json({ success: true, data: [] });
+      })
+    );
+
+    const api = await freshApi({ dossiersMock: false });
+    await api.fetchDossiers();
+
+    expect(updateTokenMock).toHaveBeenCalledWith(120);
+    expect(seen).toBe('Bearer test-token');
+  });
+
+  it('attaches the token on a raw GET', async () => {
+    let seen: string | null = null;
+    server.use(
+      http.get('*/pa/signals', ({ request }) => {
+        seen = bearerOf(request);
+        return HttpResponse.json({
+          success: true,
+          data: [],
+          meta: { total: 0, cap: 100, capped: false },
+        });
+      })
+    );
+
+    const api = await freshApi({ signalsMock: false });
+    await api.fetchInbox();
+
+    expect(seen).toBe('Bearer test-token');
+  });
+
+  it('attaches the token on a POST', async () => {
+    let seen: string | null = null;
+    server.use(
+      http.post('*/pa/searches', ({ request }) => {
+        seen = bearerOf(request);
+        return HttpResponse.json({ success: true, data: { id: 'srch-1' } });
+      })
+    );
+
+    const api = await freshApi({ signalsMock: false });
+    await api.createSavedSearch({ q: 'stikstof' });
+
+    expect(seen).toBe('Bearer test-token');
+  });
+
+  it('attaches the token on a PATCH', async () => {
+    let seen: string | null = null;
+    server.use(
+      http.patch('*/pa/searches/s1', ({ request }) => {
+        seen = bearerOf(request);
+        return HttpResponse.json({ success: true, data: {} });
+      })
+    );
+
+    const api = await freshApi({ signalsMock: false });
+    await api.updateSearch('s1', { tags: ['x'] });
+
+    expect(seen).toBe('Bearer test-token');
+  });
+
+  it('attaches the token on a DELETE', async () => {
+    let seen: string | null = null;
+    server.use(
+      http.delete('*/pa/searches/s1', ({ request }) => {
+        seen = bearerOf(request);
+        return new HttpResponse(null, { status: 204 });
+      })
+    );
+
+    const api = await freshApi({ signalsMock: false });
+    await api.deleteSavedSearch('s1');
+
+    expect(seen).toBe('Bearer test-token');
+  });
+
+  it('sends the request anyway when the token refresh fails', async () => {
+    // A refresh failure means the session is probably gone, but the answer to
+    // that is the backend's 401 and the normal re-auth flow -- not a request
+    // this client silently never made.
+    updateTokenMock.mockRejectedValue(new Error('refresh failed'));
+    let seen: string | null = null;
+    server.use(
+      http.get('*/pa/dossiers', ({ request }) => {
+        seen = bearerOf(request);
+        return HttpResponse.json({ success: true, data: [] });
+      })
+    );
+
+    const api = await freshApi({ dossiersMock: false });
+    await expect(api.fetchDossiers()).resolves.toEqual([]);
+
+    expect(seen).toBe('Bearer test-token');
+  });
+
+  it('sends no Authorization header when there is no token to send', async () => {
+    authState.token = undefined;
+    let seen: string | null = null;
+    server.use(
+      http.get('*/pa/dossiers', ({ request }) => {
+        seen = bearerOf(request);
+        return HttpResponse.json({ success: true, data: [] });
+      })
+    );
+
+    const api = await freshApi({ dossiersMock: false });
+    await api.fetchDossiers();
+
+    expect(seen).toBeNull();
+  });
+});
+
+describe('mock-mode query parameters', () => {
+  it('fetchInbox filters the fixtures by tab and by dossier', async () => {
+    const api = await freshApi({ signalsMock: true });
+
+    const all = await api.fetchInbox();
+    expect(all.data.length).toBeGreaterThan(0);
+
+    const politiek = await api.fetchInbox({ tab: 'politiek' });
+    expect(politiek.data.every((s) => s.tab === 'politiek')).toBe(true);
+    expect(politiek.meta.total).toBe(politiek.data.length);
+
+    const nothing = await api.fetchInbox({ tab: 'politiek', dossierId: 'geen-dossier' });
+    expect(nothing.data).toEqual([]);
+  });
+
+  it('fetchFeed filters the fixtures by query text and by source', async () => {
+    const api = await freshApi({ signalsMock: true });
+
+    const both = await api.fetchFeed({});
+    expect(both.items.length).toBeGreaterThan(0);
+    expect(both.total).toBe(both.items.length);
+
+    const tkOnly = await api.fetchFeed({ source: 'tk' });
+    expect(tkOnly.items.every((i) => i.source === 'tk')).toBe(true);
+
+    const noMatch = await api.fetchFeed({ q: 'zzzzzzzz' });
+    expect(noMatch.items).toEqual([]);
+  });
+
+  it('promoteToInbox routes each source to its own inbox tab', async () => {
+    const api = await freshApi({ signalsMock: true });
+    const item = (over: Partial<FeedItem>): FeedItem =>
+      ({
+        id: 'f1',
+        title: 'Motie',
+        type: 'Motie',
+        number: '1',
+        date: null,
+        url: null,
+        source: 'tk',
+        ...over,
+      }) as FeedItem;
+
+    expect((await api.promoteToInbox(item({ source: 'tk' }))).tab).toBe('politiek');
+    expect((await api.promoteToInbox(item({ source: 'ob' }))).tab).toBe('regionaal');
+    expect((await api.promoteToInbox(item({ source: 'eu' }))).tab).toBe('europa');
+  });
+
+  it('promoteToInbox carries a reference only when the hit has a URL', async () => {
+    const api = await freshApi({ signalsMock: true });
+    const base = {
+      id: 'f1',
+      title: 'Motie',
+      type: 'Motie',
+      number: '1',
+      date: null,
+      source: 'tk' as const,
+    };
+
+    expect((await api.promoteToInbox({ ...base, url: null } as FeedItem)).ref).toBeNull();
+    expect((await api.promoteToInbox({ ...base, url: 'https://tk.nl/x' } as FeedItem)).ref).toEqual(
+      { type: 'Motie', nr: '1', url: 'https://tk.nl/x' }
+    );
+  });
+});

--- a/packages/pa-demo/src/demo/DemoRoleContext.test.tsx
+++ b/packages/pa-demo/src/demo/DemoRoleContext.test.tsx
@@ -1,5 +1,5 @@
 import { StrictMode } from 'react';
-import { describe, it, expect } from 'vitest';
+import { describe, it, expect, vi } from 'vitest';
 import { render, screen, act } from '@testing-library/react';
 import { DemoRoleProvider } from './DemoRoleContext';
 import { useDemoRole, DEMO_ROLE_OPTIONS, type DemoRoleId } from './demo-role';
@@ -91,5 +91,22 @@ describe('DemoRoleContext', () => {
     );
     act(() => setRole('redacteur'));
     expect(screen.getByTestId('roles')).toHaveTextContent('public-affairs,pa-editor');
+  });
+});
+
+describe('useDemoRole outside a provider', () => {
+  it('names the missing provider instead of returning null', () => {
+    // Without the guard this returns null and the first property read on it
+    // fails somewhere far away from the actual mistake.
+    const Bare = () => {
+      useDemoRole();
+      return null;
+    };
+    const spy = vi.spyOn(console, 'error').mockImplementation(() => {});
+    try {
+      expect(() => render(<Bare />)).toThrow('useDemoRole must be used inside DemoRoleProvider');
+    } finally {
+      spy.mockRestore();
+    }
   });
 });

--- a/packages/pa-demo/src/demo/Profiel.test.tsx
+++ b/packages/pa-demo/src/demo/Profiel.test.tsx
@@ -70,4 +70,18 @@ describe('Profiel', () => {
     expect(screen.getByText('Gemeente Teststad')).toBeInTheDocument();
     expect(screen.queryByText('Provincie')).toBeNull();
   });
+  it('falls back to a neutral label for an organisation type it does not know', () => {
+    // The vocabulary is not closed -- a waterschap or a shared service centre
+    // would arrive as its own type, and labelling one of those "Gemeente"
+    // is the mismatch this switch exists to avoid.
+    vi.mocked(getTenantConfig).mockReturnValueOnce({
+      id: 'hhnk',
+      displayName: 'Hoogheemraadschap Hollands Noorderkwartier',
+      organisationType: 'waterboard',
+    });
+    renderPage();
+    expect(screen.getByText('Organisatie')).toBeInTheDocument();
+    expect(screen.queryByText('Provincie')).toBeNull();
+    expect(screen.queryByText('Gemeente')).toBeNull();
+  });
 });

--- a/packages/public-site/src/lib/api.test.ts
+++ b/packages/public-site/src/lib/api.test.ts
@@ -53,4 +53,52 @@ describe('lib/api', () => {
     const { getRegelBySlug } = await import('./api');
     expect(await getRegelBySlug('nope')).toBeNull();
   });
+  it('uses a generic message when a failed response carries no error body', async () => {
+    mockFetchOnce(503, {});
+    const { getNieuws } = await import('./api');
+    await expect(getNieuws()).rejects.toThrow(/HTTP 503: request failed/);
+  });
+
+  it('uses a generic message when success:false carries no error body', async () => {
+    mockFetchOnce(200, { success: false });
+    const { getBerichten } = await import('./api');
+    await expect(getBerichten()).rejects.toThrow('Request failed');
+  });
+
+  it('still throws from a by-slug lookup when the failure is not a 404', async () => {
+    // getJSONOrNull treats only 404 as "normal absence"; a 500 is still a
+    // fault, and swallowing it would render an empty detail page instead.
+    mockFetchOnce(500, { success: false, error: { code: 'X', message: 'upstream down' } });
+    const { getRegelBySlug } = await import('./api');
+    await expect(getRegelBySlug('zorgtoeslag')).rejects.toThrow(/HTTP 500: upstream down/);
+  });
+
+  it('throws from a by-slug lookup on success:false with a 200', async () => {
+    mockFetchOnce(200, { success: false, error: { code: 'X', message: 'business error' } });
+    const { getProcesByKey } = await import('./api');
+    await expect(getProcesByKey('some-key')).rejects.toThrow('business error');
+  });
+
+  it('uses generic messages for a by-slug lookup with no error body', async () => {
+    mockFetchOnce(500, {});
+    const { getBerichtBySlug } = await import('./api');
+    await expect(getBerichtBySlug('x')).rejects.toThrow(/HTTP 500: request failed/);
+
+    mockFetchOnce(200, { success: false });
+    const { getNieuwsBySlug } = await import('./api');
+    await expect(getNieuwsBySlug('x')).rejects.toThrow('Request failed');
+  });
+
+  it('omits the query string entirely when every parameter is empty', async () => {
+    // An empty facet array must not produce `?soort=` -- the backend reads that
+    // as "filter to nothing" rather than "no filter".
+    mockFetchOnce(200, {
+      success: true,
+      data: { items: [], total: 0, facets: { soort: [], bron: [], doelgroep: [] } },
+    });
+    const { searchPublic } = await import('./api');
+    await searchPublic({ q: '', soort: [], bron: undefined });
+
+    expect(global.fetch).toHaveBeenCalledWith('http://localhost:3002/v1/public/zoeken');
+  });
 });

--- a/packages/public-site/src/lib/prerenderedData.test.ts
+++ b/packages/public-site/src/lib/prerenderedData.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, afterEach } from 'vitest';
+import { describe, it, expect, afterEach, vi } from 'vitest';
 import { readPrerenderedData } from './prerenderedData';
 
 function setBlob(content: string | null) {
@@ -40,5 +40,25 @@ describe('readPrerenderedData', () => {
     setBlob(JSON.stringify({ route: '/regels', data: { ok: true } }));
     expect(readPrerenderedData<{ ok: boolean }>('/regels')).toEqual({ ok: true });
     expect(readPrerenderedData<{ ok: boolean }>('/regels')).toEqual({ ok: true });
+  });
+
+  it('returns null when the blob names the route but carries no data', () => {
+    // The prerender step writes the envelope before it knows whether the route
+    // produced anything; a `data`-less blob must read as "nothing prerendered"
+    // rather than as `undefined` reaching a component's state.
+    setBlob(JSON.stringify({ route: '/regels' }));
+    expect(readPrerenderedData('/regels')).toBeNull();
+  });
+
+  it('returns null when there is no document at all (the prerender runtime)', () => {
+    // scripts/prerender.ts imports the same components this reader serves, in
+    // Node, where there is no DOM. The guard is what keeps that from throwing
+    // a ReferenceError during the build rather than at runtime in a browser.
+    vi.stubGlobal('document', undefined);
+    try {
+      expect(readPrerenderedData('/regels')).toBeNull();
+    } finally {
+      vi.unstubAllGlobals();
+    }
   });
 });

--- a/packages/public-site/src/pages/Detail.test.tsx
+++ b/packages/public-site/src/pages/Detail.test.tsx
@@ -8,7 +8,14 @@ import * as api from '../lib/api';
 
 vi.mock('../lib/api', async () => {
   const actual = await vi.importActual<typeof import('../lib/api')>('../lib/api');
-  return { ...actual, getRegelBySlug: vi.fn() };
+  return {
+    ...actual,
+    getRegelBySlug: vi.fn(),
+    getBerichtBySlug: vi.fn(),
+    getNieuwsBySlug: vi.fn(),
+    getProductBySlug: vi.fn(),
+    getProcesByKey: vi.fn(),
+  };
 });
 
 const t = translations.nl;
@@ -22,6 +29,42 @@ function renderAt(slug: string) {
     </MemoryRouter>
   );
 }
+
+// Same as renderAt, for the four other section types and either language --
+// loadDetail has a separate arm per type and each one shapes its own facts,
+// tech rows and API path.
+function renderTyped(
+  type: 'bericht' | 'nieuws' | 'product' | 'proces' | 'regel',
+  slug: string,
+  lang: 'nl' | 'en' = 'nl'
+) {
+  return render(
+    <MemoryRouter initialEntries={[`/x/${slug}`]}>
+      <Routes>
+        <Route
+          path="/x/:slug"
+          element={<Detail t={translations[lang]} lang={lang} type={type} />}
+        />
+      </Routes>
+    </MemoryRouter>
+  );
+}
+
+const hit = (over: Record<string, unknown> = {}) =>
+  ({
+    id: 'x',
+    slug: 'x',
+    type: 'regel',
+    title: 'Titel',
+    summary: 'Samenvatting',
+    org: 'Provincie Flevoland',
+    date: '2026-07-01',
+    external: null,
+    audience: [],
+    facts: [],
+    tech: [['api', '/v1/public/regelcatalogus/x']],
+    ...over,
+  }) as unknown as Awaited<ReturnType<typeof api.getRegelBySlug>>;
 
 beforeEach(() => vi.clearAllMocks());
 
@@ -113,5 +156,225 @@ describe('Detail (regel)', () => {
     vi.mocked(api.getRegelBySlug).mockResolvedValue(null);
     renderAt('nope');
     await waitFor(() => expect(screen.getByText(/niet gevonden/i)).toBeInTheDocument());
+  });
+});
+
+describe('Detail (bericht)', () => {
+  it('renders the announcement, its sender fact and its external link', async () => {
+    vi.mocked(api.getBerichtBySlug).mockResolvedValue({
+      id: 'b1',
+      subject: 'Wegwerkzaamheden N23',
+      preview: 'De N23 is dicht.',
+      content: null,
+      publishedAt: '2026-07-01',
+      sender: { id: 'pf', name: 'Provincie Flevoland' },
+    } as unknown as Awaited<ReturnType<typeof api.getBerichtBySlug>>);
+
+    renderTyped('bericht', 'b1');
+
+    expect(await screen.findByRole('heading', { level: 1 })).toHaveTextContent(
+      'Wegwerkzaamheden N23'
+    );
+    expect(screen.getByText('GET /v1/public/berichten/b1')).toBeInTheDocument();
+    // The sender is already the publisher line in the aside, so repeating it as
+    // a fact row would print the same name twice.
+    expect(screen.queryByText('Afzender')).not.toBeInTheDocument();
+    expect(screen.getAllByRole('link', { name: /flevoland\.nl/ }).length).toBeGreaterThan(0);
+  });
+
+  it('shows the not-found page for a bericht slug that does not resolve', async () => {
+    vi.mocked(api.getBerichtBySlug).mockResolvedValue(null);
+    renderTyped('bericht', 'gone');
+    expect(await screen.findByRole('heading', { level: 1 })).toHaveTextContent(
+      'Item niet gevonden'
+    );
+  });
+});
+
+describe('Detail (proces)', () => {
+  const proces = (over: Record<string, unknown> = {}) =>
+    ({
+      key: 'aanvraag',
+      naam: 'Aanvraag behandelen',
+      beschrijving: 'Beschrijving van het proces.',
+      gepubliceerd: '2026-07-01',
+      status: 'active',
+      forms: [{ id: 'f1', name: 'Aanvraagformulier' }],
+      documents: [{ id: 'd1', name: 'Beschikking' }],
+      subprocesses: [{ id: 's1', name: 'Sub', bpmnProcessId: 'sub', status: 'active' }],
+      ...over,
+    }) as unknown as Awaited<ReturnType<typeof api.getProcesByKey>>;
+
+  it('counts the parts of the process', async () => {
+    vi.mocked(api.getProcesByKey).mockResolvedValue(proces());
+
+    renderTyped('proces', 'aanvraag');
+
+    expect(await screen.findByText('Onderdelen van dit proces')).toBeInTheDocument();
+    expect(screen.getByText(/1\s*formulieren/)).toBeInTheDocument();
+    expect(screen.getByText(/1\s*documentsjablonen/)).toBeInTheDocument();
+    expect(screen.getByText(/1\s*subprocessen/)).toBeInTheDocument();
+    expect(screen.getByText('Proceskey')).toBeInTheDocument();
+  });
+
+  it('counts zero parts, in English, when the engine returned none of them', async () => {
+    // An older deployment index omits these arrays entirely rather than
+    // sending empty ones; the page must say "0", not crash on undefined.
+    vi.mocked(api.getProcesByKey).mockResolvedValue(
+      proces({
+        beschrijving: null,
+        forms: undefined,
+        documents: undefined,
+        subprocesses: undefined,
+      })
+    );
+
+    renderTyped('proces', 'aanvraag', 'en');
+
+    expect(await screen.findByText('Parts of this process')).toBeInTheDocument();
+    expect(screen.getByText(/0\s*forms/)).toBeInTheDocument();
+    expect(screen.getByText(/0\s*document templates/)).toBeInTheDocument();
+    expect(screen.getByText(/0\s*subprocesses/)).toBeInTheDocument();
+  });
+
+  it('shows the not-found page for a process key that does not resolve', async () => {
+    vi.mocked(api.getProcesByKey).mockResolvedValue(null);
+    renderTyped('proces', 'gone', 'en');
+    expect(await screen.findByRole('heading', { level: 1 })).toHaveTextContent('Item not found');
+  });
+});
+
+describe('Detail (nieuws and product)', () => {
+  it('fetches nieuws through getNieuwsBySlug and links out to the source', async () => {
+    vi.mocked(api.getNieuwsBySlug).mockResolvedValue(
+      hit({ type: 'nieuws', title: 'Nieuw beleid', external: 'rijksoverheid.nl' })
+    );
+
+    renderTyped('nieuws', 'n1');
+
+    expect(await screen.findByRole('heading', { level: 1 })).toHaveTextContent('Nieuw beleid');
+    expect(screen.getAllByRole('link', { name: /rijksoverheid\.nl/ }).length).toBeGreaterThan(0);
+    expect(api.getNieuwsBySlug).toHaveBeenCalledWith('n1');
+  });
+
+  it('fetches product through getProductBySlug and explains the procedure', async () => {
+    vi.mocked(api.getProductBySlug).mockResolvedValue(
+      hit({ type: 'product', title: 'Vergunning' })
+    );
+
+    renderTyped('product', 'p1');
+
+    expect(await screen.findByText('Wat u moet weten')).toBeInTheDocument();
+    expect(screen.getByText(/valt onder de Omgevingswet/)).toBeInTheDocument();
+    expect(screen.getByText(/via het Omgevingsloket/)).toBeInTheDocument();
+    expect(screen.getByText(/Algemene wet bestuursrecht/)).toBeInTheDocument();
+    expect(api.getProductBySlug).toHaveBeenCalledWith('p1');
+  });
+
+  it('translates the whole procedure block', async () => {
+    vi.mocked(api.getProductBySlug).mockResolvedValue(hit({ type: 'product', title: 'Permit' }));
+
+    renderTyped('product', 'p1', 'en');
+
+    expect(await screen.findByText('What you need to know')).toBeInTheDocument();
+    expect(screen.getByText(/falls under the Environment Act/)).toBeInTheDocument();
+    expect(screen.getByText(/through the Omgevingsloket/)).toBeInTheDocument();
+    expect(screen.getByText(/General Administrative Law Act/)).toBeInTheDocument();
+  });
+});
+
+describe('Detail, shared chrome', () => {
+  it('shows the loading placeholder in English before anything resolves', () => {
+    vi.mocked(api.getRegelBySlug).mockReturnValue(new Promise(() => {}));
+    renderTyped('regel', 'x', 'en');
+    expect(screen.getByText('Loading…')).toBeInTheDocument();
+  });
+
+  it('truncates an over-long title in the breadcrumb but not in the heading', async () => {
+    const long = 'Regeling met een uitzonderlijk lange titel die de kruimelpad-limiet passeert';
+    vi.mocked(api.getRegelBySlug).mockResolvedValue(hit({ title: long }));
+
+    renderAt('x');
+
+    expect(await screen.findByRole('heading', { level: 1 })).toHaveTextContent(long);
+    expect(screen.getByText(`${long.slice(0, 46)}…`)).toBeInTheDocument();
+  });
+
+  it('omits the date lines entirely when the item carries no date', async () => {
+    vi.mocked(api.getRegelBySlug).mockResolvedValue(hit({ date: null }));
+
+    renderAt('x');
+
+    await screen.findByRole('heading', { level: 1 });
+    expect(screen.queryByText(t.updated)).not.toBeInTheDocument();
+  });
+
+  it('falls back to an empty API path when the item carries no api tech row', async () => {
+    vi.mocked(api.getRegelBySlug).mockResolvedValue(hit({ tech: [['engine', 'DMN 1.3']] }));
+
+    renderAt('x');
+
+    await screen.findByRole('heading', { level: 1 });
+    expect(screen.getByText('GET')).toBeInTheDocument();
+  });
+});
+
+describe('Detail (regel), rules and concepts', () => {
+  it('states the rule count in prose when the catalogue returned no rule rows', async () => {
+    vi.mocked(api.getRegelBySlug).mockResolvedValue(hit({ ruleCount: 7, rules: [] }));
+
+    renderAt('x');
+
+    expect(
+      await screen.findByText(/Deze dienst bevat 7 gepubliceerde regels\./)
+    ).toBeInTheDocument();
+  });
+
+  it('translates the rule-count prose', async () => {
+    vi.mocked(api.getRegelBySlug).mockResolvedValue(hit({ ruleCount: 7, rules: [] }));
+
+    renderTyped('regel', 'x', 'en');
+
+    expect(await screen.findByText(/This service holds 7 published rules\./)).toBeInTheDocument();
+  });
+
+  it('renders an undated rule with an em dash', async () => {
+    vi.mocked(api.getRegelBySlug).mockResolvedValue(
+      hit({ ruleCount: 1, rules: [{ naam: 'Ongedateerde regel', geldig: null }] })
+    );
+
+    renderAt('x');
+
+    expect(await screen.findByText('Ongedateerde regel')).toBeInTheDocument();
+    expect(screen.getByRole('cell', { name: '—' })).toBeInTheDocument();
+  });
+
+  it('links each concept out to Skosmos in the current language', async () => {
+    vi.mocked(api.getRegelBySlug).mockResolvedValue(
+      hit({
+        ruleCount: 1,
+        rules: [{ naam: 'R', geldig: '2026-01-01' }],
+        begrippen: ['Toetsingsinkomen'],
+      })
+    );
+
+    renderTyped('regel', 'x', 'en');
+
+    const link = await screen.findByRole('link', { name: 'Toetsingsinkomen' });
+    expect(link).toHaveAttribute(
+      'href',
+      'https://skosmos.open-regels.nl/ronl/en/search?q=Toetsingsinkomen'
+    );
+  });
+
+  it('omits the concepts block when the service has none', async () => {
+    vi.mocked(api.getRegelBySlug).mockResolvedValue(
+      hit({ ruleCount: 1, rules: [{ naam: 'R', geldig: '2026-01-01' }], begrippen: [] })
+    );
+
+    renderAt('x');
+
+    await screen.findByText('R');
+    expect(screen.queryByText(new RegExp(t.conceptsIn))).not.toBeInTheDocument();
   });
 });

--- a/packages/public-site/src/pages/Home.test.tsx
+++ b/packages/public-site/src/pages/Home.test.tsx
@@ -1,0 +1,154 @@
+// packages/public-site/src/pages/Home.test.tsx
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, waitFor, fireEvent } from '@testing-library/react';
+import { MemoryRouter } from 'react-router-dom';
+import Home from './Home';
+import { translations } from '../i18n';
+import * as api from '../lib/api';
+
+const navigate = vi.fn();
+vi.mock('react-router-dom', async () => {
+  const actual = await vi.importActual<typeof import('react-router-dom')>('react-router-dom');
+  return { ...actual, useNavigate: () => navigate };
+});
+
+vi.mock('../lib/api', async () => {
+  const actual = await vi.importActual<typeof import('../lib/api')>('../lib/api');
+  return {
+    ...actual,
+    getBerichten: vi.fn(),
+    getNieuws: vi.fn(),
+    getProducten: vi.fn(),
+    getRegelcatalogus: vi.fn(),
+    getProcessen: vi.fn(),
+  };
+});
+
+function allSourcesRespond() {
+  vi.mocked(api.getBerichten).mockResolvedValue({ items: [], total: 12 });
+  vi.mocked(api.getNieuws).mockResolvedValue({ items: [], total: 34 });
+  vi.mocked(api.getProducten).mockResolvedValue({ items: [], total: 56 });
+  vi.mocked(api.getRegelcatalogus).mockResolvedValue({
+    services: [{ id: 's1' }, { id: 's2' }],
+    organizations: [],
+    concepts: [],
+    rules: [],
+  } as unknown as api.RegelcatalogusData);
+  vi.mocked(api.getProcessen).mockResolvedValue([
+    { key: 'p1' },
+    { key: 'p2' },
+    { key: 'p3' },
+  ] as unknown as api.PublicProcess[]);
+}
+
+const renderHome = (lang: 'nl' | 'en' = 'nl') =>
+  render(
+    <MemoryRouter>
+      <Home t={translations[lang]} lang={lang} />
+    </MemoryRouter>
+  );
+
+beforeEach(() => vi.clearAllMocks());
+
+describe('Home', () => {
+  it('shows a per-source item count once every source has answered', async () => {
+    allSourcesRespond();
+    renderHome();
+
+    await waitFor(() => expect(screen.getByText(/^12 items/)).toBeInTheDocument());
+    for (const n of ['12', '34', '56', '2', '3']) {
+      expect(screen.getByText(new RegExp(`^${n} items`))).toBeInTheDocument();
+    }
+  });
+
+  it('reports zero for a source that failed, and the real count for the rest', async () => {
+    // Promise.allSettled, not Promise.all: one dead upstream must not blank out
+    // the whole card grid. A failed source reads as 0, which is the honest
+    // answer for "how many of these can this site show you right now".
+    allSourcesRespond();
+    vi.mocked(api.getNieuws).mockRejectedValue(new Error('rijksoverheid down'));
+    vi.mocked(api.getProcessen).mockRejectedValue(new Error('camunda down'));
+    renderHome();
+
+    await waitFor(() => expect(screen.getByText(/^12 items/)).toBeInTheDocument());
+    expect(screen.getAllByText(/^0 items/)).toHaveLength(2);
+  });
+
+  it('still renders every card when all five sources fail', async () => {
+    vi.mocked(api.getBerichten).mockRejectedValue(new Error('down'));
+    vi.mocked(api.getNieuws).mockRejectedValue(new Error('down'));
+    vi.mocked(api.getProducten).mockRejectedValue(new Error('down'));
+    vi.mocked(api.getRegelcatalogus).mockRejectedValue(new Error('down'));
+    vi.mocked(api.getProcessen).mockRejectedValue(new Error('down'));
+    renderHome();
+
+    await waitFor(() => expect(screen.getAllByText(/^0 items/)).toHaveLength(5));
+  });
+
+  it('does not set state after the page has been navigated away from', async () => {
+    // The counts land well after first paint, and a visitor who clicks through
+    // immediately unmounts this page mid-flight. Without the cancelled guard
+    // React logs a state-update-on-unmounted-component warning on every such
+    // click, which is how a real leak would be hidden in the noise.
+    const errors: unknown[] = [];
+    const spy = vi.spyOn(console, 'error').mockImplementation((...args) => errors.push(args));
+    let resolveBerichten!: (v: { items: never[]; total: number }) => void;
+    vi.mocked(api.getBerichten).mockReturnValue(
+      new Promise((resolve) => {
+        resolveBerichten = resolve;
+      })
+    );
+    vi.mocked(api.getNieuws).mockResolvedValue({ items: [], total: 0 });
+    vi.mocked(api.getProducten).mockResolvedValue({ items: [], total: 0 });
+    vi.mocked(api.getRegelcatalogus).mockResolvedValue({
+      services: [],
+      organizations: [],
+      concepts: [],
+      rules: [],
+    } as unknown as api.RegelcatalogusData);
+    vi.mocked(api.getProcessen).mockResolvedValue([]);
+
+    const { unmount } = renderHome();
+    unmount();
+    resolveBerichten({ items: [], total: 12 });
+    await new Promise((r) => setTimeout(r, 0));
+
+    expect(errors).toEqual([]);
+    spy.mockRestore();
+  });
+
+  it('shows a placeholder rather than a zero while the counts are still loading', () => {
+    // A zero here would be a wrong statement of fact, not a neutral default --
+    // and it is the first thing a visitor reads on the page.
+    allSourcesRespond();
+    renderHome();
+    expect(screen.getAllByText(/^… items/).length).toBeGreaterThan(0);
+  });
+
+  it('navigates to the search route with the query encoded', () => {
+    allSourcesRespond();
+    renderHome();
+
+    fireEvent.change(screen.getByLabelText(translations.nl.searchLabel), {
+      target: { value: 'groen & blauw' },
+    });
+    fireEvent.click(screen.getByRole('button', { name: new RegExp(translations.nl.search) }));
+
+    expect(navigate).toHaveBeenCalledWith('/zoeken?q=groen%20%26%20blauw');
+  });
+
+  it('navigates to the bare search route for an empty query', () => {
+    allSourcesRespond();
+    renderHome();
+
+    fireEvent.click(screen.getByRole('button', { name: new RegExp(translations.nl.search) }));
+
+    expect(navigate).toHaveBeenCalledWith('/zoeken');
+  });
+
+  it('renders the search hint in English when lang=en', () => {
+    allSourcesRespond();
+    renderHome('en');
+    expect(screen.getByText(/Searches all five sources at once/)).toBeInTheDocument();
+  });
+});

--- a/packages/public-site/src/pages/Regelcatalogus.test.tsx
+++ b/packages/public-site/src/pages/Regelcatalogus.test.tsx
@@ -58,12 +58,22 @@ beforeEach(() => {
   vi.mocked(api.getRegelcatalogus).mockResolvedValue(DATA);
 });
 
-function renderPage() {
+function renderPage(lang: 'nl' | 'en' = 'nl') {
   return render(
     <MemoryRouter>
-      <Regelcatalogus t={t} lang="nl" />
+      <Regelcatalogus t={translations[lang]} lang={lang} />
     </MemoryRouter>
   );
+}
+
+function setBlob(content: string | null) {
+  document.getElementById('__PUB_DATA__')?.remove();
+  if (content === null) return;
+  const el = document.createElement('script');
+  el.id = '__PUB_DATA__';
+  el.type = 'application/json';
+  el.textContent = content;
+  document.body.appendChild(el);
 }
 
 describe('Regelcatalogus', () => {
@@ -279,5 +289,138 @@ describe('Regelcatalogus', () => {
     expect(dienstSelectAgain).toHaveValue('Kapvergunning');
     expect(screen.queryByText('Toetsingsinkomen')).not.toBeInTheDocument();
     expect(screen.getByText('Vervangingsplicht')).toBeInTheDocument();
+  });
+  it('renders straight from the prerendered blob, without fetching', async () => {
+    // The whole point of the blob is that /regels paints its full catalogue on
+    // the first frame. A fetch here would mean the placeholder is still shown
+    // first, which is the layout shift this page was measured on.
+    setBlob(JSON.stringify({ route: '/regels', data: DATA }));
+    try {
+      renderPage();
+      expect(screen.getByRole('tab', { name: /Organisaties/ })).toBeInTheDocument();
+      expect(screen.queryByText('Laden…')).not.toBeInTheDocument();
+      await waitFor(() => expect(api.getRegelcatalogus).not.toHaveBeenCalled());
+    } finally {
+      setBlob(null);
+    }
+  });
+
+  it('translates the loading placeholder on a cold load', () => {
+    vi.mocked(api.getRegelcatalogus).mockReturnValue(new Promise(() => {}));
+    renderPage('en');
+    expect(screen.getByText('Loading…')).toBeInTheDocument();
+  });
+
+  it('Diensten tab lists every service, including one with no rules', async () => {
+    renderPage();
+    fireEvent.click(await screen.findByRole('tab', { name: /Diensten/ }));
+    expect(screen.getByText('Geen regels dienst')).toBeInTheDocument();
+    expect(screen.getAllByText('Zorgtoeslag').length).toBeGreaterThan(0);
+  });
+
+  it('Rules tab: clicking an open service summary closes it again', async () => {
+    renderPage();
+    fireEvent.click(await screen.findByRole('tab', { name: /Regels/ }));
+    const summary = screen.getByText('Zorgtoeslag').closest('summary')!;
+
+    fireEvent.click(summary);
+    expect(summary.closest('details')).toHaveAttribute('open');
+
+    fireEvent.click(summary);
+    expect(summary.closest('details')).not.toHaveAttribute('open');
+  });
+
+  it('Rules tab: an expanded rule description collapses again on a second click', async () => {
+    vi.mocked(api.getRegelcatalogus).mockResolvedValue({
+      ...DATA,
+      rules: [
+        {
+          serviceTitle: 'Zorgtoeslag',
+          ruleTitle: 'Recht op zorgtoeslag',
+          validFrom: '2026-01-01',
+          confidence: 'high',
+          description: 'De verzekerde heeft recht op zorgtoeslag.',
+        },
+      ],
+    });
+    renderPage();
+    fireEvent.click(await screen.findByRole('tab', { name: /Regels/ }));
+    fireEvent.click(screen.getByText('Zorgtoeslag').closest('summary')!);
+
+    const toggle = screen.getByRole('button', { name: /Recht op zorgtoeslag/ });
+    fireEvent.click(toggle);
+    expect(screen.getByText(/De verzekerde heeft recht/)).toBeInTheDocument();
+
+    fireEvent.click(toggle);
+    expect(screen.queryByText(/De verzekerde heeft recht/)).not.toBeInTheDocument();
+  });
+
+  it('Rules tab: the filter opens every matching service and hides the rest', async () => {
+    renderPage();
+    fireEvent.click(await screen.findByRole('tab', { name: /Regels/ }));
+
+    fireEvent.change(screen.getByLabelText(t.filterRule), { target: { value: 'leeftijd' } });
+
+    // A filtered accordion opens itself -- a hit the reader has to click to see
+    // would defeat the filter.
+    const details = screen.getByText('Zorgtoeslag').closest('details')!;
+    expect(details).toHaveAttribute('open');
+    expect(screen.getByText('Leeftijdseis 18 jaar')).toBeInTheDocument();
+    expect(screen.queryByText('Recht op zorgtoeslag')).not.toBeInTheDocument();
+  });
+
+  it('Rules tab: a service with no matching rule disappears entirely while filtering', async () => {
+    renderPage();
+    fireEvent.click(await screen.findByRole('tab', { name: /Regels/ }));
+
+    fireEvent.change(screen.getByLabelText(t.filterRule), { target: { value: 'zzzz' } });
+
+    expect(screen.queryByText('Zorgtoeslag')).not.toBeInTheDocument();
+  });
+
+  it('Rules tab: a rule with no start date shows an em dash, not an empty cell', async () => {
+    vi.mocked(api.getRegelcatalogus).mockResolvedValue({
+      ...DATA,
+      rules: [
+        {
+          serviceTitle: 'Zorgtoeslag',
+          ruleTitle: 'Ongedateerde regel',
+          validFrom: null,
+          confidence: null,
+          description: null,
+        },
+      ],
+    });
+    renderPage();
+    fireEvent.click(await screen.findByRole('tab', { name: /Regels/ }));
+    fireEvent.click(screen.getByText('Zorgtoeslag').closest('summary')!);
+
+    expect(screen.getByRole('cell', { name: '—' })).toBeInTheDocument();
+  });
+
+  it('Rules tab: links on to the service page, in English', async () => {
+    renderPage('en');
+    fireEvent.click(await screen.findByRole('tab', { name: /Rules/ }));
+    fireEvent.click(screen.getByText('Zorgtoeslag').closest('summary')!);
+
+    expect(screen.getByRole('link', { name: /Go to the service/ })).toBeInTheDocument();
+  });
+
+  it('Concepts tab: the text filter narrows the rows, and reports the count in English', async () => {
+    renderPage('en');
+    fireEvent.click(await screen.findByRole('tab', { name: /Concepts/ }));
+
+    expect(screen.getByText(/of 1 concepts/)).toBeInTheDocument();
+    expect(screen.getByRole('link', { name: 'Data dictionary' })).toBeInTheDocument();
+
+    fireEvent.change(screen.getByLabelText(translations.en.filterConcept), {
+      target: { value: 'zzzz' },
+    });
+    expect(screen.queryByText('Toetsingsinkomen')).not.toBeInTheDocument();
+
+    fireEvent.change(screen.getByLabelText(translations.en.filterConcept), {
+      target: { value: 'toetsing' },
+    });
+    expect(screen.getByText('Toetsingsinkomen')).toBeInTheDocument();
   });
 });

--- a/packages/public-site/src/pages/Results.test.tsx
+++ b/packages/public-site/src/pages/Results.test.tsx
@@ -13,13 +13,19 @@ vi.mock('../lib/api', async () => {
 
 const t = translations.nl;
 
-function renderAt(path: string) {
+function renderAt(path: string, lang: 'nl' | 'en' = 'nl') {
   return render(
     <MemoryRouter initialEntries={[path]}>
-      <Results t={t} lang="nl" />
+      <Results t={translations[lang]} lang={lang} />
     </MemoryRouter>
   );
 }
+
+const emptyResult = {
+  items: [],
+  total: 0,
+  facets: { soort: [], bron: [], doelgroep: [] },
+} as unknown as Awaited<ReturnType<typeof api.searchPublic>>;
 
 beforeEach(() => vi.clearAllMocks());
 
@@ -105,5 +111,88 @@ describe('Results', () => {
         expect.objectContaining({ q: 'zorg', soort: [], bron: [], doelgroep: [] })
       )
     );
+  });
+  it('reports a failed search in an alert instead of an empty result list', async () => {
+    // A zero here would say "we looked and there is nothing", which is a
+    // different and wrong claim when the backend never answered.
+    vi.mocked(api.searchPublic).mockRejectedValue(new Error('backend down'));
+
+    renderAt('/zoeken?q=zorg');
+
+    await waitFor(() => expect(screen.getByRole('alert')).toHaveTextContent('Zoeken is mislukt.'));
+  });
+
+  it('translates the failure message', async () => {
+    vi.mocked(api.searchPublic).mockRejectedValue(new Error('backend down'));
+
+    renderAt('/zoeken?q=zorg', 'en');
+
+    await waitFor(() => expect(screen.getByRole('alert')).toHaveTextContent('Search failed.'));
+  });
+
+  it('reports zero results, not a blank, when a failed search left no data', async () => {
+    vi.mocked(api.searchPublic).mockRejectedValue(new Error('backend down'));
+
+    renderAt('/zoeken?q=zorg');
+
+    await waitFor(() => expect(screen.getByRole('alert')).toBeInTheDocument());
+    expect(screen.getByText(/^0 /)).toBeInTheDocument();
+  });
+
+  it('translates the searching placeholder', () => {
+    vi.mocked(api.searchPublic).mockReturnValue(new Promise(() => {}));
+
+    renderAt('/zoeken?q=zorg', 'en');
+
+    expect(screen.getByText('Searching…')).toBeInTheDocument();
+  });
+
+  it('unchecking an already-selected facet removes it from the URL', async () => {
+    vi.mocked(api.searchPublic).mockResolvedValue({
+      ...emptyResult,
+      facets: { soort: [['regel', 3]], bron: [], doelgroep: [] },
+    } as unknown as Awaited<ReturnType<typeof api.searchPublic>>);
+
+    renderAt('/zoeken?q=zorg&soort=regel');
+
+    const checkbox = await screen.findByRole('checkbox', { name: /Regel/ });
+    expect(checkbox).toBeChecked();
+    fireEvent.click(checkbox);
+
+    await waitFor(() =>
+      expect(vi.mocked(api.searchPublic).mock.calls.at(-1)![0].soort).toEqual([])
+    );
+  });
+
+  it('shows a facet value the label table does not know, verbatim', async () => {
+    // The soort facet is built from whatever the backend returns; a new source
+    // type must show up as itself rather than disappear from the filter list.
+    vi.mocked(api.searchPublic).mockResolvedValue({
+      ...emptyResult,
+      facets: { soort: [['verordening', 2]], bron: [], doelgroep: [] },
+    } as unknown as Awaited<ReturnType<typeof api.searchPublic>>);
+
+    renderAt('/zoeken?q=zorg');
+
+    expect(await screen.findByRole('checkbox', { name: /verordening/ })).toBeInTheDocument();
+  });
+
+  it('does not set state after the results page has been navigated away from', async () => {
+    const errors: unknown[] = [];
+    const spy = vi.spyOn(console, 'error').mockImplementation((...args) => errors.push(args));
+    let resolveSearch!: (v: Awaited<ReturnType<typeof api.searchPublic>>) => void;
+    vi.mocked(api.searchPublic).mockReturnValue(
+      new Promise((resolve) => {
+        resolveSearch = resolve;
+      })
+    );
+
+    const { unmount } = renderAt('/zoeken?q=zorg');
+    unmount();
+    resolveSearch(emptyResult);
+    await new Promise((r) => setTimeout(r, 0));
+
+    expect(errors).toEqual([]);
+    spy.mockRestore();
   });
 });

--- a/packages/public-site/src/pages/SectionIndex.test.tsx
+++ b/packages/public-site/src/pages/SectionIndex.test.tsx
@@ -8,7 +8,13 @@ import * as api from '../lib/api';
 
 vi.mock('../lib/api', async () => {
   const actual = await vi.importActual<typeof import('../lib/api')>('../lib/api');
-  return { ...actual, getBerichten: vi.fn() };
+  return {
+    ...actual,
+    getBerichten: vi.fn(),
+    getNieuws: vi.fn(),
+    getProducten: vi.fn(),
+    getProcessen: vi.fn(),
+  };
 });
 
 const t = translations.nl;
@@ -149,5 +155,94 @@ describe('SectionIndex — prerendered seeding', () => {
       expect(screen.getByRole('link', { name: /Fetched bericht/ })).toBeInTheDocument()
     );
     expect(api.getBerichten).toHaveBeenCalled();
+  });
+});
+
+describe('SectionIndex, one loader per section type', () => {
+  // loadItems switches on the section type; each arm calls a different endpoint
+  // with its own page size and its own mapper. A wrong arm shows the wrong
+  // list on a route that otherwise looks correct, so each is pinned here.
+  const renderFor = (type: 'nieuws' | 'product' | 'proces' | 'regel') =>
+    render(
+      <MemoryRouter>
+        <SectionIndex t={t} lang="nl" type={type} />
+      </MemoryRouter>
+    );
+
+  it('loads nieuws from getNieuws', async () => {
+    vi.mocked(api.getNieuws).mockResolvedValue({
+      items: [
+        {
+          id: 'n1',
+          title: 'Nieuw beleid',
+          summary: 'Samenvatting',
+          source: { id: 'ro', name: 'Rijksoverheid' },
+          publishedAt: '2026-07-01',
+        },
+      ],
+      total: 1,
+    } as unknown as Awaited<ReturnType<typeof api.getNieuws>>);
+
+    renderFor('nieuws');
+
+    await waitFor(() => expect(screen.getByText('1 items')).toBeInTheDocument());
+    expect(api.getNieuws).toHaveBeenCalledWith(200);
+  });
+
+  it('loads producten from getProducten', async () => {
+    vi.mocked(api.getProducten).mockResolvedValue({
+      items: [
+        {
+          id: 'p1',
+          title: 'Paspoort aanvragen',
+          description: 'Beschrijving',
+          modified: '2026-07-01',
+          audience: [],
+        },
+      ],
+      total: 1,
+    } as unknown as Awaited<ReturnType<typeof api.getProducten>>);
+
+    renderFor('product');
+
+    await waitFor(() => expect(screen.getByText('1 items')).toBeInTheDocument());
+    expect(api.getProducten).toHaveBeenCalledWith(200);
+  });
+
+  it('loads processen from getProcessen', async () => {
+    vi.mocked(api.getProcessen).mockResolvedValue([
+      {
+        key: 'proc-1',
+        naam: 'Aanvraag behandelen',
+        beschrijving: null,
+        gepubliceerd: '2026-07-01',
+      },
+    ] as unknown as Awaited<ReturnType<typeof api.getProcessen>>);
+
+    renderFor('proces');
+
+    await waitFor(() => expect(screen.getByText('1 items')).toBeInTheDocument());
+    expect(api.getProcessen).toHaveBeenCalled();
+  });
+
+  it('renders the regel section empty, because Regelcatalogus owns that type', async () => {
+    renderFor('regel');
+
+    await waitFor(() => expect(screen.getByText('0 items')).toBeInTheDocument());
+    expect(api.getBerichten).not.toHaveBeenCalled();
+    expect(api.getNieuws).not.toHaveBeenCalled();
+    expect(api.getProducten).not.toHaveBeenCalled();
+    expect(api.getProcessen).not.toHaveBeenCalled();
+  });
+
+  it('translates the loading placeholder', () => {
+    // Never resolves, so the placeholder is what is on screen.
+    vi.mocked(api.getBerichten).mockReturnValue(new Promise(() => {}));
+    render(
+      <MemoryRouter>
+        <SectionIndex t={t} lang="en" type="bericht" />
+      </MemoryRouter>
+    );
+    expect(screen.getByText('Loading…')).toBeInTheDocument();
   });
 });

--- a/packages/public-site/src/pages/herkomst/HerkomstTrace.test.tsx
+++ b/packages/public-site/src/pages/herkomst/HerkomstTrace.test.tsx
@@ -99,4 +99,25 @@ describe('HerkomstTrace', () => {
     leftCells.forEach((cell) => expect(cell.getAttribute('role')).toBe('group'));
     rightCells.forEach((cell) => expect(cell.getAttribute('role')).toBe('group'));
   });
+  it('says so explicitly when a concept has nothing to ask the citizen', () => {
+    // datumberekening is derived inside the process, so its uitvraag list is
+    // empty. An empty column would read as "not filled in yet"; the fallback
+    // states the reason instead.
+    render(
+      <HerkomstTrace id="datumberekening" t={HERKOMST_STRINGS.nl} lang="nl" onOpen={vi.fn()} />
+    );
+    expect(screen.getByText(/dit gegeven ontstaat in het proces zelf/)).toBeInTheDocument();
+  });
+
+  it('translates the nothing-to-ask fallback', () => {
+    render(
+      <HerkomstTrace id="datumberekening" t={HERKOMST_STRINGS.en} lang="en" onOpen={vi.fn()} />
+    );
+    expect(screen.getByText(/this value arises in the process itself/)).toBeInTheDocument();
+  });
+
+  it('labels the provenance link in English when lang=en', () => {
+    render(<HerkomstTrace id="leeftijd" t={HERKOMST_STRINGS.en} lang="en" onOpen={vi.fn()} />);
+    expect(screen.getAllByRole('link', { name: 'provenance' }).length).toBeGreaterThan(0);
+  });
 });

--- a/packages/public-site/src/pages/herkomst/herkomstScroll.test.ts
+++ b/packages/public-site/src/pages/herkomst/herkomstScroll.test.ts
@@ -1,0 +1,42 @@
+// packages/public-site/src/pages/herkomst/herkomstScroll.test.ts
+import { describe, it, expect, vi, afterEach } from 'vitest';
+import { scrollToId } from './herkomstScroll';
+
+afterEach(() => {
+  document.body.innerHTML = '';
+  vi.restoreAllMocks();
+});
+
+describe('scrollToId', () => {
+  it('scrolls the named element to 20px below the top of the viewport', () => {
+    const scrollTo = vi.fn();
+    vi.stubGlobal('scrollTo', scrollTo);
+    Object.defineProperty(window, 'scrollY', { value: 300, configurable: true });
+
+    const el = document.createElement('section');
+    el.id = 'pijplijn';
+    document.body.appendChild(el);
+    // jsdom gives every element a zero rect, so the offset under test has to be
+    // supplied explicitly -- otherwise the assertion below would pass for any
+    // arithmetic that happens to yield 0.
+    vi.spyOn(el, 'getBoundingClientRect').mockReturnValue({ top: 120 } as DOMRect);
+
+    scrollToId('pijplijn');
+
+    // 300 (current scroll) + 120 (distance to the element) - 20 (breathing room)
+    expect(scrollTo).toHaveBeenCalledWith({ top: 400, behavior: 'smooth' });
+    vi.unstubAllGlobals();
+  });
+
+  it('does nothing when no element carries that id', () => {
+    // The jump-links are rendered before the sections they point at exist on a
+    // route that has not finished mounting; a missing target must be a no-op
+    // rather than a TypeError on null.
+    const scrollTo = vi.fn();
+    vi.stubGlobal('scrollTo', scrollTo);
+
+    expect(() => scrollToId('does-not-exist')).not.toThrow();
+    expect(scrollTo).not.toHaveBeenCalled();
+    vi.unstubAllGlobals();
+  });
+});

--- a/packages/public-site/src/pages/static-pages.test.tsx
+++ b/packages/public-site/src/pages/static-pages.test.tsx
@@ -3,6 +3,7 @@ import { render, screen } from '@testing-library/react';
 import { MemoryRouter } from 'react-router-dom';
 import Toegankelijkheid from './Toegankelijkheid';
 import OpenData from './OpenData';
+import NotFound from './NotFound';
 
 describe('Toegankelijkheid', () => {
   it('states the WCAG 2.1 AA conformance target and a contact path', () => {
@@ -33,5 +34,59 @@ describe('OpenData', () => {
       </MemoryRouter>
     );
     expect(screen.getByText(/GET \/v1\/public\/zoeken/)).toBeInTheDocument();
+  });
+  it('renders the endpoint table and the terms in English when lang=en', () => {
+    render(
+      <MemoryRouter>
+        <OpenData lang="en" />
+      </MemoryRouter>
+    );
+    expect(screen.getByRole('heading', { level: 1 })).toHaveTextContent(/Open data & API/);
+    expect(screen.getByText(/machine-readable through an open, anonymous API/)).toBeInTheDocument();
+    expect(screen.getByRole('columnheader', { name: 'Path' })).toBeInTheDocument();
+    expect(screen.getByRole('columnheader', { name: 'Description' })).toBeInTheDocument();
+    expect(screen.getByText(/free to reuse, without copyright restriction/)).toBeInTheDocument();
+  });
+
+  it('names every documented endpoint exactly once', () => {
+    render(
+      <MemoryRouter>
+        <OpenData lang="nl" />
+      </MemoryRouter>
+    );
+    for (const path of [
+      '/v1/public/zoeken?q=',
+      '/v1/public/berichten',
+      '/v1/public/nieuws',
+      '/v1/public/producten-diensten',
+      '/v1/public/regelcatalogus',
+      '/v1/public/processen',
+    ]) {
+      expect(screen.getByText(`GET ${path}`)).toBeInTheDocument();
+    }
+  });
+});
+
+describe('NotFound', () => {
+  it('explains the miss and offers a way back, in Dutch', () => {
+    render(
+      <MemoryRouter>
+        <NotFound lang="nl" />
+      </MemoryRouter>
+    );
+    expect(screen.getByRole('heading', { level: 1 })).toHaveTextContent('Pagina niet gevonden');
+    expect(screen.getByText(/Deze pagina bestaat niet/)).toBeInTheDocument();
+    expect(screen.getByRole('link', { name: /Terug naar home/ })).toHaveAttribute('href', '/');
+  });
+
+  it('explains the miss and offers a way back, in English', () => {
+    render(
+      <MemoryRouter>
+        <NotFound lang="en" />
+      </MemoryRouter>
+    );
+    expect(screen.getByRole('heading', { level: 1 })).toHaveTextContent('Page not found');
+    expect(screen.getByText(/does not \(or no longer\) exist/)).toBeInTheDocument();
+    expect(screen.getByRole('link', { name: /Back to home/ })).toHaveAttribute('href', '/');
   });
 });


### PR DESCRIPTION
Extends the backend-only coverage campaign to all five workspaces that have a test runner. **53 files were below 80% branch coverage; none are now.**

| workspace | branch % | files <80% | tests |
|---|---|---|---|
| backend | 89.97 → **92.17** | 6 → **0** | 1785 → 1849 |
| frontend | 80.42 → **89.52** | 23 → **0** | 904 → 1049 |
| pa-cockpit | 76.06 → **88.52** | 11 → **0** | 375 → 476 |
| public-site | 70.39 → **96.92** | 11 → **0** | 140 → 204 |
| pa-demo | 86.95 → **95.65** | 2 → **0** | 104 → 106 |

`@ronl/shared` has no test script and needs none: it is types plus two seed/data modules with no functions and no branches.

## What the tests actually pin

Behavioural, not coverage-shaped. By recurring theme:

- **Per-type render arms.** `DecisionViewer`, `CapacityClaimDocumentsViewer` and `RipFase1WipViewer` each carry their own copy of the same TipTap renderer; each now gets one document exercising every node type, block type and text mark the composer can emit. Same idea for `Monitoring`'s provenance chips and `Detail.tsx`'s five section types.
- **Upstream absence.** A source answering with no `value` array, a task with no `processDefinitionKey`, a signal from a source this build has no label for, a dossier-watch row storing no query at all — each has a fallback, each now has a test saying what the fallback is for.
- **"Found nothing" vs "could not look."** `Results.tsx`, `GereedschapSection` and `Home.tsx` each render a distinct state for a failed fetch; a zero in its place would be a wrong statement of fact, not a neutral default.
- **Both languages.** public-site renders every page in nl and en; the English arm of each i18n ternary was largely unexercised.
- **Cleanup on unmount.** `Home`, `Results`, `PaDataProvider` and the two assistant docks all guard against setting state after the user navigates away.

## Relevant to #56, just merged

Two files from that work are covered here:

- **`Monitoring.tsx` 64.8 → 80.7% branch.** Pins the EP provenance chips: `ep-rss` → "Plenaire documenten", `ep-teksten` → "Ingediende teksten", the responsible-committee chip, and an unrecognised sub-source key falling through to the raw key.
- **`ep-persbericht` now has its own test.** That entry is backward compatibility with no producer — the press-release feed was dropped in f355fce because the EP Open Data API has no equivalent endpoint, but signals persisted under it must keep their label. Nothing exercised it and nothing would have caught its deletion. The test carries a comment recording why the entry exists, so the next person tidying the map reads the reason first.
- **`tk.client.ts` 75 → 96.2% branch**, including the multi-term fan-out failure modes.

## One production change

`toMarkdown` in `pa-cockpit/src/pages/public-affairs-v2/dossierbeheer.data.ts` is now **exported**, purely so its empty-field arms can be tested, and commented as such. A dossier started from a blank template has empty strings in all three narrative fields — that is what its `? :` arms are for — but all five `MOCK_DOSSIERS` carry filled-in text, so those arms are unreachable through `buildSeedAdminDossiers()`, the only other caller. Same precedent as `M2M_ALLOWED_OPERATIONS` in the backend campaign. Nothing else under `src/` changed.

## Branches deliberately left uncovered

Each documented where it lives:

- `tk.client.ts`'s `buildFilter` still has an `else if (terms.length > 1)` arm building a single `contains(A) or contains(B)` filter. It is **dead code** — the multi-term path fans out one request per term precisely to avoid that shape, which measured 23–48s against the live API. Left alone here; being raised as its own issue rather than folded into a test PR.
- public-site's `api.ts` falls back to `PUBLIC_API_BASE_URL` for the Node prerender runtime. Unreachable from a test: `import.meta.env` is per-module under Vitest and `vi.stubEnv` writes only to `process.env`, so neither stubbing nor deleting the key from a test file's own env object reaches the one `api.ts` reads. Two tests written for it were removed rather than left failing. `AgendaView`'s `VITE_PA_AGENDA_MOCK` is unreachable for the same reason.
- `Monitoring`'s `OrphanActions` has an `if (!selected) return` guard; the button that calls it only renders once a dossier has been picked.

## Also fixed while writing these

A "due today" fixture in `TakenInbox` was written as `now + 1 minute`, which lands on tomorrow when the suite runs just before midnight — which it did. It is noon-of-today now, and the "this week" case no longer asserts on whether that is still ahead.

## Verification

All five suites run serially: **3684 tests, all green.** `type-check`, `lint` and `check-format` pass repo-wide.

Note on CI coverage of this PR: `azure-backend-acc.yml` has no `pull_request` trigger, so the +64 backend tests get no exercise here — they run first at merge. They were run locally against this exact tree (1849 passing, `--runInBand`), and the backend portion of the tree is byte-identical to that run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011sYf9RfoRSUZXP6p5m3nJN
