### PR TITLE
chore: gitignore .semgrep/ (live OAuth tokens), and fix bump-release.md contradicting itself

### DIFF
--- a/.claude/commands/bump-release.md
+++ b/.claude/commands/bump-release.md
@@ -62,10 +62,28 @@ or none. Out-of-scope PRs stay open and are gathered by the next release. Then:
 2. **Re-check mergeability between merges** when several PRs touch the same file.
    The `acc` ruleset does not require branches to be up to date, so merging one
    leaves the next based on a stale tree.
-3. **Each merge to `acc` redeploys frontend, pa-demo and public-site** — those
-   workflows trigger on push to `acc` with no `paths:` filter. Say so when
-   proposing to merge several. The backend workflows are path-filtered and will
-   not fire unless `packages/backend/**` or `packages/shared/**` changed.
+3. **Say what a merge will redeploy when proposing to merge several** — derived
+   from the scope, not recited from a list. Every ACC workflow is path-filtered
+   on push, so which ones fire depends entirely on which packages the PRs touch;
+   the "Why scope matters" callout at the top of this file holds the paths, and
+   is the only place they are written down.
+
+   This step used to name frontend, pa-demo and public-site as redeploying on
+   every merge, "with no `paths:` filter" — contradicting that callout 55 lines
+   above it. It was wrong the way a second copy decays, not the way a typo is
+   wrong: whoever wrote it was reasoning about frontend and pa-demo, which do
+   list `packages/shared/**` and so usually do fire, and swept public-site in by
+   association. `azure-publicsite-acc.yml` watches `packages/public-site/**`
+   alone — no `shared/**`, no `backend/**` — so public-site redeployed on no
+   backend release at all, while this step promised it had. A third of the
+   sentence was wrong on every backend release since the filters went in, and
+   nothing caught it because the two statements were never read together.
+
+   Hence one statement of the rule, in the callout, and nothing here that can
+   drift away from it. If this step ever needs a one-liner, "which sites
+   redeploy depends on the scope — see the callout above" is true for every
+   release; the enumerated version is true for none.
+
 4. **Bring the working branch up to date with `acc` afterwards** — rebase if the
    branch is unpushed, merge if it is not. Only then compute the commit range in
    step 1.

--- a/.gitignore
+++ b/.gitignore
@@ -153,3 +153,11 @@ docs/regelsimulatie-handoff/
 # it untracked stops it drifting into a second source of truth, which is the
 # problem deleting docs/TEST*.md set out to solve.
 docs/overview.md
+
+# Semgrep plugin state. Not tidiness: guardian.yml holds a live OAuth access
+# token and refresh token for the Semgrep account, written per working
+# directory (root plus one per workspace), so `git add -A` from a repo root
+# would commit five copies of a credential. Never been tracked; keep it that
+# way. It also kept `deploy-backend-to-acc.sh` from running, since that script
+# requires a clean tree and `git status --porcelain` counts untracked files.
+.semgrep/


### PR DESCRIPTION
Two unrelated fixes, one commit each, both found while deploying #56 to ACC.

## 1. `.gitignore`: ignore `.semgrep/`

**This one is a credential, not tidiness.** The semgrep plugin writes
`.semgrep/guardian.yml` into every working directory it runs from — the repo
root plus one per workspace, five in all — and that file contains a live OAuth
**access token and refresh token** for the Semgrep account, plus the user and
org ids.

So `git add -A` from the repo root would have committed five copies of a
credential. Nothing is tracked today — `git log --all -- '*.semgrep/*'` is empty
and no matching path appears in `git ls-files` — but that is luck rather than
design: the directories are new enough that nobody has run a broad add since
they appeared.

A bare `.semgrep/` pattern matches at every depth, so one line covers all five.
It sits alongside `.claude/settings.json` and `.superpowers/`, ignored for the
same reason: local tool state that happens to be written inside the repo.

Second, smaller reason: **it blocked deployment.** `deploy-backend-to-acc.sh`
refuses to run unless `git status --porcelain` is empty, and that reports
untracked files, so five directories of plugin state were enough to stop an ACC
deploy with "working tree not clean" — a failure whose cause has nothing to do
with anything the operator changed.

## 2. `bump-release.md`: delete the decayed restatement of the workflow triggers

The document stated the same fact twice and disagreed with itself.

The "Why scope matters" callout near the top lists all four ACC workflows as
path-filtered, and that is the stated justification for the entire per-scope
versioning scheme the document describes. Step 0 item 3, 55 lines below, said
frontend, pa-demo and public-site "trigger on push to `acc` with no `paths:`
filter", singling out backend as the only filtered one.

The callout is right:

```
azure-backend-acc     packages/backend/**, packages/shared/**
azure-frontend-acc    packages/frontend/**, packages/shared/**, packages/pa-cockpit/**
azure-pa-demo-acc     packages/pa-demo/**, packages/shared/**, packages/pa-cockpit/**
azure-publicsite-acc  packages/public-site/**
```

Item 3 was wrong the way a second copy decays, not the way a typo is wrong.
Whoever wrote it was reasoning about frontend and pa-demo — both list
`packages/shared/**`, so both usually *do* fire on a backend release — and swept
public-site in by association. public-site watches its own package alone, no
`shared/**` and no `backend/**`, so it redeployed on **no** backend release at
all while this step promised it had. A third of the sentence has been wrong on
every backend release since the filters went in, and nothing caught it because
the two statements were never read together.

**Hence a deletion rather than a correction.** Fixing the wrong copy in place
would leave the duplication that produced it, and the drift would recur. The
replacement gives the instruction — say what a merge will redeploy — and sends
the reader to the callout for the paths, without enumerating sites: the honest
statement is per-scope, and an enumerated one is wrong for every release.

The practical consequence of the old wording: on a pure `packages/backend/**`
release, bump-release would have told the operator that frontend, pa-demo and
public-site were being redeployed. None of them would have been, and ACC would
have kept serving the old builds with nobody looking for it.

## Checks

`npm run check-format` clean. No package touched, so this is `ci`/docs scope
only and triggers no deploy workflow on merge.
