### PR TITLE
chore: bump release to v2026.09.2

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "ronl-business-api",
-  "version": "2026.09.1",
+  "version": "2026.09.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "ronl-business-api",
-      "version": "2026.09.1",
+      "version": "2026.09.2",
       "hasInstallScript": true,
       "license": "EUPL-1.2",
       "workspaces": [
@@ -17226,7 +17226,7 @@
     },
     "packages/backend": {
       "name": "@ronl/backend",
-      "version": "2026.09.1",
+      "version": "2026.09.2",
       "license": "EUPL-1.2",
       "dependencies": {
         "@anthropic-ai/sdk": "^0.122.0",
@@ -17354,7 +17354,7 @@
     },
     "packages/frontend": {
       "name": "@ronl/frontend",
-      "version": "2026.09.1",
+      "version": "2026.09.2",
       "dependencies": {
         "@bpmn-io/form-js": "^1.20.1",
         "@ronl/pa-cockpit": "*",
@@ -18372,7 +18372,7 @@
     },
     "packages/pa-demo": {
       "name": "@ronl/pa-demo",
-      "version": "2026.09.1",
+      "version": "2026.09.2",
       "dependencies": {
         "@ronl/pa-cockpit": "*",
         "@ronl/shared": "*",
@@ -18913,7 +18913,7 @@
     },
     "packages/public-site": {
       "name": "@ronl/public-site",
-      "version": "2026.09.1",
+      "version": "2026.09.2",
       "dependencies": {
         "react": "^18.2.0",
         "react-dom": "^18.2.0",
@@ -19453,7 +19453,7 @@
     },
     "packages/shared": {
       "name": "@ronl/shared",
-      "version": "2026.09.1",
+      "version": "2026.09.2",
       "license": "EUPL-1.2",
       "devDependencies": {
         "typescript": "^5.3.3"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ronl-business-api",
-  "version": "2026.09.1",
+  "version": "2026.09.2",
   "description": "Secure, multi-tenant Business API for Dutch municipality BPMN/DMN services",
   "private": true,
   "workspaces": [

--- a/packages/backend/package.json
+++ b/packages/backend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ronl/backend",
-  "version": "2026.09.1",
+  "version": "2026.09.2",
   "description": "Secure Business API layer for Dutch municipality BPMN services",
   "main": "dist/index.js",
   "scripts": {

--- a/packages/frontend/package.json
+++ b/packages/frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ronl/frontend",
-  "version": "2026.09.1",
+  "version": "2026.09.2",
   "description": "Municipality portal (MijnOmgeving) with identity provider selection",
   "type": "module",
   "scripts": {

--- a/packages/frontend/src/pages/changelog-data.ts
+++ b/packages/frontend/src/pages/changelog-data.ts
@@ -108,6 +108,57 @@ export const changelog: Changelog = {
   versions: [
     {
       format: 'commits',
+      version: '2026.09.2',
+      status: 'Released',
+      date: '3 sep 2026',
+      scope: ['backend', 'frontend', 'pa-demo', 'public-site'],
+      commits: [
+        {
+          sha: 'bed7699',
+          author: 'Steven Gort',
+          type: 'docs',
+          subject: 'bump-release no longer contradicts itself about which sites redeploy',
+          details: [
+            'The release runbook stated the same fact twice and disagreed with itself. Its “Why scope matters” callout lists all four ACC workflows as path-filtered — the stated justification for the entire per-scope versioning scheme — while step 0, fifty-five lines below, said frontend, pa-demo and public-site trigger on push to acc “with no paths: filter”, singling out backend as the only filtered one.',
+            'The callout is right: azure-publicsite-acc watches packages/public-site/** alone, with no shared/** and no backend/**, so public-site redeployed on no backend release at all while the step promised it had. A third of that sentence has been wrong on every backend release since the filters went in, and nothing caught it because the two statements were never read together.',
+            'Deleted rather than corrected. Fixing the wrong copy in place would have left the duplication that produced it, and the same drift would recur. The replacement gives the instruction and sends the reader to the callout for the paths, without enumerating sites — the honest statement is per-scope, and an enumerated one is wrong for every release.',
+          ],
+        },
+        {
+          sha: '5b53700',
+          author: 'Steven Gort',
+          type: 'test',
+          subject: 'Every workspace held to an 80% per-file branch floor',
+          details: [
+            'Extends the backend-only coverage campaign to all five workspaces that have a test runner. 53 files were below 80% branch coverage; none are now. backend 89.97 → 92.17, frontend 80.42 → 89.52, pa-cockpit 76.06 → 88.52, public-site 70.39 → 96.92, pa-demo 86.95 → 95.65. Total 3683 tests, verified serially. @ronl/shared has no test script and needs none: it is types plus two seed modules with no functions and no branches.',
+            'The new tests are behavioural rather than coverage-shaped. Three themes recur: per-type render arms, where DecisionViewer, CapacityClaimDocumentsViewer and RipFase1WipViewer each carry their own copy of the same TipTap renderer and each now gets a document exercising every node type the composer can emit; upstream absence, where a source answering with no value array or a signal from a source this build has no label for each has a fallback that now has a test saying what it is for; and the difference between “we looked and found nothing” and “we could not look”, which Results, GereedschapSection and Home all render distinctly, because a zero in place of a failed fetch is a wrong statement of fact rather than a neutral default.',
+          ],
+        },
+        {
+          sha: 'f355fce',
+          author: 'Steven Gort',
+          type: 'feat',
+          subject: 'The EU signaalbron moves to the EP Open Data API',
+          details: [
+            'The EU source returned nothing on ACC, and not for any reason in this repository: www.europarl.europa.eu is CDN-fronted with undocumented bot mitigation that answers ACC’s outbound range with an empty 202 text/html. That passes res.ok, so the empty body parsed to zero items and the source reported success while contributing nothing — starving both the Ongefilterd browse and the six-hourly curation cron. Measured from inside the App Service, egress 20.76.244.212, in one run: both RSS URLs 202 with zero bytes, while data.europarl.europa.eu returned 200 with 211 KB of Atom. The API is also the endpoint the EP publishes for machines, documenting User-Agent as a header with the format {user-id}-{environment}-{version}, where the CDN gates on a UA family it never describes.',
+            'fetchEuFeed’s signature is unchanged, so neither call site moved. The feed endpoint takes no query parameters — a fixed “published or updated in the last month” window — so paging stays in-process exactly as it was under RSS, and one request replaces two. Three things the live feed decided that the specification would not have: the parliamentary term is not always 10, because the window covers documents updated rather than only published, so the RSS-era pattern that hardcoded -10- silently dropped every older-term document; amendment refs carry extra segments and are excluded deliberately, an amendment being a fragment of a document with no doceo page of its own; and the type now comes from the work-type vocabulary rather than the ref prefix, which had never learned QOB.',
+            'Two accepted trade-offs, both recorded rather than discovered later. Entries are English only — they arrive xml:lang="en" and Accept-Language is ignored — while the doceo link stays Dutch, since the document itself is translated even when its metadata is not. Press releases are gone: the API has no equivalent endpoint, they being a communications product rather than legislative data. Committee and per-entry summary are absent from the Atom feed too, so commissie is null for this sub-source and the description is built from the title alone; both are covered by tests so they read as decisions rather than surprises.',
+          ],
+        },
+        {
+          sha: '210fce2',
+          author: 'Steven Gort',
+          type: 'ci',
+          subject: 'The supply-chain audit runs on every pull request',
+          details: [
+            'The pull_request trigger was filtered to acc and main, so a pull request opened against a feature branch — a stacked PR — matched no trigger and accumulated no audit at all. It then reported mergeStateStatus CLEAN with zero checks: ready-looking, and not ready.',
+            'The failure arrives later and is worse than it sounds. When the parent merges and GitHub retargets the stacked PR to acc, the required audit is missing and the PR blocks permanently, because retargeting emits no pull_request event and nothing ever runs it. Closing and reopening is the only way out, reopened being one of the default trigger types. The audit is read-only and cheap, so running it on every pull request regardless of base removes the hole rather than working around it; push keeps its filter, there being no reason to audit a push to a feature branch.',
+          ],
+        },
+      ],
+    },
+    {
+      format: 'commits',
       version: '2026.09.1',
       status: 'Released',
       date: '2 sep 2026',

--- a/packages/pa-demo/package.json
+++ b/packages/pa-demo/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ronl/pa-demo",
-  "version": "2026.09.1",
+  "version": "2026.09.2",
   "description": "Public mock-only PA Cockpit demo — plato.open-regels.nl",
   "type": "module",
   "scripts": {

--- a/packages/public-site/package.json
+++ b/packages/public-site/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ronl/public-site",
-  "version": "2026.09.1",
+  "version": "2026.09.2",
   "description": "Public, unauthenticated search site for Open Regels Nederland — publiek.open-regels.nl",
   "type": "module",
   "scripts": {

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ronl/shared",
-  "version": "2026.09.1",
+  "version": "2026.09.2",
   "description": "Shared types and utilities for RONL Business API",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",


### PR DESCRIPTION
Cuts **v2026.09.2**, scope `['backend', 'frontend', 'pa-demo', 'public-site']`.

## Changelog entry

Authored fresh — `2026.09.1` was already `Released`, so there was no pending
entry to flip. `format: 'commits'`, four commits:

| sha | type | subject |
| --- | --- | --- |
| `bed7699` | docs | bump-release no longer contradicts itself about which sites redeploy |
| `5b53700` | test | Every workspace held to an 80% per-file branch floor |
| `f355fce` | feat | The EU signaalbron moves to the EP Open Data API |
| `210fce2` | ci | The supply-chain audit runs on every pull request |

Two further commits in the range are deliberately unlisted, both internal with
no product-visible change: `bb1fb34` (gitignore `.semgrep/`, which holds live
OAuth tokens) and `01887b3` (`acc-egress-probe.sh`). Called out because the
runbook's premise is that anything merged outside an entry ships silently — this
omission is a decision, not a gap.

## Versions

`2026.09.1` → `2026.09.2` in root, `packages/frontend`, `packages/backend`,
`packages/pa-demo`, `packages/public-site` and `packages/shared`, plus all
**seven** matching entries in `package-lock.json`.

`packages/shared` is included because it genuinely changed in `f355fce`
(`pa.types.ts`). `packages/pa-cockpit` stays at `1.0.0` — pinned outside the
CalVer sequence, and not a scope tag: it compiles into frontend and pa-demo
rather than deploying on its own, and both of those were bumped.

Before editing the lockfile I checked that exactly seven `"version": "2026.09.1"`
strings existed and that all seven were ours, so no third-party dependency was
touched by the replacement. Versions were edited by hand — `npm version` coerces
a zero-padded CalVer month to invalid SemVer.

## Checks run locally

- Scope cross-check passed. Touched packages were backend, frontend, pa-cockpit,
  pa-demo, public-site and shared; under the mapping (`pa-cockpit` → frontend +
  pa-demo, `shared` → frontend + backend) that is exactly the four declared.
- Endpoint map needed no reconciliation: seventeen routes mounted in
  `packages/backend/src/index.ts`, the same seventeen in the root handler.
- `npm run check-format`, `npm run type-check` and `npm run lint` all clean
  across the six workspaces.
- `npm ci --dry-run` resolves against the edited lockfile.

## What merging does

All four deployables are in scope, so this fires every ACC workflow: backend,
frontend, pa-demo and public-site.

**Merge with a merge commit.** The changelog entry names each commit by SHA;
squashing or rebasing rewrites those hashes and would leave the entry pointing
at commits that do not exist on `acc`. This repository allows merge commits
only, so that failure is impossible by construction — noted for the record
rather than as a warning.
