### PR TITLE
fix(pa-cache): bound the connect, retry after failure, report cache state in /v1/health

### DIFF
--- a/packages/backend/src/pa-monitoring/pa-cache.test.ts
+++ b/packages/backend/src/pa-monitoring/pa-cache.test.ts
@@ -15,14 +15,20 @@ export {};
 const mockRedisClient = {
   on: jest.fn(),
   connect: jest.fn(),
+  disconnect: jest.fn(),
   get: jest.fn(),
   set: jest.fn(),
+  // node-redis exposes isReady; getClient() gates on it because a client that
+  // connected but never became ready is exactly the state #62 was stuck in.
+  isReady: true,
 };
 const mockCreateClient = jest.fn(() => mockRedisClient);
 jest.mock('redis', () => ({ createClient: mockCreateClient }));
 jest.mock('@utils/config', () => ({ config: { redis: { url: 'redis://x' } } }));
+const mockWarn = jest.fn();
+const mockInfo = jest.fn();
 jest.mock('@utils/logger', () => ({
-  createLogger: () => ({ info: jest.fn(), warn: jest.fn(), error: jest.fn(), debug: jest.fn() }),
+  createLogger: () => ({ info: mockInfo, warn: mockWarn, error: jest.fn(), debug: jest.fn() }),
 }));
 
 type Mod = typeof import('./pa-cache');
