### PR TITLE
test(frontend): await the lazy changelog drawer in the variants tests

### DIFF
--- a/packages/frontend/src/pages/ChangelogPanel.variants.test.tsx
+++ b/packages/frontend/src/pages/ChangelogPanel.variants.test.tsx
@@ -35,10 +35,16 @@ function setVersions(versions: unknown[]) {
   mockChangelog.changelog = { versions };
 }
 
+// Every test here awaits findByRole('dialog') straight after render.
+// ChangelogPanel is a lazy() + Suspense shim (e4c9da1) so its content resolves
+// asynchronously; a synchronous getByRole finds an empty DOM. Dropping these
+// awaits does not merely break the file -- the negative assertions would pass
+// against nothing rendered at all, which is worse than a failure.
 describe('ChangelogPanel with an empty changelog', () => {
-  it('opens without expanding anything, rather than throwing on a missing first entry', () => {
+  it('opens without expanding anything, rather than throwing on a missing first entry', async () => {
     setVersions([]);
     render(<ChangelogPanel isOpen onClose={vi.fn()} />);
+    await screen.findByRole('dialog');
     expect(screen.getByRole('dialog')).toBeInTheDocument();
   });
 });
@@ -73,6 +79,7 @@ describe('ChangelogPanel per-commit entries', () => {
     ]);
 
     render(<ChangelogPanel isOpen onClose={vi.fn()} />);
+    await screen.findByRole('dialog');
 
     expect(screen.getAllByText('Latest')).toHaveLength(1);
     expect(screen.getByText('Released')).toBeInTheDocument();
@@ -88,7 +95,7 @@ describe('ChangelogPanel per-commit entries', () => {
     expect(screen.getByText('Reparatie')).toBeInTheDocument();
   });
 
-  it('gives a commit type it has no icon for the neutral fallback rather than nothing', () => {
+  it('gives a commit type it has no icon for the neutral fallback rather than nothing', async () => {
     setVersions([
       {
         format: 'commits',
@@ -109,12 +116,13 @@ describe('ChangelogPanel per-commit entries', () => {
     ]);
 
     render(<ChangelogPanel isOpen onClose={vi.fn()} />);
+    await screen.findByRole('dialog');
 
     expect(screen.getByText('Onbekend committype')).toBeInTheDocument();
     expect(screen.getByText('Waarom dit nodig was.')).toBeInTheDocument();
   });
 
-  it('lists resolved work items as chip links, labelled by kind', () => {
+  it('lists resolved work items as chip links, labelled by kind', async () => {
     setVersions([
       {
         format: 'commits',
@@ -128,6 +136,7 @@ describe('ChangelogPanel per-commit entries', () => {
     ]);
 
     render(<ChangelogPanel isOpen onClose={vi.fn()} />);
+    await screen.findByRole('dialog');
 
     expect(screen.getByText('Feedback / use case handled')).toBeInTheDocument();
     // The chip carries the kind and the work-item number together.
@@ -143,7 +152,7 @@ describe('ChangelogPanel per-commit entries', () => {
     );
   });
 
-  it('omits the work-item block entirely when a release resolved none', () => {
+  it('omits the work-item block entirely when a release resolved none', async () => {
     setVersions([
       {
         format: 'commits',
@@ -157,6 +166,7 @@ describe('ChangelogPanel per-commit entries', () => {
     ]);
 
     render(<ChangelogPanel isOpen onClose={vi.fn()} />);
+    await screen.findByRole('dialog');
 
     expect(screen.queryByText('Feedback / use case handled')).not.toBeInTheDocument();
     expect(screen.queryByText(/Use Case #/)).not.toBeInTheDocument();
@@ -164,7 +174,7 @@ describe('ChangelogPanel per-commit entries', () => {
 });
 
 describe('ChangelogPanel legacy section entries', () => {
-  it('renders a section with an icon colour it does not recognise', () => {
+  it('renders a section with an icon colour it does not recognise', async () => {
     // iconColor comes from hand-written history entries; an unknown value must
     // fall back to the default rather than dropping the class entirely.
     setVersions([
@@ -186,6 +196,7 @@ describe('ChangelogPanel legacy section entries', () => {
     ]);
 
     render(<ChangelogPanel isOpen onClose={vi.fn()} />);
+    await screen.findByRole('dialog');
 
     const heading = screen.getByText('Onbekende kleur');
     expect(heading).toBeInTheDocument();
@@ -195,7 +206,7 @@ describe('ChangelogPanel legacy section entries', () => {
     expect(screen.getByRole('link', { name: /Trage takenlijst/ })).toBeInTheDocument();
   });
 
-  it('renders a legacy entry with no scope badge at all', () => {
+  it('renders a legacy entry with no scope badge at all', async () => {
     setVersions([
       {
         version: '9.9.9',
@@ -208,6 +219,7 @@ describe('ChangelogPanel legacy section entries', () => {
     ]);
 
     render(<ChangelogPanel isOpen onClose={vi.fn()} />);
+    await screen.findByRole('dialog');
 
     const header = screen.getByRole('button', { name: /v9\.9\.9/ });
     expect(within(header).queryByText(/Full-stack|Frontend|Backend/)).not.toBeInTheDocument();


### PR DESCRIPTION
`acc` is red: six of the seven tests in `ChangelogPanel.variants.test.tsx`
fail, and the seventh passes for a worse reason.

## Cause

`e4c9da1` (#51) made `ChangelogPanel` a `lazy()` + `Suspense` shim, so the
drawer's content resolves on a later tick. `ChangelogPanel.variants.test.tsx`
renders the panel and queries it synchronously, so `getByRole('dialog')` finds
an empty DOM.

**The two changes never met before landing.** The variants file was added by
`5b53700` ("hold every workspace to an 80% per-file branch floor") *after* the
lazy-load branch had forked. #51's CI never ran against it, and `acc`'s CI never
ran #51. Both sides were green in isolation, and the break only appeared once
they were on the same tree.

## The seventh test

It asserts `queryByText(...).not.toBeInTheDocument()` for a feedback section
that should be absent — and an empty DOM satisfies that trivially. It has been
passing while testing nothing. It is fixed here alongside the six that failed,
and it is why there is now a comment above the first `describe`: dropping these
awaits does not merely break the file, it turns its negative assertions into
assertions about nothing.

`ChangelogPanel.test.tsx`, added by #51 itself, already awaits for exactly this
reason and says so in a comment.

## Change

Seven `await screen.findByRole('dialog')` calls straight after each `render`,
six enclosing `it()` callbacks made `async` (the seventh already was), and the
explanatory comment. Test-side only — the shim's behaviour is correct and its
early return and `import type` are both load-bearing.

## Verification

Frontend **109 files / 1058 tests**, typecheck and `check-format` clean.
