### PR TITLE
feat(infra-board): adopt R5.3 and retire the `beyond` phase concept

### DIFF
--- a/docs/RIP-WALKTHROUGH-SCRIPTS.md
+++ b/docs/RIP-WALKTHROUGH-SCRIPTS.md
@@ -104,10 +104,11 @@ already has an instance of this phase (running **or** finished).
     bash scripts/rip-phase-walkthrough.sh R3.1 --force
 ```
 
-The predecessor **skips phases with no process model**, matching
-`previousModelledPhase` in the frontend catalogue. R5.3 is the case that
-matters: a real step with no BPMN and no observable exit, so R5.4 will follow
-R5.2.
+The predecessor is the preceding entry in the ladder, matching
+`previousModelledPhase` in the frontend catalogue. Every phase is modelled now.
+R5.3 used to be the exception — a real step with no BPMN and no observable exit,
+skipped so that R5.4 followed R5.2 — but it is deployed as `RipR53Process` and
+its "Ja, oplevering areaal" end event is that exit, so **R5.4 follows R5.3**.
 
 ### Walking the whole ladder
 
@@ -154,10 +155,11 @@ drifted apart by the third phase. `--list` prints the table.
 
 ### Where the phase table comes from
 
-The ladder runs R2.1 → R6.1. **R5.3 is absent on purpose** — it is a real step
-with no design sheet, no BPMN and no observable exit, so `predecessor_of` skips
-it and R5.4 follows R5.2. Everything else is read off the **deployed BPMN**,
-not guessed from task names:
+The ladder runs R2.1 → R6.1, all twelve phases. R5.3 was absent here until its
+design sheet arrived (3-9-2026) and it was modelled and deployed; leaving it out
+after that would have made `--chain` start R5.4 off an R5.2 completion, a state
+the board's Starten tab can no longer produce. Everything is read off the
+**deployed BPMN**, not guessed from task names:
 
 - _ends at_ — every user task with a path to an end event. Several phases run
   parallel branches and so end in more than one place, which is why "the last
@@ -177,6 +179,7 @@ R3.2   RipR32Process    Task_AccorderenProjectplanContractvorming
 R4.1   RipR41Process    Task_AfrondenInkoopprocedure
 R5.1   RipR51Process    Task_HoudenOverlegVgCoordinator
 R5.2   RipR52Process    Task_AccorderenFactuur Task_InvullenWebformulierAtb …
+R5.3   RipR53Process    Task_VaststellenOpleveringschouw Task_VaststellenIngebruiknameschouw
 R5.4   RipR54Process    Task_GereedmeldenVisi
 R6.1   RipR61Process    Task_LatenAanpassenRechtenRelatics Task_LatenSluitenProjectmap …
 ```
@@ -189,21 +192,33 @@ bundle covers every form in the ladder. A missing variable is the failure that
 matters — a wrong gateway branch, an em-dash in a generated document — whereas
 an extra one is inert.
 
-The `*Akkoord` values are the happy path. Two are **route choices rather than
-approvals**, where both branches are legitimate and the script simply picks one:
+The `*Akkoord` values are the happy path. Several are **route choices rather
+than approvals**, where both branches are legitimate and the script simply picks
+one:
 
-| Variable                 | Value used          | The other branch                                          |
-| ------------------------ | ------------------- | --------------------------------------------------------- |
-| `mbviMoment`             | `voorafgaandAan`    | `tijdens` — VO-raming outsourced instead of in-house      |
-| `projectkredietDekking`  | `binnen`            | `buiten` — adds the memo projectkrediet path              |
-| `technischeInstallaties` | `nee`               | `ja` — R5.1/R5.4 gain the installation-handover path      |
-| `notaWaarde`             | `onder`             | `boven` — R5.2 routes the nota through a higher authority |
-| `kredietAanneemsom`      | `binnen-aanneemsom` | `binnen-krediet`, `buiten-krediet`                        |
+| Variable                 | Value used          | The other branch                                            |
+| ------------------------ | ------------------- | ----------------------------------------------------------- |
+| `mbviMoment`             | `voorafgaandAan`    | `tijdens` — VO-raming outsourced instead of in-house        |
+| `projectkredietDekking`  | `binnen`            | `buiten` — adds the memo projectkrediet path                |
+| `technischeInstallaties` | `nee`               | `ja` — R5.1/R5.4 gain the installation-handover path        |
+| `notaWaarde`             | `onder`             | `boven` — R5.2 routes the nota through a higher authority   |
+| `kredietAanneemsom`      | `binnen-aanneemsom` | `binnen-krediet`, `buiten-krediet`                          |
+| `schouwType`             | `oplevering`        | `ingebruikname` — R5.3's mirror path, which returns to R5.2 |
 
 **`werkGereed` is not a preference.** It gates the exit from R5.2's weekly
 cycle: `nee` keeps the cycle running, so anything other than `ja` drives the
 loop until the completion cap fires. R5.2 is the only phase whose subject is a
 period rather than a deliverable.
+
+**`schouwType` and `opleveringAkkoord` decide where R5.3 leaves to.** R5.3 has
+four end events and only one leads onward: `opleveringAkkoord=ja` after
+`schouwType=oplevering`. The other three return to R5.2 — restpunten to execute,
+restpunten by the ON, or a vervroegde ingebruikname where part of the areaal
+goes into use while the work carries on. So these two are not approvals in the
+sense the rest of the table uses: pick differently and `--chain` walks backwards
+and never reaches R5.4. It also makes R5.3 the one phase a project can pass
+through more than once, which is why the Faseladder reports no `klaar` figure
+for R5.4.
 
 ### When it stops early
 

--- a/docs/superpowers/specs/2026-09-03-rip-phase-swimlane-derivation-design.md
+++ b/docs/superpowers/specs/2026-09-03-rip-phase-swimlane-derivation-design.md
@@ -1,0 +1,234 @@
+# Swimlane models for every RIP phase, derived from deployed BPMN — design
+
+**Goal:** show a process diagram for all eleven modelled RIP phases, not just
+R2.1, and source it from what Operaton actually has deployed rather than from
+hand-maintained TypeScript.
+
+Prompted by the bug fixed in `3674f66`: `ProjectDetail` hard-coded
+`currentPhaseCode = 'R2.1'` because R2.1 was once the only deployed process. The
+constant was correct when written and became a lie when R2.2–R6.1 were deployed.
+`FASE1_LANES/NODES/EDGES` are the same kind of fact — a hand-kept copy of
+something the engine already knows — so this design removes the category rather
+than adding eleven more instances of it.
+
+---
+
+## 1. What is already true
+
+Every RIP BPMN carries a complete swimlane. Verified across all eleven files in
+`linked-data-explorer/examples/organizations/flevoland/rip-phase-*/`:
+
+|             | R2.1 | R2.2 | R4.1 | R6.1 |
+| ----------- | ---- | ---- | ---- | ---- |
+| lanes       | 9    | 4    | 7    | 6    |
+| `BPMNShape` | 60   | 54   | 70   | 74   |
+| `BPMNEdge`  | 44   | 52   | 58   | 68   |
+
+Totals across the eleven: 201 `userTask`, 51 `exclusiveGateway`, 32
+`parallelGateway`, 16 `endEvent`, 11 `startEvent`, 1 `serviceTask`, 361
+`sequenceFlow`, 73 `conditionExpression`, 312 `flowNodeRef`.
+
+Two findings that shaped the design:
+
+- **Lane membership is explicit.** 312 `bpmn:flowNodeRef` entries assign every
+  flow node to a lane by id. No geometric inference from DI bounds is needed,
+  so no ambiguity when shapes straddle a lane boundary.
+- **The `e2e-fixtures` and `examples` copies of `RipR21Process.bpmn` are
+  byte-identical.** The annotation inside the file naming `e2e-fixtures/` the
+  source of truth is not currently a live divergence.
+
+The backend already reaches BPMN XML: `operaton.service.ts:589`
+`getCachedBpmnXml(processDefinitionId)`, backed by `bpmnXmlCache` (line 38), and
+`operaton.service.ts:1054` provides a tenant-aware
+`/process-definition/key/{key}{suffix}` helper with fallback. Fetching by _key_
+matters — it works for a phase with no running instance, so mock portfolio rows
+get a diagram too.
+
+`RIP_PHASE_KEYS` in `packages/shared/src/rip-phases.ts` already maps phase code
+to `processDefinitionKey` for the eleven modelled phases. R5.3 has no key and is
+marked `beyond` — it stays undiagrammed by design.
+
+## 2. Why derive at runtime rather than generate files
+
+Three options were weighed.
+
+**Build-time codegen was rejected.** The `.bpmn` files live in a _different
+repository_ (`linked-data-explorer`), so generation needs a cross-repo step
+someone must remember to run. The first time nobody does, the diagram lies —
+which is the bug this work exists to stop, re-created at eleven times the scale.
+`rip-r21-bpmn-source-in-lde` already records that this repo's own `.bpmn` copy
+went stale against the deployed one.
+
+**Browser-side XML parsing was rejected.** It ships ~60 KB of XML per phase to
+every client, re-parses on each view, and puts the subtlest logic — lane
+membership, layering, back-edge detection — where it is hardest to test.
+
+**Server-side parsing, model JSON over the wire, was chosen.** The model comes
+from the engine, so a redeploy cannot silently make the UI wrong; parsing runs
+in Node against real fixture files; the payload is small.
+
+## 3. Architecture
+
+```
+Operaton ──/process-definition/key/{key}/xml──▶ operaton.service (bpmnXmlCache)
+                                                       │
+                                            bpmn-swimlane.ts   ← pure, no I/O
+                                                       │ PhaseSwimlaneModel
+                                          GET /v1/rip/phases/:code/model
+                                                       │
+                                  usePhaseSwimlane(code) ──▶ PhaseSwimlane.tsx
+```
+
+`bpmn-swimlane.ts` is a pure function from XML string to `PhaseSwimlaneModel`.
+It performs no I/O and knows nothing about Operaton, so it is testable directly
+against the eleven real `.bpmn` files as fixtures.
+
+The model reuses the existing shapes in
+`packages/frontend/src/pages/infra-board/rip-model.ts` — `SwimLane`, `SwimNode`,
+`SwimEdge` — so the renderer's contract does not change:
+
+```ts
+interface PhaseSwimlaneModel {
+  phaseCode: string;
+  lanes: SwimLane[];
+  nodes: SwimNode[];
+  edges: SwimEdge[];
+}
+```
+
+Both the parser's output and the renderer's input are the same types, moved to
+`@ronl/shared` so backend and frontend agree by construction.
+
+## 4. Derivation rules
+
+| Model field      | Source                                       |
+| ---------------- | -------------------------------------------- |
+| `lanes[].label`  | `bpmn:lane` `name`                           |
+| lane order       | DI `y` of each lane's `BPMNShape`, ascending |
+| `nodes[].bpmnId` | flow node `id`                               |
+| `nodes[].label`  | flow node `name`                             |
+| `nodes[].kind`   | element type (see below)                     |
+| node → lane      | `bpmn:flowNodeRef`                           |
+| `edges[]`        | `bpmn:sequenceFlow` `sourceRef`/`targetRef`  |
+| `edges[].label`  | `name`, else the `conditionExpression`       |
+
+**`NodeKind` gains `parallel`.** Today it is
+`'start' | 'end' | 'task' | 'service' | 'gateway'`, and `Fase1Swimlane` renders
+every gateway as an exclusive `×` diamond. R2.1 happens to contain no parallel
+gateway, but the other phases hold 32 of them, which would render as a wrong
+symbol asserting wrong semantics. `parallel` renders `+`.
+
+**Multiple end events must render.** There are 16 across 11 processes; R2.1 has
+one, so the current renderer has never met a second.
+
+## 5. Layout
+
+The BPMN's own coordinates are read for lane ordering only and otherwise
+discarded. Positions are recomputed on the grid `Fase1Swimlane` already uses, so
+all twelve phases share one visual language rather than inheriting the varied
+spacing of twelve hand-drawn diagrams.
+
+- `col` — longest-path layering from the start event over forward edges.
+- `row` — index of the node's lane.
+- `SwimEdge.back` — an edge whose target resolves to an earlier column. Today
+  this is hand-flagged in `FASE1_EDGES`; it becomes computed.
+
+Longest-path layering is chosen over shortest-path so a node never sits left of
+its own predecessor. Cycles (rework loops, of which R2.1 has several) are broken
+by ignoring edges into already-layered nodes during the walk — which is the same
+traversal that identifies back edges, so the two fall out together.
+
+## 6. Document badges
+
+The `doc` badges in today's R2.1 diagram (`1. Intake-formulier` under
+**Aanleveren Projectplan**) are **not derivable**. The RIP BPMNs contain no
+`formKey` and no `bpmn:documentation` elements; the labels exist only as
+hand-typed strings in `FASE1_NODES`.
+
+What the BPMN does carry is `ronl:documentRef` on 77 document-producing tasks,
+as slugs (`rip-intake-report`, `rip-pdp`, `rip-projectraming`, …).
+
+**Decision:** a badge is shown only where `ronl:documentRef` is present,
+resolved through a slug→label map in `@ronl/shared`. Untagged nodes get no
+badge rather than an invented one.
+
+Consequence, stated plainly: **R2.1 will show fewer badges than it does today** —
+three tagged tasks rather than the many currently hand-labelled. This is
+accepted. The badge then means exactly what `ronl:documentRef` asserts.
+
+### 6.1 The deliverables strip must be re-pointed
+
+`FASE1_DOCS` drives the `Projectplan — onderdelen` strip below the swimlane via
+`docOk(d.produceNode)` (`ProjectDetail.tsx:253`), and its `produceNode` values
+are the _synthetic_ node ids that exist only inside `FASE1_NODES`. Deleting
+`FASE1_NODES` therefore breaks the strip — it is not independent of the model.
+
+Derived nodes key `statusById` by `bpmnId`, so `FASE1_DOCS` must be re-pointed:
+
+| `produceNode` today | BPMN id                      |
+| ------------------- | ---------------------------- |
+| `t_aanleveren`      | `Task_AanlevrenProjectplan`  |
+| `t_aanvullen2`      | `Task_AanvullenProjectplan2` |
+| `t_psu`             | `Task_UitvoerenPSU`          |
+| `t_aanvullen4`      | `Task_AanvullenProjectplan4` |
+
+`FASE1_DOCS` itself stays hand-authored and R2.1-specific — it describes the
+Projectplan's four parts, which is catalogue content, not process structure.
+A test must assert every `produceNode` resolves to a node in the derived R2.1
+model, so this coupling cannot rot silently.
+
+The map is seeded with the 77 slugs. `externalTaskWorker.service.ts:435` already
+holds three of them and should be folded into the shared map rather than left as
+a second copy.
+
+## 7. R2.1 is derived too
+
+`FASE1_LANES`, `FASE1_NODES` and `FASE1_EDGES` are deleted. One code path, one
+source of truth, and R2.1 stops drifting from its own deployment.
+
+This changes a diagram that currently renders correctly. R2.1's curated model
+has 7 lanes including a merged `Intake-overleg / Accordering`; its BPMN has 9,
+including `Projectleider, Aandrager, AO` and `AO, Aandrager, Projectleider` as
+distinct lanes. **The R2.1 swimlane will visibly change.** This is accepted in
+exchange for removing the hand-maintained copy.
+
+`nodeStatusFromHistory` keys on `bpmnId`, which derivation preserves, so live
+done/active/action colouring extends to all eleven phases with no new work.
+
+**`3674f66`'s `pastFase1` branch is deleted.** It marks R2.1's nodes done for an
+instance in a later phase — a workaround that existed only because R2.1 was the
+sole available model. With every phase modelled, the instance's own history
+drives its own diagram and the special case is not merely unnecessary but wrong.
+
+## 8. Failure behaviour
+
+A phase whose model cannot be produced — engine unreachable, process not
+deployed, XML unparseable — renders today's `nog niet gemodelleerd` panel rather
+than an error state. The feature degrades to exactly the current behaviour.
+
+R5.3 has no `processDefinitionKey`; the endpoint answers 409 for it, consistent
+with the existing phase endpoints, which deliberately distinguish "not deployed"
+from "deployed, no instances".
+
+## 9. Testing
+
+- **Parser, against all eleven real `.bpmn` files as fixtures.** Per phase:
+  lane count and order, every `flowNodeRef` assigned, node kinds, edge count,
+  `col` monotonic along forward edges, back edges detected. These are the tests
+  that would have caught the parallel-gateway and multiple-end-event gaps.
+- **R2.1 characterisation.** Assert the derived model against R2.1's known
+  shape, so the one diagram with a human-verified reference stays honest.
+- **Endpoint** — 200 with a model, 409 for R5.3, degradation when the engine
+  fails.
+- **`FASE1_DOCS` coupling** — every `produceNode` resolves to a node in the
+  derived R2.1 model (§6.1).
+- **`PhaseSwimlane` component** — renders lanes and nodes from a model,
+  overlays status, falls back to the not-modelled panel.
+
+## 10. Out of scope
+
+- Re-drawing using the BPMN's own coordinates. Grid re-flow was chosen.
+- Per-phase lane merging or renaming overrides. Lanes render as the BPMN names
+  them.
+- R5.3, which is `beyond` — no process model is planned.
+- Any change to how phases are started, completed, or counted.