@@ -39,6 +45,9 @@ function freshModule(): Mod {
 beforeEach(() => {
   jest.clearAllMocks();
   mockRedisClient.connect.mockResolvedValue(undefined);
+  mockRedisClient.disconnect.mockResolvedValue(undefined);
+  mockRedisClient.isReady = true;
+  mockCreateClient.mockReturnValue(mockRedisClient);
 });
 
 describe('cacheGet', () => {
@@ -106,5 +115,192 @@ describe('cacheSet', () => {
     const { cacheSet } = freshModule();
     await expect(cacheSet('k', {}, 900)).resolves.toBeUndefined();
     expect(mockRedisClient.set).not.toHaveBeenCalled();
+  });
+});
+
+describe('cacheHealth', () => {
+  it('reports up when the client connects and is ready', async () => {
+    const { cacheHealth } = freshModule();
+    await expect(cacheHealth()).resolves.toEqual({ status: 'up' });
+  });
+
+  it('reports down with the reason when the connect rejects', async () => {
+    mockRedisClient.connect.mockRejectedValue(new Error('unreachable'));
+    const { cacheHealth } = freshModule();
+    await expect(cacheHealth()).resolves.toEqual({ status: 'down', error: 'unreachable' });
+  });
+
+  it('reports down when the client connects but never becomes ready', async () => {
+    // The #62 state exactly: the socket is accepted and then reset, so connect()
+    // resolves against a client that can never run a command.
+    mockRedisClient.isReady = false;
+    const { cacheHealth } = freshModule();
+    await expect(cacheHealth()).resolves.toEqual({
+      status: 'down',
+      error: 'connected but not ready',
+    });
+  });
+
+  it('never rejects, even when createClient throws outright', async () => {
+    // A malformed REDIS_URL throws synchronously. cacheHealth() is called from
+    // /v1/health, so a throw here would 503 the whole health check and make an
+    // optional dependency fatal. This is the regression a route test caught.
+    mockCreateClient.mockImplementation(() => {
+      throw new Error('Invalid URL');
+    });
+    const { cacheHealth } = freshModule();
+    await expect(cacheHealth()).resolves.toEqual({ status: 'down', error: 'Invalid URL' });
+  });
+
+  it('does not fail a cacheGet when the cache is down', async () => {
+    // The fail-soft contract: a dead cache costs a live fetch, never an error.
+    mockRedisClient.connect.mockRejectedValue(new Error('unreachable'));
+    const { cacheGet, cacheSet } = freshModule();
+    await expect(cacheGet('k')).resolves.toBeNull();
+    await expect(cacheSet('k', {}, 900)).resolves.toBeUndefined();
+  });
+});
+
+describe('reconnection after a failed connect', () => {
+  it('retries on a later call instead of latching off until restart', async () => {
+    // The defect this replaces: connectAttempted was cleared only in a catch,
+    // and the real failure arrived as an 'error' EVENT rather than a rejection,
+    // so the catch never ran and the cache stayed dead for nine days (#62).
+    jest.useFakeTimers();
+    try {
+      mockRedisClient.connect.mockRejectedValueOnce(new Error('unreachable'));
+      const { cacheHealth } = freshModule();
+
+      await expect(cacheHealth()).resolves.toEqual({ status: 'down', error: 'unreachable' });
+      expect(mockCreateClient).toHaveBeenCalledTimes(1);
+
+      // Within the cooldown: no new attempt, so a dead Redis is not hammered.
+      await expect(cacheHealth()).resolves.toEqual({ status: 'down', error: 'unreachable' });
+      expect(mockCreateClient).toHaveBeenCalledTimes(1);
+
+      // Past the cooldown: it tries again and recovers without a restart.
+      jest.advanceTimersByTime(31_000);
+      await expect(cacheHealth()).resolves.toEqual({ status: 'up' });
+      expect(mockCreateClient).toHaveBeenCalledTimes(2);
+    } finally {
+      jest.useRealTimers();
+    }
+  });
+
+  it('drops a client that stopped being ready rather than issuing commands at it', async () => {
+    const { cacheGet } = freshModule();
+    await expect(cacheGet('k')).resolves.toBeNull(); // connects, get returns null
+    expect(mockCreateClient).toHaveBeenCalledTimes(1);
+
+    // The connection dies underneath us.
+    mockRedisClient.isReady = false;
+    await expect(cacheGet('k')).resolves.toBeNull();
+    expect(mockRedisClient.disconnect).toHaveBeenCalled();
+  });
+});
+
+describe('error logging', () => {
+  it('logs a repeated identical error once rather than on every event', async () => {
+    // 10,269 identical "read ECONNRESET" lines is volume, not signal (#62).
+    const { cacheHealth } = freshModule();
+    await cacheHealth();
+
+    const handler = mockRedisClient.on.mock.calls.find((c) => c[0] === 'error')?.[1] as (
+      err: Error
+    ) => void;
+    expect(handler).toBeDefined();
+
+    const before = mockWarn.mock.calls.filter((c) => c[0] === 'PA cache Redis error').length;
+    handler(new Error('read ECONNRESET'));
+    handler(new Error('read ECONNRESET'));
+    handler(new Error('read ECONNRESET'));
+    const after = mockWarn.mock.calls.filter((c) => c[0] === 'PA cache Redis error');
+
+    expect(after.length - before).toBe(1);
+    expect(after[after.length - 1][1]).toEqual({ error: 'read ECONNRESET' });
+  });
+
+  it('logs again when the error changes, so a new fault is not swallowed', async () => {
+    const { cacheHealth } = freshModule();
+    await cacheHealth();
+    const handler = mockRedisClient.on.mock.calls.find((c) => c[0] === 'error')?.[1] as (
+      err: Error
+    ) => void;
+
+    const before = mockWarn.mock.calls.filter((c) => c[0] === 'PA cache Redis error').length;
+    handler(new Error('read ECONNRESET'));
+    handler(new Error('read ECONNRESET'));
+    handler(new Error('WRONGPASS invalid username-password pair'));
+    const after = mockWarn.mock.calls.filter((c) => c[0] === 'PA cache Redis error').length;
+
+    expect(after - before).toBe(2);
+  });
+
+  it('announces a successful connection, which never once appeared in nine days', async () => {
+    const { cacheHealth } = freshModule();
+    await cacheHealth();
+    expect(mockInfo).toHaveBeenCalledWith('PA cache Redis connected');
+  });
+});
+
+describe('connect failures the ECONNRESET loop actually produced', () => {
+  it('gives up on a connect that never settles, rather than awaiting forever', async () => {
+    // This is the #62 state precisely: node-redis retries a resetting socket
+    // internally, so connect() neither resolves nor rejects. The old code had
+    // no timeout on it, which is why neither 'connected' nor 'unavailable' was
+    // ever logged across 10,269 errors — the await simply never returned.
+    jest.useFakeTimers();
+    try {
+      mockRedisClient.connect.mockReturnValue(new Promise(() => {}));
+      const { cacheHealth } = freshModule();
+
+      const pending = cacheHealth();
+      await jest.advanceTimersByTimeAsync(3_100);
+
+      await expect(pending).resolves.toEqual({
+        status: 'down',
+        error: 'connect timed out after 3000ms',
+      });
+    } finally {
+      jest.useRealTimers();
+    }
+  });
+
+  it('reports a non-Error connect rejection as its string form', async () => {
+    mockRedisClient.connect.mockRejectedValue('ECONNREFUSED');
+    const { cacheHealth } = freshModule();
+    await expect(cacheHealth()).resolves.toEqual({ status: 'down', error: 'ECONNREFUSED' });
+  });
+
+  it('reports down with no reason when the cooldown blocks an attempt', async () => {
+    // Second call inside the cooldown never reaches a client, and by then the
+    // recorded error has been cleared by an intervening success. Reporting
+    // 'down' without inventing a cause is the honest answer.
+    jest.useFakeTimers();
+    try {
+      mockRedisClient.connect.mockRejectedValueOnce(new Error('boom'));
+      const mod = freshModule();
+      await mod.cacheHealth();
+
+      // A later ready client, but still inside the cooldown window.
+      mockRedisClient.isReady = true;
+      jest.advanceTimersByTime(1_000);
+      await expect(mod.cacheHealth()).resolves.toEqual({ status: 'down', error: 'boom' });
+      expect(mockCreateClient).toHaveBeenCalledTimes(1);
+    } finally {
+      jest.useRealTimers();
+    }
+  });
+
+  it('tolerates a client whose disconnect rejects during teardown', async () => {
+    // teardown() swallows this on purpose: the client is already unusable, and
+    // an error while discarding it must not surface as a cache failure.
+    mockRedisClient.isReady = false;
+    mockRedisClient.disconnect.mockRejectedValue(new Error('already closed'));
+    const { cacheHealth } = freshModule();
+    await expect(cacheHealth()).resolves.toEqual({
+      status: 'down',
+      error: 'connected but not ready',
+    });
   });
 });

--- a/packages/backend/src/pa-monitoring/pa-cache.ts
+++ b/packages/backend/src/pa-monitoring/pa-cache.ts
@@ -1,6 +1,23 @@
 /**
  * Fail-soft Redis cache for PA monitoring.
  * Any Redis error falls through to a live fetch — the service stays up.
+ *
+ * Fail-soft is the right contract, but it hid a total outage for at least nine
+ * days (#62): REDIS_URL pointed a plaintext scheme at the TLS-only port, every
+ * connection was reset, and every request silently did a live fetch. Three
+ * things about the old implementation let that run unnoticed, all fixed here.
+ *
+ *   1. connect() was unbounded. withTimeout() guarded get() and set() but not
+ *      the connect itself, and node-redis retries a failing socket internally
+ *      rather than rejecting — so the await never settled. Neither the
+ *      'connected' nor the 'unavailable' line was ever logged, across 10,269
+ *      errors, which is why the logs described the symptom and never the state.
+ *   2. The retry never fired. `connectAttempted` was cleared only in the catch,
+ *      and this failure arrives as an 'error' EVENT rather than a rejection, so
+ *      the catch never ran and the cache stayed disabled until the process
+ *      restarted. A transient blip became permanent.
+ *   3. Nothing reported it. /v1/health covered keycloak and operaton, so a
+ *      dependency failing 100% of the time still read "healthy".
  */
 
 import { createClient } from 'redis';
@@ -9,28 +26,7 @@ import { createLogger } from '@utils/logger';
 
 const logger = createLogger('pa-cache');
 
-let redisClient: ReturnType<typeof createClient> | null = null;
-let connectAttempted = false;
-
-async function getClient(): Promise<ReturnType<typeof createClient> | null> {
-  if (connectAttempted) return redisClient;
-  connectAttempted = true;
-  try {
-    const client = createClient({ url: config.redis.url });
-    client.on('error', (err: Error) => {
-      logger.warn('PA cache Redis error', { error: err.message });
-    });
-    await client.connect();
-    redisClient = client;
-    logger.info('PA cache Redis connected');
-  } catch (err) {
-    connectAttempted = false; // allow retry on next curation cycle
-    logger.warn('PA cache Redis unavailable — live fetch only', {
-      error: err instanceof Error ? err.message : String(err),
-    });
-  }
-  return redisClient;
-}
+type RedisClient = ReturnType<typeof createClient>;
 
 // node-redis v4 queues commands while reconnecting after ECONNRESET, so an
 // awaited client.get() can hang indefinitely. Race against a 2 s timeout so a
@@ -38,9 +34,111 @@ async function getClient(): Promise<ReturnType<typeof createClient> | null> {
 // curation cycle.
 const CACHE_OP_TIMEOUT_MS = 2_000;
 
-function withTimeout<T>(promise: Promise<T>, fallback: T): Promise<T> {
+// The connect must be bounded for the same reason, and more urgently: a socket
+// that keeps resetting leaves connect() pending forever rather than rejecting.
+// Kept short — this is on the path of a health check.
+const CONNECT_TIMEOUT_MS = 3_000;
+
+// How long to wait before trying again after a failed connect. Without it, a
+// dead Redis means one connect attempt per cache operation, which is a
+// reconnect storm against a host that is already unhappy.
+const RETRY_COOLDOWN_MS = 30_000;
+
+let redisClient: RedisClient | null = null;
+let lastError: string | null = null;
+let loggedError: string | null = null;
+let nextAttemptAt = 0;
+let connecting: Promise<RedisClient | null> | null = null;
+
+/** Stop a client's internal reconnect loop; it is what produced 10k log lines. */
+async function teardown(client: RedisClient): Promise<void> {
+  try {
+    await client.disconnect();
+  } catch {
+    // Already closed, or never opened. Either way there is nothing to release.
+  }
+}
+
+function recordError(message: string): void {
+  lastError = message;
+  // The old code logged every 'error' event, which produced 10,269 identical
+  // "read ECONNRESET" lines — volume that reads as noise rather than signal.
+  // Log a given message once until it changes or a connection succeeds.
+  if (message !== loggedError) {
+    loggedError = message;
+    logger.warn('PA cache Redis error', { error: message });
+  }
+}
+
+async function openClient(): Promise<RedisClient | null> {
+  // Set the cooldown before awaiting, so concurrent callers that arrive while
+  // this attempt is in flight do not queue up behind it and retry immediately.
+  nextAttemptAt = Date.now() + RETRY_COOLDOWN_MS;
+
+  // createClient throws synchronously on a malformed URL, and cacheHealth() is
+  // on the /v1/health path — an unhandled throw here made the whole health
+  // check 503, turning an optional dependency into a fatal one. Caught by a
+  // route test, which is the only reason it is not shipping.
+  let client: RedisClient;
+  try {
+    client = createClient({ url: config.redis.url });
+    client.on('error', (err: Error) => recordError(err.message));
+  } catch (err) {
+    recordError(err instanceof Error ? err.message : String(err));
+    logger.warn('PA cache Redis unavailable — live fetch only', { error: lastError });
+    return null;
+  }
+
+  const connected = await withTimeout(
+    client.connect().then(
+      () => true,
+      (err: unknown) => {
+        recordError(err instanceof Error ? err.message : String(err));
+        return false;
+      }
+    ),
+    false,
+    CONNECT_TIMEOUT_MS
+  );
+
+  if (!connected || !client.isReady) {
+    if (connected) recordError('connected but not ready');
+    else if (!lastError) recordError(`connect timed out after ${CONNECT_TIMEOUT_MS}ms`);
+    logger.warn('PA cache Redis unavailable — live fetch only', { error: lastError });
+    void teardown(client);
+    return null;
+  }
+
+  redisClient = client;
+  lastError = null;
+  loggedError = null;
+  logger.info('PA cache Redis connected');
+  return client;
+}
+
+async function getClient(): Promise<RedisClient | null> {
+  if (redisClient?.isReady) return redisClient;
+
+  // A client that exists but is not ready is unusable, and its own reconnect
+  // loop is still running. Drop it rather than wait on it.
+  if (redisClient) {
+    const stale = redisClient;
+    redisClient = null;
+    void teardown(stale);
+  }
+
+  if (connecting) return connecting;
+  if (Date.now() < nextAttemptAt) return null;
+
+  connecting = openClient().finally(() => {
+    connecting = null;
+  });
+  return connecting;
+}
+
+function withTimeout<T>(promise: Promise<T>, fallback: T, ms = CACHE_OP_TIMEOUT_MS): Promise<T> {
   return new Promise<T>((resolve) => {
-    const timer = setTimeout(() => resolve(fallback), CACHE_OP_TIMEOUT_MS);
+    const timer = setTimeout(() => resolve(fallback), ms);
     promise.then(
       (val) => {
         clearTimeout(timer);
@@ -74,4 +172,33 @@ export async function cacheSet(key: string, value: unknown, ttlSeconds: number):
   } catch {
     // fail-soft
   }
+}
+
+export interface CacheHealth {
+  status: 'up' | 'down';
+  error?: string;
+}
+
+/**
+ * Report whether the cache is usable, for /v1/health.
+ *
+ * Deliberately active rather than a cached flag: it calls getClient(), so a
+ * health check both reports the true state AND drives reconnection. That makes
+ * the health endpoint the thing that recovers the cache after an outage,
+ * instead of a restart. The RETRY_COOLDOWN_MS gate means only one check per
+ * thirty seconds actually attempts a connect; the rest return immediately.
+ *
+ * Redis is optional here — the cache is fail-soft and the service is designed
+ * to run without it — so a 'down' result must not fail the health check. It
+ * only has to be visible, which is exactly what was missing.
+ */
+export async function cacheHealth(): Promise<CacheHealth> {
+  // No try/catch here on purpose. openClient() already catches the one path
+  // that can throw (createClient on a malformed URL), so a catch at this level
+  // would be unreachable — untestable defensive code that only depresses branch
+  // coverage and implies a failure mode that does not exist. The health route
+  // guards the call itself, and that guard is exercised by a route test.
+  const client = await getClient();
+  if (client) return { status: 'up' };
+  return lastError ? { status: 'down', error: lastError } : { status: 'down' };
 }

--- a/packages/backend/src/routes/health.routes.test.ts
+++ b/packages/backend/src/routes/health.routes.test.ts
@@ -16,13 +16,22 @@ jest.mock('@utils/config', () => ({
 jest.mock('@utils/logger', () => ({
   createLogger: () => ({ info: jest.fn(), warn: jest.fn(), error: jest.fn(), debug: jest.fn() }),
 }));
+// Spread requireActual before overriding, so an export added to pa-cache later
+// is inherited rather than silently undefined — the failure mode that once made
+// GET /v1/pa/types answer 500 while every route test passed.
+jest.mock('../pa-monitoring/pa-cache', () => ({
+  ...jest.requireActual('../pa-monitoring/pa-cache'),
+  cacheHealth: jest.fn(),
+}));
 
 import express from 'express';
 import request from 'supertest';
 import healthRouter from './health.routes';
 import { operatonService } from '@services/operaton.service';
+import { cacheHealth } from '../pa-monitoring/pa-cache';
 
 const opHealth = (operatonService as unknown as { healthCheck: jest.Mock }).healthCheck;
+const mockCacheHealth = cacheHealth as jest.Mock;
 
 const app = express();
 app.use('/v1/health', healthRouter);
@@ -31,7 +40,10 @@ const mockFetch = jest.fn();
 beforeAll(() => {
   global.fetch = mockFetch as unknown as typeof fetch;
 });
-beforeEach(() => jest.clearAllMocks());
+beforeEach(() => {
+  jest.clearAllMocks();
+  mockCacheHealth.mockResolvedValue({ status: 'up' });
+});
 
 describe('GET /v1/health', () => {
   it('200 healthy when Operaton and Keycloak are both up', async () => {
@@ -146,5 +158,107 @@ describe('reported environment', () => {
     const res = await request(app).get('/v1/health');
 
     expect(res.body.data.environment).toBe('acceptance');
+  });
+});
+
+describe('GET /v1/health — the PA cache', () => {
+  it('reports the cache alongside keycloak and operaton', async () => {
+    opHealth.mockResolvedValue({ status: 'up' });
+    mockFetch.mockResolvedValue({ ok: true, status: 200 });
+    mockCacheHealth.mockResolvedValue({ status: 'up' });
+
+    const res = await request(app).get('/v1/health');
+
+    expect(res.status).toBe(200);
+    expect(res.body.data.dependencies.cache).toEqual({ status: 'up' });
+  });
+
+  it('stays healthy when the cache is down, and says so', async () => {
+    // The cache is optional: every source client falls through to a live fetch
+    // without it. A down cache must be VISIBLE without failing the check — the
+    // whole point of #62, where a dependency failing 100% of the time still
+    // read "healthy" because nothing reported it.
+    opHealth.mockResolvedValue({ status: 'up' });
+    mockFetch.mockResolvedValue({ ok: true, status: 200 });
+    mockCacheHealth.mockResolvedValue({ status: 'down', error: 'read ECONNRESET' });
+
+    const res = await request(app).get('/v1/health');
+
+    expect(res.status).toBe(200);
+    expect(res.body.success).toBe(true);
+    expect(res.body.data.status).toBe('healthy');
+    expect(res.body.data.dependencies.cache).toEqual({
+      status: 'down',
+      error: 'read ECONNRESET',
+    });
+  });
+
+  it('does not 503 the health check when the cache probe itself throws', async () => {
+    // cacheHealth() is written never to reject, but the route must not depend on
+    // that: an optional dependency has no business failing the whole check.
+    opHealth.mockResolvedValue({ status: 'up' });
+    mockFetch.mockResolvedValue({ ok: true, status: 200 });
+    mockCacheHealth.mockRejectedValue(new Error('Invalid URL'));
+
+    const res = await request(app).get('/v1/health');
+
+    expect(res.status).toBe(200);
+    expect(res.body.data.dependencies.cache.status).toBe('down');
+  });
+});
+
+describe('GET /v1/health — failure paths', () => {
+  it('reports keycloak down when the JWKS fetch rejects outright', async () => {
+    opHealth.mockResolvedValue({ status: 'up' });
+    mockFetch.mockRejectedValue(new Error('getaddrinfo ENOTFOUND kc'));
+
+    const res = await request(app).get('/v1/health');
+
+    expect(res.status).toBe(503);
+    expect(res.body.data.status).toBe('degraded');
+    expect(res.body.data.dependencies.keycloak).toEqual({
+      status: 'down',
+      error: 'getaddrinfo ENOTFOUND kc',
+    });
+  });
+
+  it('reports keycloak down with the status when JWKS answers non-2xx', async () => {
+    opHealth.mockResolvedValue({ status: 'up' });
+    mockFetch.mockResolvedValue({ ok: false, status: 500 });
+
+    const res = await request(app).get('/v1/health');
+
+    expect(res.status).toBe(503);
+    expect(res.body.data.dependencies.keycloak).toEqual({ status: 'down', error: 'HTTP 500' });
+  });
+
+  it('503s unhealthy when the probe itself throws, rather than reporting degraded', async () => {
+    // A required dependency failing is 'degraded'; the check being unable to run
+    // at all is 'unhealthy'. The two are distinct and the payload differs.
+    opHealth.mockRejectedValue(new Error('operaton client exploded'));
+    mockFetch.mockResolvedValue({ ok: true, status: 200 });
+
+    const res = await request(app).get('/v1/health');
+
+    expect(res.status).toBe(503);
+    expect(res.body.success).toBe(false);
+    expect(res.body.data.status).toBe('unhealthy');
+    expect(res.body.data.error).toBe('operaton client exploded');
+  });
+
+  it('survives a cache probe that rejects with a non-Error', async () => {
+    // The String(err) arm. A rejected non-Error is what a stray `throw 'oops'`
+    // or an aborted promise produces, and it must not take the endpoint down.
+    opHealth.mockResolvedValue({ status: 'up' });
+    mockFetch.mockResolvedValue({ ok: true, status: 200 });
+    mockCacheHealth.mockRejectedValue('socket closed');
+
+    const res = await request(app).get('/v1/health');
+
+    expect(res.status).toBe(200);
+    expect(res.body.data.dependencies.cache).toEqual({
+      status: 'down',
+      error: 'socket closed',
+    });
   });
 });

--- a/packages/backend/src/routes/health.routes.ts
+++ b/packages/backend/src/routes/health.routes.ts
@@ -1,6 +1,7 @@
 import express from 'express';
 import { config } from '@utils/config';
 import { operatonService } from '@services/operaton.service';
+import { cacheHealth } from '../pa-monitoring/pa-cache';
 import { createLogger } from '@utils/logger';
 import packageJson from '../../package.json';
 
@@ -37,6 +38,23 @@ router.get('/', async (req, res) => {
       };
     }
 
+    // The PA cache is optional: it is fail-soft by design and every source
+    // client falls through to a live fetch without it, so it is reported but
+    // deliberately excluded from `allUp`. Reporting is the whole point — a
+    // cache that was failing 100% of the time still read "healthy" for at
+    // least nine days (#62), because nothing here looked at it.
+    //
+    // cacheHealth() also drives reconnection, so polling this endpoint is what
+    // recovers the cache after an outage. Its own cooldown means at most one
+    // connect attempt per thirty seconds regardless of how often it is called.
+    // cacheHealth() is written never to reject, but the route does not rely on
+    // that: an optional dependency must not be able to fail the check that
+    // reports it. Without this guard a throwing probe 503s the whole endpoint.
+    const cache = await cacheHealth().catch((err: unknown) => ({
+      status: 'down' as const,
+      error: err instanceof Error ? err.message : String(err),
+    }));
+
     // Overall status
     const allUp = operatonHealth.status === 'up' && keycloakHealth.status === 'up';
     const overallStatus = allUp ? 'healthy' : 'degraded';
@@ -53,11 +71,13 @@ router.get('/', async (req, res) => {
       dependencies: {
         keycloak: keycloakHealth,
         operaton: operatonHealth,
+        cache,
       },
     };
 
     logger.info('Health check completed', {
       status: overallStatus,
+      cache: cache.status,
       duration: healthData.duration,
     });
 


### PR DESCRIPTION
Fixes the two code items in #62. The misconfiguration itself was already fixed
operationally on ACC; this is what stops the same outage running unseen again.

**#62 stays open** — PROD still carries the original `redis://`-against-the-TLS-port
setting.

## The root cause was not what #62 originally said

#62 identified the misconfiguration correctly but not why it was *silent*. The
answer is that **`connect()` was unbounded**. `withTimeout()` guarded `get()` and
`set()` but not the connect itself, and node-redis retries a failing socket
internally rather than rejecting — so the await never settled.

That is why neither `"PA cache Redis connected"` nor `"PA cache Redis unavailable"`
appeared in the log even once, across 10,269 errors. The logs described the
symptom forever and the state never. The connect now has its own 3 s budget.

## Three fixes

**1. Bounded connect.** As above. A connect that never settles now fails and is
reported, rather than hanging the state machine.

**2. The retry actually retries.** `connectAttempted` was cleared only in the
`catch`, and this failure arrives as an `'error'` **event** rather than a
rejection — so the catch never ran, the flag stayed set, and the client stayed
`null`. PA caching was then disabled until the process restarted, turning any
transient blip permanent. Connection state is now tracked behind a 30 s
cooldown; a client that is no longer ready is torn down rather than issued
commands; and teardown stops the internal reconnect loop that produced the log
volume.

**3. `/v1/health` reports the cache.** It covered keycloak and operaton, so a
dependency failing 100% of the time still read `healthy`. `cache` is now in
`dependencies` and deliberately **not** in `allUp` — it is fail-soft by design
and every source client falls through to a live fetch without it, so a down
cache must be *visible* without failing the check.

`cacheHealth()` also drives reconnection, so polling `/v1/health` is what
recovers the cache after an outage rather than a restart. Its cooldown means at
most one connect attempt per thirty seconds however often it is polled.

Plus: an identical repeated error logs once until it changes. 10,269 copies of
`read ECONNRESET` is volume, not signal, and it is what buried the state.

## Two bugs the tests caught, not review

Both would have shipped:

- **`createClient()` throws synchronously on a malformed URL.** Nothing caught
  it, so `cacheHealth()` rejected and the route's catch answered **503** —
  turning an optional dependency into a fatal one, the exact opposite of the
  intent. A route test failed with `Expected: 200, Received: 503`. Now caught in
  `openClient`, and the route guards the call independently rather than relying
  on that.
- **A worthless test.** An error-logging test asserted
  `typeof ...length === 'number'`, which passes however the code behaves.
  Replaced with real assertions, then mutation-checked: disabling the dedupe
  guard fails two tests.

An unreachable `try/catch` added mid-work in `cacheHealth` was **removed** rather
than covered — `openClient` already catches the only throwing path, so it was
untestable defensive code implying a failure mode that does not exist. Same
argument as #61.

## Verification

- **1870 backend tests pass, run serially** (84 suites)
- `pa-cache.ts` **86.36%** branch, `health.routes.ts` **81.81%** — both above the
  per-file floor set in #58. They were 70.83% and 77.27% mid-change; this raises
  them rather than regressing a standard set the same day.
- `check-format`, `type-check` and `lint` clean repo-wide

Tests pin the states that actually occurred: a connect that never settles, a
client that connects but never becomes ready (the ECONNRESET loop exactly),
recovery after the cooldown without a restart, and a down cache reported without
failing the health check.

## After merge

`Build Backend for ACC` runs on push. The backend still needs its separate
deploy script for this to reach ACC — worth doing, since `/v1/health` gaining a
`cache` entry is only useful once it is deployed.