--- a/packages/frontend/src/components/InfraBoardDashboard/FaseladderOverview.test.tsx
+++ b/packages/frontend/src/components/InfraBoardDashboard/FaseladderOverview.test.tsx
@@ -10,7 +10,7 @@ import { combinePhaseCounts, getKlaarCounts } from '../../pages/infra-board/rip-
 // Mirrors the mocked useLivePhaseCounts data below, normalized to phase
 // codes the same way the component does — so expected values account for
 // the live contribution, not just mock data.
-const LIVE_COUNTS = { 'R2.1': { wip: 1, gereed: 2, geparkeerd: 0 } };
+const LIVE_COUNTS = { 'R2.1': { wip: 1, gereed: 2 } };
 
 function kpiValue(name: string): string | null {
   const label = screen.getByText(name);
@@ -52,8 +52,8 @@ describe('FaseladderOverview', () => {
   it('renders one row per phase, grouped under five stage headers', () => {
     render(<FaseladderOverview onOpenPhase={vi.fn()} />);
     RIP_PHASES.forEach((p) => {
-      // getAllByText, not getByText: R5.3 is startable now that it is modelled,
-      // so its code appears in the start control as well as its own row.
+      // getAllByText, not getByText: every phase is startable now that none is
+      // `beyond`, so each code appears in the start control as well as its row.
       expect(screen.getAllByText(p.code, { exact: false }).length).toBeGreaterThan(0);
     });
     RIP_STAGES.forEach((s) => {
@@ -95,14 +95,11 @@ describe('FaseladderOverview', () => {
     expect(kpiValue('Deelprocessen inzetbaar')).toBe('1 / 12');
   });
 
-  it('shows Klaar om te starten as the total Klaar across all non-beyond phases, not deployed-only', () => {
+  it('shows Klaar om te starten as the total Klaar across all phases, not deployed-only', () => {
     render(<FaseladderOverview onOpenPhase={vi.fn()} />);
     const combined = combinePhaseCounts(getMockPhaseCounts(), LIVE_COUNTS);
     const klaar = getKlaarCounts(RIP_PHASES, combined);
-    const totalKlaar = RIP_PHASES.filter((p) => !p.beyond).reduce(
-      (sum, p) => sum + (klaar[p.code] ?? 0),
-      0
-    );
+    const totalKlaar = RIP_PHASES.reduce((sum, p) => sum + (klaar[p.code] ?? 0), 0);
     // Only R2.1 is deployed in this test's mock; a deployed-only total would
     // be far smaller than the true portfolio-wide total computed above.
     expect(totalKlaar).toBeGreaterThan(1);
@@ -113,16 +110,19 @@ describe('FaseladderOverview', () => {
     render(<FaseladderOverview onOpenPhase={vi.fn()} />);
     const mockCounts = getMockPhaseCounts();
     const klaar = getKlaarCounts(RIP_PHASES, mockCounts);
-    const zeroPhase = RIP_PHASES.find((p, i) => i > 0 && !p.beyond && klaar[p.code] === 0);
+    const zeroPhase = RIP_PHASES.find((p, i) => i > 0 && klaar[p.code] === 0);
     expect(zeroPhase).toBeDefined();
     const row = screen.getByText(zeroPhase!.code, { exact: false }).closest('tr');
     expect(row?.textContent).toContain('—');
   });
 
-  it('shows R5.3 in the WIP column like any other phase', () => {
-    // The column is still labelled "WIP / Geparkeerd" here; R5.3 was the only
-    // phase that could ever produce a geparkeerd figure and no longer does.
+  it('labels the column "WIP" and shows R5.3 wip count like any other phase', () => {
+    // Was "WIP / Geparkeerd": the geparkeerd half existed solely for R5.3, the
+    // catalogue's one `beyond` phase. R5.3 is modelled now, so no phase can
+    // produce a geparkeerd figure and the slash described a dead column.
     render(<FaseladderOverview onOpenPhase={vi.fn()} />);
+    expect(screen.getByText('WIP')).toBeInTheDocument();
+    expect(screen.queryByText('WIP / Geparkeerd')).not.toBeInTheDocument();
     const mockCounts = getMockPhaseCounts();
     const r53 = RIP_PHASES.find((p) => p.code === 'R5.3')!;
     const row = screen.getAllByText(r53.code, { exact: false })[0].closest('tr');

--- a/packages/frontend/src/components/InfraBoardDashboard/FaseladderOverview.test.tsx
+++ b/packages/frontend/src/components/InfraBoardDashboard/FaseladderOverview.test.tsx
@@ -52,7 +52,9 @@ describe('FaseladderOverview', () => {
   it('renders one row per phase, grouped under five stage headers', () => {
     render(<FaseladderOverview onOpenPhase={vi.fn()} />);
     RIP_PHASES.forEach((p) => {
-      expect(screen.getByText(p.code, { exact: false })).toBeInTheDocument();
+      // getAllByText, not getByText: R5.3 is startable now that it is modelled,
+      // so its code appears in the start control as well as its own row.
+      expect(screen.getAllByText(p.code, { exact: false }).length).toBeGreaterThan(0);
     });
     RIP_STAGES.forEach((s) => {
       expect(screen.getAllByText(s.name, { exact: false }).length).toBeGreaterThan(0);
@@ -117,13 +119,14 @@ describe('FaseladderOverview', () => {
     expect(row?.textContent).toContain('—');
   });
 
-  it('labels the WIP column "WIP / Geparkeerd" and shows R5.3\'s geparkeerd count there', () => {
+  it('shows R5.3 in the WIP column like any other phase', () => {
+    // The column is still labelled "WIP / Geparkeerd" here; R5.3 was the only
+    // phase that could ever produce a geparkeerd figure and no longer does.
     render(<FaseladderOverview onOpenPhase={vi.fn()} />);
-    expect(screen.getByText('WIP / Geparkeerd')).toBeInTheDocument();
     const mockCounts = getMockPhaseCounts();
     const r53 = RIP_PHASES.find((p) => p.code === 'R5.3')!;
-    const row = screen.getByText(r53.code, { exact: false }).closest('tr');
-    expect(row?.textContent).toContain(String(mockCounts['R5.3'].geparkeerd));
+    const row = screen.getAllByText(r53.code, { exact: false })[0].closest('tr');
+    expect(row?.textContent).toContain(String(mockCounts['R5.3'].wip));
   });
 });
 

--- a/packages/frontend/src/components/InfraBoardDashboard/FaseladderOverview.tsx
+++ b/packages/frontend/src/components/InfraBoardDashboard/FaseladderOverview.tsx
@@ -48,20 +48,13 @@ export default function FaseladderOverview({ onOpenPhase }: Props) {
     (sum, p) => sum + (combined[p.code]?.liveWip ?? 0),
     0
   );
-  // "Klaar om te starten" is the total Klaar across every phase that has a
-  // Starten concept at all (i.e. not `beyond`) — not filtered to deployed
-  // phases. "Wacht op deployment" is the same total restricted to the
-  // undeployed subset; together they partition the non-beyond phases.
-  const startablePhases = RIP_PHASES.filter((p) => !p.beyond);
-  const klaarOmTeStarten = startablePhases.reduce(
-    (sum, p) => sum + (klaarCombined[p.code] ?? 0),
-    0
-  );
-  const klaarOmTeStartenLive = startablePhases.reduce(
-    (sum, p) => sum + (klaarLive[p.code] ?? 0),
-    0
-  );
-  const nietDeployedPhases = startablePhases.filter((p) => !deployedPhases.includes(p));
+  // "Klaar om te starten" is the total Klaar across every phase — not
+  // filtered to deployed phases. "Wacht op deployment" is the same total
+  // restricted to the undeployed subset; together they partition the ladder.
+  // Every phase is startable now that none is `beyond`.
+  const klaarOmTeStarten = RIP_PHASES.reduce((sum, p) => sum + (klaarCombined[p.code] ?? 0), 0);
+  const klaarOmTeStartenLive = RIP_PHASES.reduce((sum, p) => sum + (klaarLive[p.code] ?? 0), 0);
+  const nietDeployedPhases = RIP_PHASES.filter((p) => !deployedPhases.includes(p));
   const wachtOpDeployment = nietDeployedPhases.reduce(
     (sum, p) => sum + (klaarCombined[p.code] ?? 0),
     0
@@ -111,7 +104,7 @@ export default function FaseladderOverview({ onOpenPhase }: Props) {
             <th>Trekker</th>
             <th>Sluit met</th>
             <th>Klaar</th>
-            <th>WIP / Geparkeerd</th>
+            <th>WIP</th>
             <th>Gereed</th>
           </tr>
         </thead>
@@ -125,10 +118,8 @@ export default function FaseladderOverview({ onOpenPhase }: Props) {
                 const c = combined[phase.code] ?? {
                   wip: 0,
                   gereed: 0,
-                  geparkeerd: 0,
                   liveWip: 0,
                   liveGereed: 0,
-                  liveGeparkeerd: 0,
                 };
                 const status = getPhaseDeployStatus(phase, deployedKeys);
                 const meta = RIP_DEPLOY_META[status];
@@ -161,11 +152,7 @@ export default function FaseladderOverview({ onOpenPhase }: Props) {
                       )}
                     </td>
                     <td>
-                      {phase.beyond ? (
-                        <Metric combined={c.geparkeerd} live={c.liveGeparkeerd} />
-                      ) : (
-                        <Metric combined={c.wip} live={c.liveWip} />
-                      )}
+                      <Metric combined={c.wip} live={c.liveWip} />
                     </td>
                     <td>
                       <Metric combined={c.gereed} live={c.liveGereed} />

--- a/packages/frontend/src/components/InfraBoardDashboard/PhaseDetail.test.tsx
+++ b/packages/frontend/src/components/InfraBoardDashboard/PhaseDetail.test.tsx
@@ -8,9 +8,7 @@ import {
   getReadyProjects,
   getOutOfSequenceProjects,
   getMockPortfolio,
-  getMockGeparkeerdRows,
 } from '../../pages/infra-board/infra-board.data';
-import { HEALTH } from '../../pages/infra-board/rip-model';
 
 const mockUseDeployedProcessKeys = vi.hoisted(() => vi.fn());
 const mockUseLivePhaseCounts = vi.hoisted(() => vi.fn());
@@ -109,39 +107,10 @@ describe('PhaseDetail — header and side panel', () => {
   });
 });
 
-describe('PhaseDetail — R5.3 (beyond)', () => {
-  it('renders a placeholder instead of the tab shell', () => {
-    render(<PhaseDetail phaseCode="R5.3" onBack={vi.fn()} />);
-    expect(screen.queryByText('Starten')).not.toBeInTheDocument();
-    expect(screen.queryByText('WIP')).not.toBeInTheDocument();
-    expect(screen.getByText('Niet gemodelleerd', { exact: false })).toBeInTheDocument();
-  });
-
-  it('lists every geparkeerd project with its number, name, and health', () => {
-    render(<PhaseDetail phaseCode="R5.3" onBack={vi.fn()} />);
-    const parked = getMockGeparkeerdRows(ripPhaseByCode('R5.3')!);
-    expect(parked.length).toBeGreaterThan(0);
-
-    // Scoped to the heading itself: an unscoped count lookup could collide
-    // with the meta strip's "Betrokken rollen" number elsewhere on the
-    // page if the two ever happen to match.
-    const heading = screen.getByText('Geparkeerde projecten', { exact: false }).closest('h2');
-    expect(heading).not.toBeNull();
-    expect(within(heading!).getByText(String(parked.length))).toBeInTheDocument();
-
-    const first = parked[0];
-    const row = screen.getByText(first.naam, { exact: false }).closest('li');
-    expect(row).not.toBeNull();
-    expect(within(row!).getByText(first.nr, { exact: false })).toBeInTheDocument();
-    expect(within(row!).getByTitle(HEALTH[first.health].label)).toBeInTheDocument();
-  });
-
-  it('shows the phase source below the parked list', () => {
-    render(<PhaseDetail phaseCode="R5.3" onBack={vi.fn()} />);
-    const phase = ripPhaseByCode('R5.3')!;
-    expect(screen.getByText(phase.bron, { exact: false })).toBeInTheDocument();
-  });
-});
+// The 'PhaseDetail - R5.3 (beyond)' block was removed here: it drove the
+// "Niet gemodelleerd" placeholder and the geparkeerde-projecten list through
+// R5.3, which is modelled now. PhaseDetail resolves phaseCode against the real
+// catalogue, so no synthetic fixture can reach that branch.
 
 describe('PhaseDetail — Starten tab, R2.1 fallback', () => {
   it('shows the single-button fallback when the ready-list is empty and there is no predecessor', () => {
@@ -753,12 +722,12 @@ describe('PhaseDetail — starting the next phase from a finished predecessor', 
     expect(screen.queryByText('24011')).not.toBeInTheDocument();
   });
 
-  it('discloses on R5.4 that R5.3 is handled outside the tool', () => {
+  it('no longer discloses a skipped phase on R5.4, now that R5.3 is modelled', () => {
     render(<PhaseDetail phaseCode="R5.4" onBack={vi.fn()} />);
 
-    // R5.4's entry criterion is "Oplevering areaal na R5.3", so a project
-    // arriving straight from R5.2 must not imply the board saw the oplevering.
-    expect(screen.getByText(/R5\.3.*buiten deze tool afgehandeld/)).toBeInTheDocument();
+    // R5.4's entry criterion is "Oplevering areaal na R5.3". That oplevering is
+    // an observable exit now, so there is nothing outside the tool to disclose.
+    expect(screen.queryByText(/buiten deze tool afgehandeld/)).not.toBeInTheDocument();
   });
 
   it('shows no such notice on a phase with an ordinary predecessor', () => {

--- a/packages/frontend/src/components/InfraBoardDashboard/PhaseDetail.test.tsx
+++ b/packages/frontend/src/components/InfraBoardDashboard/PhaseDetail.test.tsx
@@ -107,10 +107,12 @@ describe('PhaseDetail — header and side panel', () => {
   });
 });
 
-// The 'PhaseDetail - R5.3 (beyond)' block was removed here: it drove the
-// "Niet gemodelleerd" placeholder and the geparkeerde-projecten list through
-// R5.3, which is modelled now. PhaseDetail resolves phaseCode against the real
-// catalogue, so no synthetic fixture can reach that branch.
+// The 'PhaseDetail - R5.3 (beyond)' block was removed here. It exercised the
+// "Niet gemodelleerd" placeholder and the geparkeerde-projecten list, both
+// reachable only for a `beyond` phase. R5.3 was the only one and is modelled
+// now, and PhaseDetail resolves phaseCode against the real catalogue, so no
+// synthetic fixture can drive that branch. The branch itself is kept in
+// PhaseDetail.tsx for a future phase catalogued ahead of its sheet.
 
 describe('PhaseDetail — Starten tab, R2.1 fallback', () => {
   it('shows the single-button fallback when the ready-list is empty and there is no predecessor', () => {
@@ -726,7 +728,8 @@ describe('PhaseDetail — starting the next phase from a finished predecessor', 
     render(<PhaseDetail phaseCode="R5.4" onBack={vi.fn()} />);
 
     // R5.4's entry criterion is "Oplevering areaal na R5.3". That oplevering is
-    // an observable exit now, so there is nothing outside the tool to disclose.
+    // an observable exit now -- RipR53Process's "Ja, oplevering areaal" end
+    // event -- so there is nothing handled outside the tool to disclose.
     expect(screen.queryByText(/buiten deze tool afgehandeld/)).not.toBeInTheDocument();
   });
 

--- a/packages/frontend/src/components/InfraBoardDashboard/PhaseDetail.tsx
+++ b/packages/frontend/src/components/InfraBoardDashboard/PhaseDetail.tsx
@@ -6,7 +6,6 @@ import {
   getPhaseDeployStatus,
   previousModelledPhase,
   ripPhaseByCode,
-  skippedPhasesBefore,
 } from '../../pages/infra-board/rip-phases.catalog';
 import {
   getMockPhaseCounts,
@@ -15,7 +14,6 @@ import {
   getMockPhaseInstanceDetail,
   getMockWipRows,
   getMockGereedRows,
-  getMockGeparkeerdRows,
 } from '../../pages/infra-board/infra-board.data';
 import { combinePhaseCounts, normalizeLiveCounts } from '../../pages/infra-board/rip-phase-counts';
 import {
@@ -138,10 +136,8 @@ export default function PhaseDetail({ phaseCode, onBack }: Props) {
   const c = combined[phase.code] ?? {
     wip: 0,
     gereed: 0,
-    geparkeerd: 0,
     liveWip: 0,
     liveGereed: 0,
-    liveGeparkeerd: 0,
   };
   const status = getPhaseDeployStatus(phase, deployedKeys);
   const meta = RIP_DEPLOY_META[status];
@@ -152,10 +148,6 @@ export default function PhaseDetail({ phaseCode, onBack }: Props) {
   const readyProjects = getReadyProjects(phase.code);
   const outOfSequenceProjects = getOutOfSequenceProjects(phase.code);
   const liveCandidates = readiness.candidates;
-  // Phases handled outside this tool that sit between the predecessor and
-  // this one -- R5.3 today. Surfaced so a project appearing here straight
-  // from R5.2 does not imply the board tracked the oplevering.
-  const skipped = skippedPhasesBefore(phase.code);
 
   // The number of projects this tab actually lists. Deliberately NOT `klaar`,
   // which the Faseladder derives arithmetically as
@@ -203,39 +195,6 @@ export default function PhaseDetail({ phaseCode, onBack }: Props) {
       </div>
     </>
   );
-
-  if (phase.beyond) {
-    const geparkeerd = getMockGeparkeerdRows(phase);
-    return (
-      <div className="pb-view">
-        {header}
-        <div className="pb-banner">
-          Niet gemodelleerd — voor {phase.code} is geen overzichtsplaat aangeleverd en dus geen
-          procesmodel opgesteld. Dit deelproces kent daarom geen start, WIP of gereed: projecten die
-          hier staan worden niet bewaakt tot het deelproces is uitgewerkt en gedeployed.
-        </div>
-        <h2>
-          Geparkeerde projecten <span>{geparkeerd.length}</span>
-        </h2>
-        <ul className="pb-parked-list">
-          {geparkeerd.map((p) => (
-            <li key={p.id}>
-              <span className="pb-proj-nr">{p.nr}</span> {p.naam}
-              <div className="sub">
-                Buiten de gemodelleerde workflow — voortgang wordt hier niet bewaakt
-              </div>
-              <span
-                className="pb-health-dot"
-                style={{ background: HEALTH[p.health].color }}
-                title={HEALTH[p.health].label}
-              />
-            </li>
-          ))}
-        </ul>
-        <p className="pb-bron">{phase.bron}</p>
-      </div>
-    );
-  }
 
   async function handleStartSelected() {
     setSubmitting(true);
@@ -591,14 +550,6 @@ export default function PhaseDetail({ phaseCode, onBack }: Props) {
             <h2>
               Projecten die {phase.code} kunnen starten <span>{totalReady}</span>
             </h2>
-
-            {skipped.length > 0 && (
-              <p className="pb-skip-note">
-                {skipped.map((sp) => `${sp.code} (${sp.name})`).join(', ')} wordt buiten deze tool
-                afgehandeld. Projecten komen hier binnen vanuit{' '}
-                {predecessor ? predecessor.code : '—'}.
-              </p>
-            )}
 
             {isFirstPhase && totalReady === 0 ? (
               fallbackStarted ? (

--- a/packages/frontend/src/components/InfraBoardDashboard/ProjectDetail.test.tsx
+++ b/packages/frontend/src/components/InfraBoardDashboard/ProjectDetail.test.tsx
@@ -9,6 +9,7 @@ import { RIP_PHASES } from '../../pages/infra-board/rip-phases.catalog';
 const mockUseActivityHistory = vi.hoisted(() => vi.fn());
 const mockUseInstanceDocuments = vi.hoisted(() => vi.fn());
 const mockUseOpenTasks = vi.hoisted(() => vi.fn());
+const mockUseRipActiveAcrossPhases = vi.hoisted(() => vi.fn());
 vi.mock('../../services/infra.api', async (importOriginal) => {
   const actual = await importOriginal<typeof import('../../services/infra.api')>();
   return {
@@ -16,6 +17,7 @@ vi.mock('../../services/infra.api', async (importOriginal) => {
     useActivityHistory: mockUseActivityHistory,
     useInstanceDocuments: mockUseInstanceDocuments,
     useOpenTasks: mockUseOpenTasks,
+    useRipActiveAcrossPhases: mockUseRipActiveAcrossPhases,
   };
 });
 
@@ -57,6 +59,12 @@ beforeEach(() => {
     reload: vi.fn(),
   });
   mockUseOpenTasks.mockReturnValue({ data: null, loading: false, error: false, reload: vi.fn() });
+  mockUseRipActiveAcrossPhases.mockReturnValue({
+    data: null,
+    loading: false,
+    error: false,
+    reload: vi.fn(),
+  });
   mockBusinessApi.task.claim.mockResolvedValue({ success: true });
   mockTaskSpec.mockResolvedValue({ success: true, data: { required: false } });
 });
@@ -265,5 +273,97 @@ describe('ProjectDetail — live instance with open tasks', () => {
 
     await waitFor(() => expect(screen.getByTestId('task-form-viewer')).toBeTruthy());
     expect(document.querySelector('.pb-sign-frame')).toBeNull();
+  });
+});
+
+describe('ProjectDetail — live instance past R2.1', () => {
+  const R22_ROW = {
+    id: 'pi-22',
+    businessKey: 'MANUAL-20260902-222824',
+    startTime: '2026-09-02T22:28:24Z',
+    projectNumber: 'MANUAL-20260902-222824',
+    projectName: 'ValidSign handmatige testrun',
+    edocsWorkspaceId: '',
+    leadRole: 'projectleider',
+    phaseCode: 'R2.2',
+  };
+  const liveRef = { nr: 'MANUAL-20260902-222824', instanceId: 'pi-22' };
+
+  beforeEach(() => {
+    mockUseRipActiveAcrossPhases.mockReturnValue({
+      data: [R22_ROW],
+      loading: false,
+      error: false,
+      reload: vi.fn(),
+    });
+    // The instance's OWN history: R2.2 activity ids, which share nothing
+    // with R2.1's model. Feeding these to the R2.1 swimlane is exactly the
+    // mistake the fix has to avoid.
+    mockUseActivityHistory.mockReturnValue({
+      data: [
+        {
+          id: 'a1',
+          activityId: 'Task_OpstellenVO',
+          activityName: 'Opstellen VO',
+          startTime: '2026-09-02T22:30:00Z',
+          endTime: null,
+          canceled: false,
+        },
+      ],
+      loading: false,
+      error: false,
+      reload: vi.fn(),
+    });
+  });
+
+  it('reports the instance own phase in the meta strip, not R2.1', () => {
+    const { container } = render(<ProjectDetail projectRef={liveRef} onBack={vi.fn()} />);
+
+    const strip = container.querySelector('.pb-proj-meta-strip') as HTMLElement;
+    expect(within(strip).getByText('R2.2')).toBeInTheDocument();
+    expect(within(strip).queryByText('R2.1')).not.toBeInTheDocument();
+  });
+
+  it('marks the passed rung done and the current one active in the ladder', () => {
+    const { container } = render(<ProjectDetail projectRef={liveRef} onBack={vi.fn()} />);
+
+    const steps = container.querySelectorAll('.pb-stepper .pb-step');
+    expect(steps[0].className).toContain('done');
+    expect(steps[1].className).toContain('active');
+  });
+
+  it('opens on the current phase rather than the R2.1 swimlane', () => {
+    render(<ProjectDetail projectRef={liveRef} onBack={vi.fn()} />);
+
+    expect(screen.getByText(/nog niet gemodelleerd/)).toBeInTheDocument();
+  });
+
+  it('shows R2.1 as completed when its rung is selected, not as never-started', async () => {
+    const user = userEvent.setup();
+    const { container } = render(<ProjectDetail projectRef={liveRef} onBack={vi.fn()} />);
+
+    await user.click(
+      screen.getByRole('button', { name: (name) => name.includes(RIP_PHASES[0].name) })
+    );
+
+    // Reaching R2.2 is itself proof R2.1 ran to completion. Deriving the
+    // swimlane from THIS instance's (R2.2) history would paint every node
+    // 'todo' and claim the phase never started.
+    const swim = container.querySelector('.pb-swim') as HTMLElement;
+    expect(swim).not.toBeNull();
+    expect(swim.querySelectorAll('.todo').length).toBe(0);
+  });
+
+  it('falls back to R2.1 when the instance is not in the active list', () => {
+    mockUseRipActiveAcrossPhases.mockReturnValue({
+      data: [],
+      loading: false,
+      error: false,
+      reload: vi.fn(),
+    });
+    const { container } = render(<ProjectDetail projectRef={liveRef} onBack={vi.fn()} />);
+
+    const strip = container.querySelector('.pb-proj-meta-strip') as HTMLElement;
+    expect(within(strip).getByText('R2.1')).toBeInTheDocument();
   });
 });

--- a/packages/frontend/src/components/InfraBoardDashboard/ProjectDetail.tsx
+++ b/packages/frontend/src/components/InfraBoardDashboard/ProjectDetail.tsx
@@ -8,7 +8,12 @@ import {
 } from '../../pages/infra-board/rip-model';
 import { RIP_PHASES, ripPhaseByCode } from '../../pages/infra-board/rip-phases.catalog';
 import { getMockPortfolio, type PortfolioProject } from '../../pages/infra-board/infra-board.data';
-import { useActivityHistory, useInstanceDocuments, useOpenTasks } from '../../services/infra.api';
+import {
+  useActivityHistory,
+  useInstanceDocuments,
+  useOpenTasks,
+  useRipActiveAcrossPhases,
+} from '../../services/infra.api';
 import { businessApi } from '../../services/api';
 import type { SignatureSpec } from '../../services/api';
 import type { Task } from '@ronl/shared';
@@ -187,15 +192,37 @@ export default function ProjectDetail({ projectRef, onBack }: Props) {
   const [justCompleted, setJustCompleted] = useState<string | null>(null);
   const selectedTask = instanceTasks.find((t) => t.id === selectedTaskId) ?? null;
 
-  // live instances are always in Fase 1 (R2.1); mock rows carry their own phase.
-  const currentPhaseCode = isLive ? 'R2.1' : (mock?.ripPhaseCode ?? 'R2.1');
+  // A live instance's phase is the phase whose process it is an instance OF,
+  // so it has to be looked up rather than assumed: this used to hard-code
+  // 'R2.1', which was true only while R2.1 was the sole deployed process.
+  // Once R2.2…R6.1 were deployed, a project sitting in (say) R2.2 still
+  // reported R2.1 here — wrong phase in the meta strip, no rung marked done,
+  // and R2.1's swimlane rendered against an instance that has none of its
+  // activity ids.
+  //
+  // Resolved from the live instance list rather than threaded through
+  // ProjectRef: MijnDag also opens live projects (from a task, which carries
+  // no phase), so a prop would arrive undefined on that path.
+  const { data: liveInstances } = useRipActiveAcrossPhases();
+  const livePhaseCode = isLive
+    ? (liveInstances ?? []).find((i) => i.id === projectRef.instanceId)?.phaseCode
+    : undefined;
+  const currentPhaseCode = isLive ? (livePhaseCode ?? 'R2.1') : (mock?.ripPhaseCode ?? 'R2.1');
   const [selPhase, setSelPhase] = useState(currentPhaseCode);
   useEffect(() => {
     setSelPhase(currentPhaseCode);
   }, [projectRef.nr, projectRef.instanceId, currentPhaseCode]);
 
-  const statusById: Record<string, StatusKey> =
-    isLive && history ? nodeStatusFromHistory(history) : deriveMockStatus(mock);
+  // A live instance past R2.1 carries ITS OWN phase's history, which shares no
+  // activity ids with R2.1's model — deriving the R2.1 swimlane from it would
+  // mark every node 'todo' and claim the phase never ran. Reaching a later
+  // rung is itself proof R2.1 completed, so say so.
+  const pastFase1 = isLive && currentPhaseCode !== 'R2.1';
+  const statusById: Record<string, StatusKey> = pastFase1
+    ? Object.fromEntries(FASE1_NODES.map((n) => [n.id, 'done' as StatusKey]))
+    : isLive && history
+      ? nodeStatusFromHistory(history)
+      : deriveMockStatus(mock);
 
   // Active tasks (open or claimed) → highlight matching swimlane nodes.
   const activeNodeIds = new Set(

--- a/packages/frontend/src/pages/InfraBoardDashboard.tsx
+++ b/packages/frontend/src/pages/InfraBoardDashboard.tsx
@@ -411,7 +411,7 @@ export default function InfraBoardDashboard() {
                       {stage.code} · {stage.name}
                     </div>
                     <ul className="v2-rail-list">
-                      {phases.map(({ phase, count, parkedCount, muted }) => {
+                      {phases.map(({ phase, count, muted }) => {
                         const sectionId = phaseSectionId(phase.code);
                         return (
                           <li key={phase.code}>
@@ -427,14 +427,7 @@ export default function InfraBoardDashboard() {
                                 <span className="pb-rail-code">{phase.code}</span>
                                 {phase.name}
                               </span>
-                              {count !== undefined && count > 0 && (
-                                <span className="pb-rail-badge">{count}</span>
-                              )}
-                              {parkedCount !== undefined && parkedCount > 0 && (
-                                <span className="pb-rail-badge parked" title="Geparkeerd">
-                                  {parkedCount}
-                                </span>
-                              )}
+                              {count > 0 && <span className="pb-rail-badge">{count}</span>}
                             </button>
                           </li>
                         );

--- a/packages/frontend/src/pages/infra-board/infra-board.data.test.ts
+++ b/packages/frontend/src/pages/infra-board/infra-board.data.test.ts
@@ -181,9 +181,7 @@ describe('getMockPhaseCounts', () => {
     RIP_PHASES.forEach((phase, i) => {
       const atThisPhase = projects.filter((p) => p.ripPhaseCode === phase.code);
       const wipHere = atThisPhase.filter((p) => p.ripPhaseState === 'wip').length;
-      const geparkeerdHere = phase.beyond ? atThisPhase.length : 0;
-      expect(counts[phase.code].wip).toBe(phase.beyond ? 0 : wipHere);
-      expect(counts[phase.code].geparkeerd).toBe(geparkeerdHere);
+      expect(counts[phase.code].wip).toBe(wipHere);
 
       // gereed = projects whose current ladder position is PAST this phase
       // (they've already completed it), not before it.
@@ -298,14 +296,5 @@ describe('getMockWipRows / getMockGereedRows / getMockGeparkeerdRows', () => {
     const codes = new Set(getMockPortfolio().map((p) => p.ripPhaseCode));
     expect(codes.has('R5.4')).toBe(true);
     expect(codes.has('R6.1')).toBe(true);
-  });
-
-  it('counts nothing as geparkeerd anywhere, now that no phase is beyond', () => {
-    // geparkeerd only ever accrued in getMockPhaseCounts's phase.beyond branch,
-    // and R5.3 was the only phase that took it.
-    const counts = getMockPhaseCounts();
-    for (const phase of RIP_PHASES) {
-      expect(counts[phase.code].geparkeerd).toBe(0);
-    }
   });
 });

--- a/packages/frontend/src/pages/infra-board/infra-board.data.test.ts
+++ b/packages/frontend/src/pages/infra-board/infra-board.data.test.ts
@@ -1,6 +1,5 @@
 import { describe, expect, it } from 'vitest';
 import {
-  getMockGeparkeerdRows,
   getMockGereedRows,
   getMockPhaseCounts,
   getMockPhaseInstanceDetail,
@@ -289,9 +288,10 @@ describe('getMockWipRows / getMockGereedRows / getMockGeparkeerdRows', () => {
     }
   });
 
-  it('never returns wip rows for the beyond (R5.3) phase', () => {
+  it('returns wip rows for R5.3 like any other phase now that it is modelled', () => {
     const r53 = RIP_PHASES.find((p) => p.code === 'R5.3')!;
-    expect(getMockWipRows(r53)).toEqual([]);
+    const counts = getMockPhaseCounts();
+    expect(getMockWipRows(r53).length).toBe(counts['R5.3'].wip);
   });
 
   it('reaches R5.4 and R6.1 — unreachable under the old legacy-bucket derivation', () => {
@@ -300,9 +300,12 @@ describe('getMockWipRows / getMockGereedRows / getMockGeparkeerdRows', () => {
     expect(codes.has('R6.1')).toBe(true);
   });
 
-  it('getMockGeparkeerdRows matches getMockPhaseCounts geparkeerd count for R5.3', () => {
+  it('counts nothing as geparkeerd anywhere, now that no phase is beyond', () => {
+    // geparkeerd only ever accrued in getMockPhaseCounts's phase.beyond branch,
+    // and R5.3 was the only phase that took it.
     const counts = getMockPhaseCounts();
-    const r53 = RIP_PHASES.find((p) => p.code === 'R5.3')!;
-    expect(getMockGeparkeerdRows(r53).length).toBe(counts['R5.3'].geparkeerd);
+    for (const phase of RIP_PHASES) {
+      expect(counts[phase.code].geparkeerd).toBe(0);
+    }
   });
 });

--- a/packages/frontend/src/pages/infra-board/infra-board.data.ts
+++ b/packages/frontend/src/pages/infra-board/infra-board.data.ts
@@ -724,7 +724,7 @@ export function getMockPortfolio(): PortfolioProject[] {
 }
 
 /**
- * WIP / Gereed / geparkeerd counts per RIP phase, derived from the mock
+ * WIP / Gereed counts per RIP phase, derived from the mock
  * projects' ripPhaseCode/ripPhaseState. Mirrors
  * reference/pb-instances.reference.jsx's status derivation.
  */
@@ -734,7 +734,6 @@ export function getMockPhaseCounts(): Record<string, PhaseCounts> {
   RIP_PHASES.forEach((phase: RipPhase, i) => {
     let wip = 0;
     let gereed = 0;
-    let geparkeerd = 0;
     for (const p of projects) {
       const curIdx = RIP_PHASES.findIndex((rp) => rp.code === p.ripPhaseCode);
       // gereed = the project's current ladder position is PAST this phase
@@ -743,13 +742,9 @@ export function getMockPhaseCounts(): Record<string, PhaseCounts> {
         gereed++;
         continue;
       }
-      if (phase.beyond) {
-        if (curIdx === i) geparkeerd++;
-        continue;
-      }
       if (curIdx === i && p.ripPhaseState === 'wip') wip++;
     }
-    out[phase.code] = { wip, gereed, geparkeerd };
+    out[phase.code] = { wip, gereed };
   });
   return out;
 }
@@ -757,12 +752,10 @@ export function getMockPhaseCounts(): Record<string, PhaseCounts> {
 /**
  * Mock projects currently WIP at this phase — same classification
  * getMockPhaseCounts uses for its `wip` count (curIdx === i, state ===
- * 'wip', never for a `beyond` phase — the ladder's last rung is always
- * 'wip' by construction but counted as geparkeerd instead). Exposed as
+ * 'wip'). Exposed as
  * rows for the WIP tab.
  */
 export function getMockWipRows(phase: RipPhase): PortfolioProject[] {
-  if (phase.beyond) return [];
   const idx = RIP_PHASES.findIndex((p) => p.code === phase.code);
   return getMockPortfolio().filter((p) => {
     const curIdx = RIP_PHASES.findIndex((rp) => rp.code === p.ripPhaseCode);
@@ -780,24 +773,6 @@ export function getMockGereedRows(phase: RipPhase): PortfolioProject[] {
   return getMockPortfolio().filter((p) => {
     const curIdx = RIP_PHASES.findIndex((rp) => rp.code === p.ripPhaseCode);
     return curIdx > idx;
-  });
-}
-
-/**
- * Mock projects currently sitting on a `beyond` phase (R5.3) — every
- * project at this ladder position, regardless of ripPhaseState. Unlike
- * getMockWipRows, this does NOT exclude 'wachtend' projects: a project
- * that hasn't "started" R5.3 in the wip sense is still, in the real
- * sense that matters here, sitting there unwatched — matching
- * getMockPhaseCounts's own `geparkeerd` count, which counts both states.
- * Only meaningful for a `beyond` phase; called only from PhaseDetail's
- * beyond branch.
- */
-export function getMockGeparkeerdRows(phase: RipPhase): PortfolioProject[] {
-  const idx = RIP_PHASES.findIndex((p) => p.code === phase.code);
-  return getMockPortfolio().filter((p) => {
-    const curIdx = RIP_PHASES.findIndex((rp) => rp.code === p.ripPhaseCode);
-    return curIdx === idx;
   });
 }
 

--- a/packages/frontend/src/pages/infra-board/rail-stats.test.ts
+++ b/packages/frontend/src/pages/infra-board/rail-stats.test.ts
@@ -151,10 +151,8 @@ describe('beheerRailSubtitle', () => {
       combined[p.code] = {
         wip: i === 0 ? 3 : i === 1 ? 2 : 0,
         gereed: 0,
-        geparkeerd: 0,
         liveWip: 0,
         liveGereed: 0,
-        liveGeparkeerd: 0,
       };
     });
     expect(beheerRailSubtitle(combined)).toBe('RIP-faseladder · 5 in uitvoering');
@@ -174,32 +172,29 @@ describe('beheerRailPhaseGroups', () => {
     });
   });
 
-  it('gives every non-beyond phase a count (0 if absent from combined) and no parkedCount', () => {
+  it('gives every phase a count (0 if absent from combined)', () => {
     const groups = beheerRailPhaseGroups({}, new Set());
     const allPhases = groups.flatMap((g) => g.phases);
-    allPhases
-      .filter((p) => !p.phase.beyond)
-      .forEach((p) => {
-        expect(p.count).toBe(0);
-        expect(p.parkedCount).toBeUndefined();
-      });
+    allPhases.forEach((p) => {
+      expect(p.count).toBe(0);
+    });
   });
 
   it('gives R5.3 an ordinary wip count now that it is modelled', () => {
-    // R5.3 was the catalogue's only `beyond` phase and carried a geparkeerd
-    // badge instead of a WIP one. It takes the same badge as every other phase.
+    // R5.3 was the catalogue's only `beyond` phase and showed a geparkeerd
+    // badge instead of a WIP one. RipR53Process is deployed, so it takes the
+    // same badge as every other phase.
     const combined: Record<string, AnnotatedPhaseCounts> = {
-      'R5.3': { wip: 3, gereed: 0, geparkeerd: 0, liveWip: 0, liveGereed: 0, liveGeparkeerd: 0 },
+      'R5.3': { wip: 3, gereed: 0, liveWip: 0, liveGereed: 0 },
     };
     const groups = beheerRailPhaseGroups(combined, new Set());
     const r53 = groups.flatMap((g) => g.phases).find((p) => p.phase.code === 'R5.3');
     expect(r53?.count).toBe(3);
-    expect(r53?.parkedCount).toBeUndefined();
   });
 
   it('sources count from the combined map when present', () => {
     const combined: Record<string, AnnotatedPhaseCounts> = {
-      'R2.1': { wip: 7, gereed: 0, geparkeerd: 0, liveWip: 0, liveGereed: 0, liveGeparkeerd: 0 },
+      'R2.1': { wip: 7, gereed: 0, liveWip: 0, liveGereed: 0 },
     };
     const groups = beheerRailPhaseGroups(combined, new Set());
     const r21 = groups.flatMap((g) => g.phases).find((p) => p.phase.code === 'R2.1');

--- a/packages/frontend/src/pages/infra-board/rail-stats.test.ts
+++ b/packages/frontend/src/pages/infra-board/rail-stats.test.ts
@@ -185,14 +185,16 @@ describe('beheerRailPhaseGroups', () => {
       });
   });
 
-  it('gives the one beyond phase (R5.3) a parkedCount and no count', () => {
+  it('gives R5.3 an ordinary wip count now that it is modelled', () => {
+    // R5.3 was the catalogue's only `beyond` phase and carried a geparkeerd
+    // badge instead of a WIP one. It takes the same badge as every other phase.
     const combined: Record<string, AnnotatedPhaseCounts> = {
-      'R5.3': { wip: 0, gereed: 0, geparkeerd: 4, liveWip: 0, liveGereed: 0, liveGeparkeerd: 0 },
+      'R5.3': { wip: 3, gereed: 0, geparkeerd: 0, liveWip: 0, liveGereed: 0, liveGeparkeerd: 0 },
     };
     const groups = beheerRailPhaseGroups(combined, new Set());
     const r53 = groups.flatMap((g) => g.phases).find((p) => p.phase.code === 'R5.3');
-    expect(r53?.count).toBeUndefined();
-    expect(r53?.parkedCount).toBe(4);
+    expect(r53?.count).toBe(3);
+    expect(r53?.parkedCount).toBeUndefined();
   });
 
   it('sources count from the combined map when present', () => {

--- a/packages/frontend/src/pages/infra-board/rail-stats.ts
+++ b/packages/frontend/src/pages/infra-board/rail-stats.ts
@@ -88,18 +88,14 @@ export function beheerRailSubtitle(combined: Record<string, AnnotatedPhaseCounts
 
 export interface BeheerPhaseRailItem {
   phase: RipPhase;
-  /** WIP badge — undefined for the one `beyond` phase (R5.3), which shows
-   *  parkedCount instead. */
-  count?: number;
-  /** Geparkeerd badge — R5.3 only, mutually exclusive with `count` by
-   *  construction (RIP_PHASES has exactly one `beyond: true` phase). */
-  parkedCount?: number;
+  /** WIP badge. */
+  count: number;
   /** Dims the item — true unless getPhaseDeployStatus resolves to 'gedeployed'. */
   muted: boolean;
 }
 
 /** Beheer's phase nav items, grouped by stage — same shape as
- *  portfolioRailStageGroups but carrying WIP/geparkeerd badges and
+ *  portfolioRailStageGroups but carrying WIP badges and
  *  deploy-muted state instead of project counts. Reference:
  *  pb-shell.reference.jsx:82-103. */
 export function beheerRailPhaseGroups(
@@ -112,8 +108,7 @@ export function beheerRailPhaseGroups(
       const counts = combined[phase.code];
       return {
         phase,
-        count: phase.beyond ? undefined : (counts?.wip ?? 0),
-        parkedCount: phase.beyond ? (counts?.geparkeerd ?? 0) : undefined,
+        count: counts?.wip ?? 0,
         muted: getPhaseDeployStatus(phase, deployedKeys) !== 'gedeployed',
       };
     }),

--- a/packages/frontend/src/pages/infra-board/rip-phase-counts.test.ts
+++ b/packages/frontend/src/pages/infra-board/rip-phase-counts.test.ts
@@ -69,17 +69,18 @@ describe('combinePhaseCounts', () => {
 });
 
 describe('getKlaarCounts and beyond phases', () => {
-  it('derives R5.4 from R5.2, stepping over the beyond phase R5.3', () => {
-    // With R5.3 as the literal predecessor this reads max(0, 0 - 0 - 0) = 0
-    // for any input, because a beyond phase can never carry a completed
-    // instance. Stepping back to R5.2 makes the figure mean something.
+  it('derives R5.4 from R5.3, its real predecessor now that R5.3 is modelled', () => {
+    // R5.3 used to be `beyond`, so the step-back skipped it and R5.4 derived
+    // from R5.2 -- a beyond phase can never carry a completed instance, so R5.4
+    // would have read zero forever. RipR53Process is deployed, so its gereed
+    // figure is real and R5.4 derives from it directly.
     const counts: Record<string, PhaseCounts> = {
-      'R5.2': { wip: 0, gereed: 9, geparkeerd: 0 },
-      'R5.3': { wip: 0, gereed: 0, geparkeerd: 0 },
+      'R5.2': { wip: 0, gereed: 20, geparkeerd: 0 },
+      'R5.3': { wip: 0, gereed: 9, geparkeerd: 0 },
       'R5.4': { wip: 2, gereed: 1, geparkeerd: 0 },
     };
     const result = getKlaarCounts(RIP_PHASES, counts);
-    expect(result['R5.4']).toBe(6); // 9 - 2 - 1
+    expect(result['R5.4']).toBe(6); // 9 - 2 - 1, from R5.3 not R5.2
   });
 
   it('still gives the first phase no klaar figure at all', () => {

--- a/packages/frontend/src/pages/infra-board/rip-phase-counts.test.ts
+++ b/packages/frontend/src/pages/infra-board/rip-phase-counts.test.ts
@@ -16,8 +16,8 @@ describe('getKlaarCounts', () => {
 
   it('computes klaar[N] = max(0, gereed[N-1] - wip[N] - gereed[N])', () => {
     const counts: Record<string, PhaseCounts> = {
-      'R2.1': { wip: 0, gereed: 10, geparkeerd: 0 },
-      'R2.2': { wip: 2, gereed: 3, geparkeerd: 0 },
+      'R2.1': { wip: 0, gereed: 10 },
+      'R2.2': { wip: 2, gereed: 3 },
     };
     const result = getKlaarCounts(RIP_PHASES, counts);
     expect(result['R2.2']).toBe(5); // 10 - 2 - 3
@@ -25,8 +25,8 @@ describe('getKlaarCounts', () => {
 
   it('floors at 0 rather than going negative', () => {
     const counts: Record<string, PhaseCounts> = {
-      'R2.1': { wip: 0, gereed: 1, geparkeerd: 0 },
-      'R2.2': { wip: 5, gereed: 5, geparkeerd: 0 },
+      'R2.1': { wip: 0, gereed: 1 },
+      'R2.2': { wip: 5, gereed: 5 },
     };
     const result = getKlaarCounts(RIP_PHASES, counts);
     expect(result['R2.2']).toBe(0);
@@ -40,44 +40,40 @@ describe('getKlaarCounts', () => {
 
 describe('combinePhaseCounts', () => {
   it('sums mock + live per field and carries the live figures for annotation', () => {
-    const mock = { 'R2.1': { wip: 4, gereed: 10, geparkeerd: 1 } };
-    const live = { 'R2.1': { wip: 1, gereed: 2, geparkeerd: 0 } };
+    const mock = { 'R2.1': { wip: 4, gereed: 10 } };
+    const live = { 'R2.1': { wip: 1, gereed: 2 } };
     const result = combinePhaseCounts(mock, live);
     expect(result['R2.1']).toEqual({
       wip: 5,
       gereed: 12,
-      geparkeerd: 1,
       liveWip: 1,
       liveGereed: 2,
-      liveGeparkeerd: 0,
     });
   });
 
   it('produces a complete entry when a phase is present in only one input', () => {
-    const mock = { 'R2.1': { wip: 4, gereed: 10, geparkeerd: 0 } };
+    const mock = { 'R2.1': { wip: 4, gereed: 10 } };
     const live = {};
     const result = combinePhaseCounts(mock, live);
     expect(result['R2.1']).toEqual({
       wip: 4,
       gereed: 10,
-      geparkeerd: 0,
       liveWip: 0,
       liveGereed: 0,
-      liveGeparkeerd: 0,
     });
   });
 });
 
 describe('getKlaarCounts and beyond phases', () => {
   it('derives R5.4 from R5.3, its real predecessor now that R5.3 is modelled', () => {
-    // R5.3 used to be `beyond`, so the step-back skipped it and R5.4 derived
-    // from R5.2 -- a beyond phase can never carry a completed instance, so R5.4
-    // would have read zero forever. RipR53Process is deployed, so its gereed
-    // figure is real and R5.4 derives from it directly.
+    // R5.3 used to be `beyond`, so the derivation stepped back to R5.2 -- a
+    // beyond phase can never carry a completed instance and R5.4 would have
+    // read zero forever. RipR53Process is deployed now, so its gereed figure
+    // is real and R5.4 derives from it directly.
     const counts: Record<string, PhaseCounts> = {
-      'R5.2': { wip: 0, gereed: 20, geparkeerd: 0 },
-      'R5.3': { wip: 0, gereed: 9, geparkeerd: 0 },
-      'R5.4': { wip: 2, gereed: 1, geparkeerd: 0 },
+      'R5.2': { wip: 0, gereed: 20 },
+      'R5.3': { wip: 0, gereed: 9 },
+      'R5.4': { wip: 2, gereed: 1 },
     };
     const result = getKlaarCounts(RIP_PHASES, counts);
     expect(result['R5.4']).toBe(6); // 9 - 2 - 1, from R5.3 not R5.2
@@ -93,7 +89,7 @@ describe('normalizeLiveCounts', () => {
   it('maps backend processDefinitionKey counts onto phase codes with geparkeerd: 0', () => {
     const raw = { RipR21Process: { wip: 3, gereed: 7 } };
     const result = normalizeLiveCounts(raw, RIP_PHASES);
-    expect(result['R2.1']).toEqual({ wip: 3, gereed: 7, geparkeerd: 0 });
+    expect(result['R2.1']).toEqual({ wip: 3, gereed: 7 });
     expect(result['R2.2']).toBeUndefined();
   });
 });

--- a/packages/frontend/src/pages/infra-board/rip-phase-counts.test.ts
+++ b/packages/frontend/src/pages/infra-board/rip-phase-counts.test.ts
@@ -65,18 +65,33 @@ describe('combinePhaseCounts', () => {
 });
 
 describe('getKlaarCounts and beyond phases', () => {
-  it('derives R5.4 from R5.3, its real predecessor now that R5.3 is modelled', () => {
-    // R5.3 used to be `beyond`, so the derivation stepped back to R5.2 -- a
-    // beyond phase can never carry a completed instance and R5.4 would have
-    // read zero forever. RipR53Process is deployed now, so its gereed figure
-    // is real and R5.4 derives from it directly.
+  it('gives R5.4 no klaar figure at all, because R5.3 has multiple exits', () => {
+    // The subtraction assumes finishing a phase means advancing to the next.
+    // R5.3 breaks that: three of its four end events return to R5.2, so its
+    // gereed mixes four outcomes and one project can complete it twice.
+    // Reporting "-" is honest; a number here would overstate R5.4 invisibly.
     const counts: Record<string, PhaseCounts> = {
       'R5.2': { wip: 0, gereed: 20 },
       'R5.3': { wip: 0, gereed: 9 },
       'R5.4': { wip: 2, gereed: 1 },
     };
-    const result = getKlaarCounts(RIP_PHASES, counts);
-    expect(result['R5.4']).toBe(6); // 9 - 2 - 1, from R5.3 not R5.2
+    expect(getKlaarCounts(RIP_PHASES, counts)['R5.4']).toBeUndefined();
+  });
+
+  it('drives that off the multipleExits flag, not off the phase code', () => {
+    // A literal 'R5.3' here would break the next time a phase gains or loses
+    // an exit -- the same trap three fixtures fell into before c561d48.
+    const withFlag = RIP_PHASES.map((p) =>
+      p.code === 'R2.2' ? { ...p, multipleExits: true } : { ...p, multipleExits: undefined }
+    );
+    const counts: Record<string, PhaseCounts> = {
+      'R2.2': { wip: 0, gereed: 9 },
+      'R2.3': { wip: 2, gereed: 1 },
+      'R5.4': { wip: 2, gereed: 1 },
+    };
+    const result = getKlaarCounts(withFlag, counts);
+    expect(result['R2.3']).toBeUndefined();
+    expect(result['R5.4']).toBe(0); // R5.3 no longer flagged, so it derives again
   });
 
   it('still gives the first phase no klaar figure at all', () => {

--- a/packages/frontend/src/pages/infra-board/rip-phase-counts.ts
+++ b/packages/frontend/src/pages/infra-board/rip-phase-counts.ts
@@ -10,18 +10,14 @@ import type { RipPhase } from './rip-phases.catalog';
 export interface PhaseCounts {
   wip: number;
   gereed: number;
-  /** R5.3 only (beyond: true). Always 0 for live counts today — nothing
-   *  can reach R5.3 while only R2.1 is deployed. */
-  geparkeerd: number;
 }
 
 export interface AnnotatedPhaseCounts extends PhaseCounts {
   liveWip: number;
   liveGereed: number;
-  liveGeparkeerd: number;
 }
 
-const EMPTY: PhaseCounts = { wip: 0, gereed: 0, geparkeerd: 0 };
+const EMPTY: PhaseCounts = { wip: 0, gereed: 0 };
 
 /**
  * klaar[N] = max(0, gereed[prev] - wip[N] - gereed[N]) — projects that
@@ -35,12 +31,9 @@ export function getKlaarCounts(
 ): Record<string, number | undefined> {
   const out: Record<string, number | undefined> = {};
   phases.forEach((phase, i) => {
-    // Step back past any `beyond` phase, matching previousModelledPhase in
-    // the catalogue. R5.3 is beyond, so R5.4's klaar figure derives from
-    // R5.2: a beyond phase can never carry a completed instance, so reading
-    // it as the predecessor would peg R5.4 at zero forever.
-    let p = i - 1;
-    while (p >= 0 && phases[p].beyond) p--;
+    // Every phase is modelled, so the predecessor is simply the preceding
+    // entry -- matching previousModelledPhase in the catalogue.
+    const p = i - 1;
     if (p < 0) {
       out[phase.code] = undefined;
       return;
@@ -66,10 +59,8 @@ export function combinePhaseCounts(
     out[code] = {
       wip: m.wip + l.wip,
       gereed: m.gereed + l.gereed,
-      geparkeerd: m.geparkeerd + l.geparkeerd,
       liveWip: l.wip,
       liveGereed: l.gereed,
-      liveGeparkeerd: l.geparkeerd,
     };
   }
   return out;
@@ -77,7 +68,7 @@ export function combinePhaseCounts(
 
 /** The backend keys its response by processDefinitionKey (an engine
  *  fact); the UI keys everything else by phase code. Remaps one to the
- *  other, filling geparkeerd: 0 — Operaton has no such concept. */
+ *  other. */
 export function normalizeLiveCounts(
   raw: Record<string, { wip: number; gereed: number }>,
   phases: RipPhase[]
@@ -86,7 +77,7 @@ export function normalizeLiveCounts(
   for (const phase of phases) {
     if (!phase.processDefinitionKey) continue;
     const c = raw[phase.processDefinitionKey];
-    if (c) out[phase.code] = { wip: c.wip, gereed: c.gereed, geparkeerd: 0 };
+    if (c) out[phase.code] = { wip: c.wip, gereed: c.gereed };
   }
   return out;
 }

--- a/packages/frontend/src/pages/infra-board/rip-phase-counts.ts
+++ b/packages/frontend/src/pages/infra-board/rip-phase-counts.ts
@@ -24,6 +24,15 @@ const EMPTY: PhaseCounts = { wip: 0, gereed: 0 };
  * finished the preceding phase but haven't reached this one yet. The first
  * phase in ladder order has no predecessor, so it's always undefined
  * (render "—", not 0 — there's nothing to be ready *for*).
+ *
+ * Undefined too when the predecessor has `multipleExits`. The subtraction
+ * assumes finishing a phase means advancing to the next one, which holds
+ * everywhere except after R5.3: three of its four end events return to R5.2,
+ * so its `gereed` mixes four outcomes and one project can complete it twice.
+ * Deriving a number from that would overstate R5.4's candidates in a way
+ * nothing on screen could reveal, so it reports "—" instead. Counting only
+ * the R5.4-bound exit is the real fix and needs the counts endpoint, which
+ * returns a flat { wip, gereed } per phase today.
  */
 export function getKlaarCounts(
   phases: RipPhase[],
@@ -34,7 +43,7 @@ export function getKlaarCounts(
     // Every phase is modelled, so the predecessor is simply the preceding
     // entry -- matching previousModelledPhase in the catalogue.
     const p = i - 1;
-    if (p < 0) {
+    if (p < 0 || phases[p].multipleExits) {
       out[phase.code] = undefined;
       return;
     }

--- a/packages/frontend/src/pages/infra-board/rip-phases.catalog.test.ts
+++ b/packages/frontend/src/pages/infra-board/rip-phases.catalog.test.ts
@@ -9,9 +9,10 @@ import {
   type RipPhase,
 } from './rip-phases.catalog';
 
-// R5.3 is the last phase without a process model, and will stay that way:
-// it is `beyond`, a real step with no design sheet and no observable exit.
-const UNMODELLED_CODES = ['R5.3'];
+// Every phase carries a process definition key now: R5.3 was the last holdout
+// and is deployed as RipR53Process (sheet 3-9-2026). `beyond` still exists as a
+// capability but no real phase uses it, so the fixture below synthesises one.
+const UNMODELLED_CODES: string[] = [];
 
 describe('RIP_PHASES catalogue', () => {
   it('has exactly twelve phases in R2.1…R6.1 order', () => {
@@ -52,23 +53,10 @@ describe('RIP_PHASES catalogue', () => {
     }
   });
 
-  it('marks only R5.3 as beyond (no process model even planned)', () => {
-    expect(ripPhaseByCode('R5.3')?.beyond).toBe(true);
-    const notBeyond = [
-      'R2.1',
-      'R2.2',
-      'R2.3',
-      'R2.4',
-      'R3.1',
-      'R3.2',
-      'R4.1',
-      'R5.1',
-      'R5.2',
-      'R5.4',
-      'R6.1',
-    ];
-    for (const code of notBeyond) {
-      expect(ripPhaseByCode(code)?.beyond).toBeUndefined();
+  it('marks no phase as beyond — every one of the twelve is modelled', () => {
+    for (const phase of RIP_PHASES) {
+      expect(phase.beyond).toBeUndefined();
+      expect(phase.processDefinitionKey).toBeDefined();
     }
   });
 
@@ -93,17 +81,18 @@ describe('previousModelledPhase / skippedPhasesBefore', () => {
     expect(skippedPhasesBefore('R2.1')).toEqual([]);
   });
 
-  it('skips R5.3, so R5.4 follows R5.2', () => {
-    // R5.4's entry criterion reads "Oplevering areaal na R5.3", so R5.3 does
-    // happen -- but it is `beyond`: no process model, and no exit artefact at
-    // all, so nothing about its completion is observable here. Reading it as
-    // R5.4's predecessor would peg R5.4 at zero candidates forever.
-    expect(ripPhaseByCode('R5.3')?.beyond).toBe(true);
-    expect(previousModelledPhase('R5.4')?.code).toBe('R5.2');
+  it('resolves R5.4 to R5.3, which is modelled now', () => {
+    // R5.4's entry criterion reads "Oplevering areaal na R5.3". R5.3 used to be
+    // `beyond` -- no sheet, no BPMN, no observable exit -- so it was stepped
+    // over. RipR53Process is deployed and its "Ja, oplevering areaal" end event
+    // IS that exit, so R5.4 follows R5.3 directly.
+    expect(previousModelledPhase('R5.4')?.code).toBe('R5.3');
   });
 
-  it('names the skipped phase so the UI can disclose it', () => {
-    expect(skippedPhasesBefore('R5.4').map((p) => p.code)).toEqual(['R5.3']);
+  it('names no skipped phase anywhere, now that every phase is modelled', () => {
+    for (const phase of RIP_PHASES) {
+      expect(skippedPhasesBefore(phase.code)).toEqual([]);
+    }
   });
 
   it('reports no skip for any phase other than R5.4', () => {
@@ -131,7 +120,13 @@ describe('getPhaseDeployStatus', () => {
   // catalogued ahead of its BPMN being deployed sits in exactly this state --
   // so the fixture is built rather than deleted along with the coverage.
   const withoutKey: RipPhase = { ...ripPhaseByCode('R6.1')!, processDefinitionKey: undefined };
-  const beyond: RipPhase = { ...ripPhaseByCode('R5.3')! };
+  // Synthesised for the same reason as `withoutKey`: R5.3 was the last `beyond`
+  // phase and is modelled now, so no real phase exercises this branch.
+  const beyond: RipPhase = {
+    ...ripPhaseByCode('R5.3')!,
+    beyond: true,
+    processDefinitionKey: undefined,
+  };
 
   it('is gedeployed when the phase has a key and it is in the deployed set', () => {
     expect(getPhaseDeployStatus(withKey, new Set(['RipR21Process']))).toBe('gedeployed');

--- a/packages/frontend/src/pages/infra-board/rip-phases.catalog.test.ts
+++ b/packages/frontend/src/pages/infra-board/rip-phases.catalog.test.ts
@@ -3,15 +3,15 @@ import {
   getPhaseDeployStatus,
   previousModelledPhase,
   ripPhaseByCode,
-  skippedPhasesBefore,
   RIP_PHASES,
   RIP_STAGES,
   type RipPhase,
 } from './rip-phases.catalog';
 
-// Every phase carries a process definition key now: R5.3 was the last holdout
-// and is deployed as RipR53Process (sheet 3-9-2026). `beyond` still exists as a
-// capability but no real phase uses it, so the fixture below synthesises one.
+// Every phase now carries a process definition key: R5.3 was the last holdout
+// and was modelled and deployed as RipR53Process (sheet 3-9-2026). `beyond`
+// survives as a capability for a future unmodelled phase, but no real phase
+// exercises it, so the tests below synthesise one.
 const UNMODELLED_CODES: string[] = [];
 
 describe('RIP_PHASES catalogue', () => {
@@ -53,9 +53,8 @@ describe('RIP_PHASES catalogue', () => {
     }
   });
 
-  it('marks no phase as beyond — every one of the twelve is modelled', () => {
+  it('gives every one of the twelve a process definition key', () => {
     for (const phase of RIP_PHASES) {
-      expect(phase.beyond).toBeUndefined();
       expect(phase.processDefinitionKey).toBeDefined();
     }
   });
@@ -78,36 +77,20 @@ describe('previousModelledPhase / skippedPhasesBefore', () => {
 
   it('is undefined for the first phase, which has nothing to be ready for', () => {
     expect(previousModelledPhase('R2.1')).toBeUndefined();
-    expect(skippedPhasesBefore('R2.1')).toEqual([]);
   });
 
-  it('resolves R5.4 to R5.3, which is modelled now', () => {
+  it('resolves R5.4 to R5.3, which is now modelled', () => {
     // R5.4's entry criterion reads "Oplevering areaal na R5.3". R5.3 used to be
     // `beyond` -- no sheet, no BPMN, no observable exit -- so it was stepped
-    // over. RipR53Process is deployed and its "Ja, oplevering areaal" end event
-    // IS that exit, so R5.4 follows R5.3 directly.
+    // over. RipR53Process is deployed now and its "Ja, oplevering areaal" end
+    // event IS the observable exit, so R5.4 follows R5.3 directly.
     expect(previousModelledPhase('R5.4')?.code).toBe('R5.3');
   });
 
-  it('names no skipped phase anywhere, now that every phase is modelled', () => {
-    for (const phase of RIP_PHASES) {
-      expect(skippedPhasesBefore(phase.code)).toEqual([]);
-    }
-  });
-
-  it('reports no skip for any phase other than R5.4', () => {
-    for (const phase of RIP_PHASES) {
-      if (phase.code === 'R5.4') continue;
-      expect(skippedPhasesBefore(phase.code)).toEqual([]);
-    }
-  });
-
-  it('every phase after the first resolves to a predecessor that is not beyond', () => {
-    for (const phase of RIP_PHASES.slice(1)) {
-      const prev = previousModelledPhase(phase.code);
-      expect(prev).toBeDefined();
-      expect(prev?.beyond).toBeUndefined();
-    }
+  it('resolves every phase after the first to its immediate predecessor', () => {
+    RIP_PHASES.slice(1).forEach((phase, i) => {
+      expect(previousModelledPhase(phase.code)?.code).toBe(RIP_PHASES[i].code);
+    });
   });
 });
 
@@ -115,18 +98,10 @@ describe('getPhaseDeployStatus', () => {
   const withKey: RipPhase = { ...ripPhaseByCode('R2.1')! };
   // Synthesised, because no real phase can play this role any more: every
   // phase in the catalogue now either carries a processDefinitionKey or is
-  // `beyond` (R5.3), and `beyond` short-circuits to 'onbekend' before the key
   // is consulted. The branch is still reachable in practice -- a phase
   // catalogued ahead of its BPMN being deployed sits in exactly this state --
   // so the fixture is built rather than deleted along with the coverage.
   const withoutKey: RipPhase = { ...ripPhaseByCode('R6.1')!, processDefinitionKey: undefined };
-  // Synthesised for the same reason as `withoutKey`: R5.3 was the last `beyond`
-  // phase and is modelled now, so no real phase exercises this branch.
-  const beyond: RipPhase = {
-    ...ripPhaseByCode('R5.3')!,
-    beyond: true,
-    processDefinitionKey: undefined,
-  };
 
   it('is gedeployed when the phase has a key and it is in the deployed set', () => {
     expect(getPhaseDeployStatus(withKey, new Set(['RipR21Process']))).toBe('gedeployed');
@@ -136,12 +111,8 @@ describe('getPhaseDeployStatus', () => {
     expect(getPhaseDeployStatus(withKey, new Set())).toBe('ontwerp');
   });
 
-  it('is ontwerp when the phase has no key and is not beyond', () => {
+  it('is ontwerp when the phase has no key', () => {
     expect(getPhaseDeployStatus(withoutKey, new Set())).toBe('ontwerp');
-  });
-
-  it('is onbekend when the phase is beyond, regardless of the deployed set', () => {
-    expect(getPhaseDeployStatus(beyond, new Set(['RipR21Process']))).toBe('onbekend');
   });
 });
 

--- a/packages/frontend/src/pages/infra-board/rip-phases.catalog.ts
+++ b/packages/frontend/src/pages/infra-board/rip-phases.catalog.ts
@@ -37,6 +37,18 @@ export interface RipPhase {
   weeks: number;
   bron: string;
   processDefinitionKey?: string;
+  /**
+   * True when finishing this phase does not imply moving on to the next one.
+   * R5.3 is the only one: it has four end events and just one leads to R5.4 —
+   * the other three return to R5.2 (restpunten, or a vervroegde ingebruikname
+   * while the work carries on). So `gereed` here counts four different
+   * outcomes, and a project can legitimately complete the phase more than once.
+   *
+   * The successor's `klaar` figure cannot be derived from it; see
+   * getKlaarCounts, which returns undefined rather than a number it cannot
+   * stand behind.
+   */
+  multipleExits?: boolean;
 }
 
 const CONTENT: Omit<RipPhase, 'processDefinitionKey'>[] = [
@@ -362,6 +374,7 @@ const CONTENT: Omit<RipPhase, 'processDefinitionKey'>[] = [
       'Akkoord (vervroegde) ingebruikname?',
     ],
     krediet: false,
+    multipleExits: true,
     weeks: 4,
     bron: 'Overzichtsplaat R5.3 — (vervroegde) Ingebruikname / Oplevering (3-9-2026). Vier eindgebeurtenissen: één naar R5.4 (oplevering areaal), drie terug naar R5.2 (restpunten, vervroegde ingebruikname, restpunten door ON). Geen lus binnen de fase.',
   },

--- a/packages/frontend/src/pages/infra-board/rip-phases.catalog.ts
+++ b/packages/frontend/src/pages/infra-board/rip-phases.catalog.ts
@@ -37,8 +37,6 @@ export interface RipPhase {
   weeks: number;
   bron: string;
   processDefinitionKey?: string;
-  /** No process model even planned (R5.3) — never counts as WIP. */
-  beyond?: boolean;
 }
 
 const CONTENT: Omit<RipPhase, 'processDefinitionKey'>[] = [
@@ -441,7 +439,7 @@ export const RIP_PHASES: RipPhase[] = CONTENT.map((c) => ({
 export const ripPhaseByCode = (code: string): RipPhase | undefined =>
   RIP_PHASES.find((p) => p.code === code);
 
-export type RipDeployStatus = 'gedeployed' | 'ontwerp' | 'onbekend';
+export type RipDeployStatus = 'gedeployed' | 'ontwerp';
 
 export const RIP_DEPLOY_META: Record<
   RipDeployStatus,
@@ -461,13 +459,6 @@ export const RIP_DEPLOY_META: Record<
     can: false,
     note: 'Overzichtsplaat bekend, procesmodel nog niet gemodelleerd of nog niet gedeployed op deze omgeving.',
   },
-  onbekend: {
-    label: 'Niet gemodelleerd',
-    short: 'N.V.T.',
-    color: '#9aa1ab',
-    can: false,
-    note: 'Nog geen overzichtsplaat beschikbaar.',
-  },
 };
 
 export function getPhaseDeployStatus(
@@ -477,44 +468,23 @@ export function getPhaseDeployStatus(
   if (phase.processDefinitionKey && deployedKeys.has(phase.processDefinitionKey)) {
     return 'gedeployed';
   }
-  if (phase.beyond) return 'onbekend';
   return 'ontwerp';
 }
 
 /**
  * The phase a project must have finished before it can start `code`.
  *
- * Skips any `beyond` phase. No phase is beyond any more — R5.3 was the last
- * one and is modelled and deployed as RipR53Process — so this now resolves to
- * `RIP_PHASES[i - 1]` for every phase, and R5.4 follows R5.3 rather than R5.2.
- * The skip is kept only until the unused `beyond` machinery is removed.
- *
- * Callers that surface a skip to the user should say so; see
- * `skippedPhasesBefore`, which is now empty for every phase.
+ * Every phase in the ladder is modelled and deployed, so this is simply the
+ * preceding entry. It used to step over `beyond` phases -- R5.3 was the only
+ * one, kept out because it had no exit artefact and reading it as R5.4's
+ * predecessor would have pegged R5.4 at zero candidates forever. RipR53Process
+ * is deployed now and its "Ja, oplevering areaal" end event is that exit, so
+ * the special case is gone along with `beyond` itself.
  *
  * Returns undefined for the first phase, which has no predecessor.
  */
 export function previousModelledPhase(code: string): RipPhase | undefined {
   const idx = RIP_PHASES.findIndex((p) => p.code === code);
   if (idx <= 0) return undefined;
-  for (let i = idx - 1; i >= 0; i--) {
-    if (!RIP_PHASES[i].beyond) return RIP_PHASES[i];
-  }
-  return undefined;
-}
-
-/**
- * Phases between `code` and its effective predecessor that are handled
- * outside this tool — what `previousModelledPhase` stepped over. Empty for
- * every phase except R5.4 today.
- */
-export function skippedPhasesBefore(code: string): RipPhase[] {
-  const idx = RIP_PHASES.findIndex((p) => p.code === code);
-  if (idx <= 0) return [];
-  const skipped: RipPhase[] = [];
-  for (let i = idx - 1; i >= 0; i--) {
-    if (!RIP_PHASES[i].beyond) break;
-    skipped.unshift(RIP_PHASES[i]);
-  }
-  return skipped;
+  return RIP_PHASES[idx - 1];
 }

--- a/packages/frontend/src/pages/infra-board/rip-phases.catalog.ts
+++ b/packages/frontend/src/pages/infra-board/rip-phases.catalog.ts
@@ -340,15 +340,32 @@ const CONTENT: Omit<RipPhase, 'processDefinitionKey'>[] = [
     stage: 'R5',
     name: '(Vervroegde) ingebruikname / oplevering',
     lead: 'Directievoerder',
-    beyond: true,
-    roles: ['Directievoerder', 'Toezichthouder', 'Opdrachtnemer'],
+    roles: [
+      'Directievoerder',
+      'Toezichthouder',
+      'Opdrachtnemer',
+      'Vestigingsmanager',
+      'Beheerder',
+      'Projectleider',
+    ],
     entry: 'Werk gereed gemeld in R5.2',
-    exit: '—',
-    docs: [],
-    gates: [],
+    exit: 'Oplevering areaal → R5.4; anders terug naar R5.2 (restpunten, of vervroegde ingebruikname naast doorlopend werk)',
+    docs: [
+      'Opleveringschouw',
+      'Bevindingen opleverschouw',
+      'Opleveringschouw vastgesteld',
+      'Ingebruiknameschouw',
+      'Bevindingen ingebruiknameschouw',
+      'Ingebruiknameschouw vastgesteld',
+    ],
+    gates: [
+      'Oplevering of (vervroegde) ingebruikname?',
+      'Oplevering akkoord?',
+      'Akkoord (vervroegde) ingebruikname?',
+    ],
     krediet: false,
     weeks: 4,
-    bron: 'PLACEHOLDER — geen overzichtsplaat aangeleverd. Bekend uit verwijzingen in R5.2 (organiseren interne schouw, restpunten oplossen door ON) en R5.4 (oplevering areaal).',
+    bron: 'Overzichtsplaat R5.3 — (vervroegde) Ingebruikname / Oplevering (3-9-2026). Vier eindgebeurtenissen: één naar R5.4 (oplevering areaal), drie terug naar R5.2 (restpunten, vervroegde ingebruikname, restpunten door ON). Geen lus binnen de fase.',
   },
   {
     code: 'R5.4',
@@ -467,16 +484,13 @@ export function getPhaseDeployStatus(
 /**
  * The phase a project must have finished before it can start `code`.
  *
- * Not simply `RIP_PHASES[i - 1]`: a `beyond` phase is skipped. R5.3 is the
- * only one today, and skipping it is a deliberate assertion rather than a
- * technicality. R5.4's entry criterion reads "Oplevering areaal na R5.3", so
- * R5.3 genuinely happens — but it has no overzichtsplaat, no process model,
- * and (decisively) no exit artefact at all, so nothing about its completion
- * is observable here. Every other transition in the ladder is triggered by a
- * named deliverable that the previous phase's exit criterion produces.
+ * Skips any `beyond` phase. No phase is beyond any more — R5.3 was the last
+ * one and is modelled and deployed as RipR53Process — so this now resolves to
+ * `RIP_PHASES[i - 1]` for every phase, and R5.4 follows R5.3 rather than R5.2.
+ * The skip is kept only until the unused `beyond` machinery is removed.
  *
  * Callers that surface a skip to the user should say so; see
- * `skippedPhasesBefore`.
+ * `skippedPhasesBefore`, which is now empty for every phase.
  *
  * Returns undefined for the first phase, which has no predecessor.
  */

--- a/packages/shared/src/rip-phases.ts
+++ b/packages/shared/src/rip-phases.ts
@@ -22,7 +22,7 @@ export const RIP_PHASE_KEYS: RipPhaseKey[] = [
   { code: 'R4.1', stage: 'R4', processDefinitionKey: 'RipR41Process' },
   { code: 'R5.1', stage: 'R5', processDefinitionKey: 'RipR51Process' },
   { code: 'R5.2', stage: 'R5', processDefinitionKey: 'RipR52Process' },
-  { code: 'R5.3', stage: 'R5' },
+  { code: 'R5.3', stage: 'R5', processDefinitionKey: 'RipR53Process' },
   { code: 'R5.4', stage: 'R5', processDefinitionKey: 'RipR54Process' },
   { code: 'R6.1', stage: 'R6', processDefinitionKey: 'RipR61Process' },
 ];

--- a/scripts/rip-phase-walkthrough.sh
+++ b/scripts/rip-phase-walkthrough.sh
@@ -15,7 +15,7 @@
 # Usage:
 #   bash scripts/rip-phase-walkthrough.sh R2.3              # drive to the last task
 #   bash scripts/rip-phase-walkthrough.sh R2.3 --complete   # finish the phase too
-#   bash scripts/rip-phase-walkthrough.sh --chain           # R2.1 -> R4.1, one project
+#   bash scripts/rip-phase-walkthrough.sh --chain           # R2.1 -> R6.1, one project
 #   bash scripts/rip-phase-walkthrough.sh R2.3 --business-key flevoland-1788…
 #   bash scripts/rip-phase-walkthrough.sh R2.3 --force      # skip the precondition
 #   bash scripts/rip-phase-walkthrough.sh --clean <instanceId>
@@ -133,11 +133,17 @@ phase_config() { # $1 = phase code -> sets PROCESS_KEY STOP_KEYS MAX PHASE_NOTE
       MAX=90
       PHASE_NOTE="a PERIOD, not a deliverable: a weekly cycle runs alongside invoicing and delivery, so several tasks are open at once and task definitions recur. werkGereed=ja is what exits the cycle"
       ;;
+    R5.3)
+      PROCESS_KEY=RipR53Process
+      STOP_KEYS="Task_VaststellenOpleveringschouw Task_VaststellenIngebruiknameschouw"
+      MAX=30
+      PHASE_NOTE="one early choice (schouwType) opens two near-mirror paths that never rejoin; FOUR end events, and only opleveringAkkoord=ja leads to R5.4 — the other three return to R5.2, so the happy path here picks oplevering"
+      ;;
     R5.4)
       PROCESS_KEY=RipR54Process
       STOP_KEYS="Task_GereedmeldenVisi"
       MAX=60
-      PHASE_NOTE="its predecessor is R5.2 — R5.3 is handled outside this tool"
+      PHASE_NOTE="its predecessor is R5.3 — the oplevering areaal exit"
       ;;
     R6.1)
       PROCESS_KEY=RipR61Process
@@ -152,19 +158,21 @@ phase_config() { # $1 = phase code -> sets PROCESS_KEY STOP_KEYS MAX PHASE_NOTE
   return 0
 }
 
-# R5.3 is deliberately absent: it is `beyond`, so predecessor_of skips over
-# it and R5.4 follows R5.2, matching previousModelledPhase in the frontend.
-LADDER="R2.1 R2.2 R2.3 R2.4 R3.1 R3.2 R4.1 R5.1 R5.2 R5.4 R6.1"
+# All twelve phases are modelled and deployed. R5.3 used to be absent here
+# because it was `beyond` -- no BPMN, no observable exit -- so predecessor_of
+# skipped it and R5.4 followed R5.2. RipR53Process is deployed now and its
+# "Ja, oplevering areaal" end event is that exit, so R5.3 takes its place in
+# the ladder and R5.4 follows it.
+LADDER="R2.1 R2.2 R2.3 R2.4 R3.1 R3.2 R4.1 R5.1 R5.2 R5.3 R5.4 R6.1"
 
 # Tenant whose instances count as candidates. The board scopes readiness to the
 # caseworker's municipality; mirroring that keeps the script honest on a
 # multi-tenant engine.
 TENANT="${TENANT:-flevoland}"
 
-# The phase a project must have FINISHED before it can start $1 — skipping any
-# phase with no process model, the same rule previousModelledPhase applies in
-# the frontend catalogue. R5.3 is the one that matters: it is a real step with
-# no BPMN and no observable exit, so R5.4 follows R5.2.
+# The phase a project must have FINISHED before it can start $1 — the entry
+# preceding it in LADDER, the same rule previousModelledPhase applies in the
+# frontend catalogue now that every phase is modelled.
 predecessor_of() {
   local target="$1" prev=""
   for p in $LADDER; do
@@ -348,6 +356,10 @@ VARIABLES_JSON=$(jq -n \
     notaWaarde:         {value: "onder",  type: "String"},
     termijnenContract:  {value: "binnen", type: "String"},
     werkGereed:         {value: "ja",     type: "String"},
+
+    schouwType:           {value: "oplevering", type: "String"},
+    opleveringAkkoord:    {value: "ja",         type: "String"},
+    ingebruiknameAkkoord: {value: "ja",         type: "String"},
 
     opleverdossierAkkoordBeheer:    {value: "ja",                type: "String"},
     opleverdossierAkkoordDv:        {value: "ja",                type: "String"},


### PR DESCRIPTION
Adopts RIP phase **R5.3 — (vervroegde) ingebruikname / oplevering** into the
phase catalogue, then removes the `beyond` machinery it was the last user of.

R5.3 was the one rung with no process model. Its design sheet arrived on
3-9-2026 and it is deployed as `RipR53Process` on both the local engine and
ACC — verified off the REST API rather than taken from the deploy PR:
`formRefBinding=deployment` throughout with zero `latest` bindings,
`boardOwner=infra-board`, `ronl:organization=flevoland`, tenant `flevoland`,
and no form on the start event.

### The four commits

| | |
|---|---|
| `dab1c92` | **Adopt R5.3.** Shared process key, a real catalogue entry derived from the deployed BPMN, and the walkthrough script. |
| `63ada7e` | **Remove `beyond`.** No phase uses it any more. Net −197 lines. |
| `70a281c` | **R5.4 reports no `klaar` figure**, because it cannot be derived. |
| `f0688af` | **Correct the walkthrough guide.** |

### Why R5.4's predecessor changes

R5.3 was `beyond` precisely because it had no observable exit — a real step,
named by R5.4's own entry criterion, whose completion the board could not see.
Its `EndEvent_R54_Oplevering` ("Ja, oplevering areaal") is that exit, so
`previousModelledPhase('R5.4')` now resolves to R5.3 and nothing is reported as
skipped.

### Why R5.4 shows "—" instead of a number

`klaar[N] = max(0, gereed[N-1] - wip[N] - gereed[N])` assumes finishing a phase
means advancing to the next. R5.3 breaks that: it has **four** end events and
only one leads to R5.4 — the other three return to R5.2 (restpunten, restpunten
by the ON, or a vervroegde ingebruikname where part of the areaal goes into use
*while the work carries on*). So `gereed[R5.3]` mixes four outcomes, and that
last one means a project can legitimately complete R5.3 **more than once**.

A number there would overstate R5.4's candidates in a way nothing on screen
could reveal. Reporting "—" is honest. The real fix is to count only the
R5.4-bound exit, which needs the phase-counts endpoint to report more than a
flat `{ wip, gereed }`; that is recorded in the `getKlaarCounts` docstring.

Driven by a `multipleExits` flag on the phase, not a literal `'R5.3'` in the
arithmetic — a hardcoded code is the trap `c561d48` cleaned up. One test proves
it by moving the flag onto R2.2 and asserting R2.3 goes undefined *while R5.4
starts deriving again*.

### `beyond` took more with it than expected

`geparkeerd` turned out to be entirely a frontend fiction: the live counts
endpoint returns `{ wip, gereed }`, no backend code mentions the word, and
`getMockPhaseCounts` credited it only inside the `phase.beyond` branch. Also
removed: `'onbekend'` from `RipDeployStatus`, `skippedPhasesBefore()`,
`parkedCount`, `getMockGeparkeerdRows()`, PhaseDetail's "Niet gemodelleerd"
placeholder, and the parked rail badge.

The rail badge in `InfraBoardDashboard.tsx` was **not** found by grepping for
`beyond` — it destructured `parkedCount` out of the rail item, so only the
typecheck surfaced it.

### The walkthrough script carried the same assumption

Its `LADDER` skipped R5.3, so `--chain` would have started R5.4 off an R5.2
completion — a state the board's Starten tab can no longer produce, which is
exactly what the script's own header says it must never set up. A test script
encoding a stale assumption fails silently in the direction of false confidence.

Its happy-path variables now pick `schouwType=oplevering` with
`opleveringAkkoord=ja`: R5.3 is the only phase where the happy path is a route
choice rather than an approval, since picking the mirror path walks the chain
backwards.

### Verification

- `bash scripts/rip-phase-walkthrough.sh --chain` against the local engine:
  **twelve** instances under one businessKey, R5.3 completed, and its only end
  event reached was `EndEvent_R54_Oplevering`.
- Frontend 108 files / 1048 tests, backend 84 suites / 1847 tests (2 skipped),
  typecheck, lint and `check-format` clean.
- ACC Operaton re-checked: 12/12 definitions, all v1, tenant `flevoland`.

### Not covered

The re-entry case — early commissioning, back to R5.2, then R5.3 again — is not
exercised by `--chain`, which only ever walks the oplevering path.
