### PR TITLE
chore: bump release to v2026.09.3

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "ronl-business-api",
-  "version": "2026.09.2",
+  "version": "2026.09.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "ronl-business-api",
-      "version": "2026.09.2",
+      "version": "2026.09.3",
       "hasInstallScript": true,
       "license": "EUPL-1.2",
       "workspaces": [
@@ -17226,7 +17226,7 @@
     },
     "packages/backend": {
       "name": "@ronl/backend",
-      "version": "2026.09.2",
+      "version": "2026.09.3",
       "license": "EUPL-1.2",
       "dependencies": {
         "@anthropic-ai/sdk": "^0.122.0",
@@ -17354,7 +17354,7 @@
     },
     "packages/frontend": {
       "name": "@ronl/frontend",
-      "version": "2026.09.2",
+      "version": "2026.09.3",
       "dependencies": {
         "@bpmn-io/form-js": "^1.20.1",
         "@ronl/pa-cockpit": "*",
@@ -19453,7 +19453,7 @@
     },
     "packages/shared": {
       "name": "@ronl/shared",
-      "version": "2026.09.2",
+      "version": "2026.09.3",
       "license": "EUPL-1.2",
       "devDependencies": {
         "typescript": "^5.3.3"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ronl-business-api",
-  "version": "2026.09.2",
+  "version": "2026.09.3",
   "description": "Secure, multi-tenant Business API for Dutch municipality BPMN/DMN services",
   "private": true,
   "workspaces": [

--- a/packages/backend/package.json
+++ b/packages/backend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ronl/backend",
-  "version": "2026.09.2",
+  "version": "2026.09.3",
   "description": "Secure Business API layer for Dutch municipality BPMN services",
   "main": "dist/index.js",
   "scripts": {

--- a/packages/frontend/package.json
+++ b/packages/frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ronl/frontend",
-  "version": "2026.09.2",
+  "version": "2026.09.3",
   "description": "Municipality portal (MijnOmgeving) with identity provider selection",
   "type": "module",
   "scripts": {

--- a/packages/frontend/src/pages/ChangelogPanelContent.tsx
+++ b/packages/frontend/src/pages/ChangelogPanelContent.tsx
@@ -342,6 +342,7 @@ const COMMIT_TYPE_META: Record<CommitType, { icon: string; color: keyof typeof T
   docs: { icon: '📘', color: 'blue' },
   chore: { icon: '🧹', color: 'gray' },
   refactor: { icon: '♻️', color: 'orange' },
+  perf: { icon: '⚡', color: 'teal' },
   ci: { icon: '🔒', color: 'amber' },
   other: { icon: '📄', color: 'gray' },
 };
@@ -354,6 +355,7 @@ const TEXT_COLORS = {
   red: 'text-red-700',
   gray: 'text-gray-700',
   amber: 'text-amber-700',
+  teal: 'text-teal-700',
 };
 
 function CommitBlock({ commit }: { commit: ChangelogCommit }) {

--- a/packages/frontend/src/pages/changelog-data.ts
+++ b/packages/frontend/src/pages/changelog-data.ts
@@ -63,6 +63,10 @@ export type CommitType =
   | 'docs'
   | 'chore'
   | 'refactor'
+  // A measured change to how much work the product does or how much it ships,
+  // with the behaviour left alone. Distinct from 'refactor', which restructures
+  // without claiming a difference the user could observe.
+  | 'perf'
   // Pipeline and supply-chain work: workflow pinning, CI gates, release
   // tooling. Distinct from 'chore' because it is the one category whose
   // commits change how everything else is built and shipped.

--- a/packages/frontend/src/pages/changelog-data.ts
+++ b/packages/frontend/src/pages/changelog-data.ts
@@ -112,6 +112,125 @@ export const changelog: Changelog = {
   versions: [
     {
       format: 'commits',
+      version: '2026.09.3',
+      status: 'Released',
+      date: '3 sep 2026',
+      scope: ['backend', 'frontend'],
+      commits: [
+        {
+          sha: '533c288',
+          author: 'Steven Gort',
+          type: 'feat',
+          subject: 'The changelog gained a performance commit type',
+          details: [
+            'CommitType had no perf, so a perf commit could only be filed as other and rendered with the neutral document icon beside genuine miscellany. This release contains one — the drawer’s lazy load — and that is not miscellany. It gets its own icon and colour; every existing colour was already spoken for, so a new one is added rather than doubling up on a substantive type.',
+            'The distinction from refactor is written on the union itself: perf claims a difference the user could observe, refactor explicitly does not.',
+          ],
+        },
+        {
+          sha: '71458eb',
+          author: 'Steven Gort',
+          type: 'test',
+          subject: 'The changelog drawer tests await their lazy content',
+          details: [
+            'ChangelogPanel.variants.test.tsx rendered the panel and queried it synchronously. Splitting the drawer made ChangelogPanel a lazy() + Suspense shim, so its content resolves on a later tick and a synchronous getByRole finds an empty DOM. Six of its seven tests failed.',
+            'The seventh is the one worth recording. It asserts a feedback section is absent, and an empty DOM satisfies that trivially — so it went on passing while testing nothing at all. Both halves are fixed here, and a note above the first describe explains why the awaits are load-bearing: removing them does not merely break the file, it converts its negative assertions into assertions about nothing.',
+            'The two changes never met before landing. The variants file was added after the lazy-load branch had forked, so neither side’s CI ever ran both. Each was green in isolation and the break appeared only once they shared a tree.',
+          ],
+        },
+        {
+          sha: '70a281c',
+          author: 'Steven Gort',
+          type: 'fix',
+          subject: 'R5.4 reports no Klaar figure, because it cannot be derived',
+          details: [
+            'Klaar is computed as gereed[predecessor] − wip − gereed, which assumes that finishing a phase means advancing to the next one. That holds for every transition in the ladder except the one out of R5.3.',
+            'R5.3 has four end events and only "Ja, oplevering areaal" leads to R5.4. The other three return to R5.2: restpunten to execute, restpunten by the opdrachtnemer, and a vervroegde ingebruikname where part of the areaal goes into use while the work carries on. So gereed for R5.3 mixes four outcomes, and that last one means one project can legitimately complete the phase more than once. A number there would overstate R5.4’s candidates in a way nothing on the screen could reveal, so R5.4 now shows "—", the same treatment R2.1 gets for having no predecessor.',
+            'Driven by a multipleExits flag on the phase rather than a literal phase code in the arithmetic. Counting only the R5.4-bound exit is the real fix and needs the phase-counts endpoint to report more than a flat wip/gereed pair.',
+          ],
+        },
+        {
+          sha: '63ada7e',
+          author: 'Steven Gort',
+          type: 'refactor',
+          subject: 'The `beyond` phase concept is gone',
+          details: [
+            'R5.3 was the catalogue’s only beyond phase, and adopting it left the flag with no users. Removed along with it: the onbekend deploy status and its metadata entry, skippedPhasesBefore (which returned an empty list for every phase), parkedCount, getMockGeparkeerdRows, the "Niet gemodelleerd" placeholder view, and the parked badge on the Beheer rail. previousModelledPhase is now simply the preceding entry.',
+            'geparkeerd went with it, and turned out to be entirely a frontend fiction: the live counts endpoint returns wip and gereed only, no backend code mentions the concept, and the mock counter credited it exclusively inside the beyond branch. It existed to give the one unmodelled phase something to show instead of WIP. Net 197 lines removed.',
+          ],
+        },
+        {
+          sha: 'dab1c92',
+          author: 'Steven Gort',
+          type: 'feat',
+          subject: 'R5.3 adopted in the phase catalogue — twelve of twelve deelprocessen inzetbaar',
+          details: [
+            'R5.3 was the last rung with no process model. Its design sheet arrived on 3-9-2026 and it is deployed as RipR53Process on both the local engine and ACC, verified against the engine REST API rather than taken from the deploy pull request: deployment form bindings throughout with no latest bindings, boardOwner and organization set, tenant flevoland, and no form on the start event.',
+            'The catalogue entry was a placeholder — no exit, no documents, no gates, three roles, and a source line reading PLACEHOLDER. All of it now derives from the deployed BPMN, and the six roles match the six candidate groups on the engine exactly, which is an independent check that the entry and the engine agree.',
+            'R5.4’s predecessor changes from R5.2 to R5.3 and nothing is reported as skipped any more, because R5.3 finally has an observable exit. The walkthrough script carried the same assumption and is corrected here: its ladder skipped R5.3, so a chained run would have started R5.4 from an R5.2 completion — a state the board can no longer produce.',
+          ],
+        },
+        {
+          sha: '3674f66',
+          author: 'Steven Gort',
+          type: 'fix',
+          subject: 'A live project shows its own RIP phase, not always R2.1',
+          details: [
+            'ProjectDetail hard-coded the current phase for every live instance. That was true when it was written — R2.1 was the only process modelled as BPMN — and deploying R2.2 through R6.1 falsified the premise while the constant stayed. One stale constant produced three wrong things at once for a project sitting in R2.2.',
+          ],
+        },
+        {
+          sha: 'e519902',
+          author: 'Steven Gort',
+          type: 'fix',
+          subject:
+            'PA cache: a bounded connect, retry after failure, and cache state in /v1/health',
+          details: [
+            'PA caching turned out never to have worked in either environment. The misconfiguration was fixed operationally on ACC; this fixes the three things in code that let a total cache outage run for at least nine days without anyone noticing.',
+            'The root cause of the silence is the important one: connect() was unbounded. The timeout wrapper guarded get() and set() but not the connect itself, and node-redis retries a failing socket internally rather than rejecting — so the await never settled. /v1/health now reports cache state, with a down cache visible without failing the health check.',
+          ],
+        },
+        {
+          sha: 'f4976fc',
+          author: 'Steven Gort',
+          type: 'test',
+          subject: 'The changelog guard sees bare dynamic imports and braced gates',
+          details: [
+            'A bare dynamic import at module scope passed all three of the guard’s assertions while firing the fetch at module evaluation — the chunk downloading on every page load whether or not the drawer opens, which is exactly what the split exists to prevent. All three checks looked at declaration syntax, so none saw a bare expression statement, and it evades noUnusedLocals by having no binding.',
+          ],
+        },
+        {
+          sha: 'e2f65ee',
+          author: 'Steven Gort',
+          type: 'test',
+          subject: 'The changelog guard sees re-exports too',
+          details: [
+            'The guard’s first assertion inspected import declarations and never export declarations, but a re-export with a module specifier is an equally static runtime edge. Confirmed with a real build rather than reasoned about: adding one re-export plus a consumer collapsed the output to a single 709 KB gzipped chunk, where the split produces a 581 KB entry and a separate 129 KB changelog.',
+          ],
+        },
+        {
+          sha: '5343685',
+          author: 'Steven Gort',
+          type: 'test',
+          subject: 'A guard keeps ChangelogPanel a shim',
+          details: [
+            'Three small edits would each undo the split while every behavioural test stayed green, because none of them change what a user sees — a static value import that reaches the data being the plainest. The unauthenticated login screen renders this panel, so an undetected regression here means the whole changelog ships in the entry chunk again.',
+          ],
+        },
+        {
+          sha: 'e4c9da1',
+          author: 'Steven Gort',
+          type: 'perf',
+          subject: 'The changelog drawer loads its content on demand',
+          details: [
+            'changelog-data.ts is 432 KB raw and 131 KB gzipped across 102 releases, about 19% of what a visitor downloads. The login screen renders this panel, so before the split an unauthenticated visitor downloaded the project’s entire engineering diary before they could log in.',
+            'ChangelogPanel is now a shim over a lazily imported ChangelogPanelContent. The Suspense boundary sits inside the shim rather than at the call sites, because the PA cockpit renders this panel through the host contract and contains no boundary of its own; a bare lazy component would throw the moment the drawer opened there.',
+          ],
+        },
+      ],
+    },
+    {
+      format: 'commits',
       version: '2026.09.2',
       status: 'Released',
       date: '3 sep 2026',

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ronl/shared",
-  "version": "2026.09.2",
+  "version": "2026.09.3",
   "description": "Shared types and utilities for RONL Business API",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",


### PR DESCRIPTION
Cuts **v2026.09.3**. Eleven commits since v2026.09.2, in three streams.

## The RIP ladder is complete

R5.3 was the last rung with no process model. Its design sheet arrived on
3-9-2026 and it is deployed as `RipR53Process` on both the local engine and
ACC, so the Faseladder now reads **twelve of twelve deelprocessen inzetbaar**.

Adopting it left `beyond` with no users and the concept is gone — taking
`geparkeerd` with it, which turned out to be entirely a frontend fiction (the
live counts endpoint returns `wip` and `gereed` only, and no backend code
mentions the concept). Net 197 lines removed.

R5.4 stops reporting a Klaar figure. R5.3 has four end events and only
"Ja, oplevering areaal" leads onward; the other three return to R5.2, and one of
them means a project can legitimately complete the phase twice. The subtraction
that derives Klaar assumes finishing means advancing, so the number could not be
derived honestly and now reads "—".

## The changelog drawer loads on demand

`changelog-data.ts` is 432 KB raw across 102 releases, about 19% of what a
visitor downloads, and the login screen rendered it — so an unauthenticated
visitor downloaded the project's entire engineering diary before they could log
in. Three guard tests keep the split from being undone by an edit that leaves
every behavioural test green.

## PA caching never worked

`connect()` was unbounded. The timeout wrapper guarded `get()` and `set()` but
not the connect itself, and node-redis retries a failing socket internally
rather than rejecting — so the await never settled and a total cache outage ran
for at least nine days unnoticed. `/v1/health` now reports cache state.

## Scope and versions

`['backend', 'frontend']`. `packages/shared` changed too and has no scope tag of
its own — it feeds both builds — so **root, frontend, backend and shared** are
versioned to `2026.09.3`, along with their four `package-lock.json` entries.
Bumped by hand: `npm version` coerces CalVer to SemVer and would have written
`2026.9.3`.

**On merge this redeploys** backend, frontend and pa-demo (pa-demo watches
`packages/shared/**`). Public-site does **not** — `azure-publicsite-acc.yml`
watches `packages/public-site/**` alone.

## Two things deliberately left out

**Six docs, design and plan commits are not listed.** The changelog records what
changed for a user of this software, not the paper trail.

**`/v1/docs` is still advertised in the root endpoint map.** `bump-release`
step 5 reconciles that map on every backend-scoped release and flagged it: 17
routes mounted, 18 advertised. But `git log -S` shows it was **never** mounted
in the entire history — a gap rather than drift from this release — so removing
it here would have shipped an unrelated API-surface change unlisted. Filed as
#67.

## Preceded by a source change, not folded into the bump

`533c288` adds a `perf` commit type. `CommitType` had none, so the drawer's lazy
load could only be filed as `other` and rendered with the neutral document icon.
Per `bump-release` step 7 it is committed *before* the bump and listed in the
entry — the bump commit is the boundary marker `git log --grep` searches for and
is never listed in its own entry, so a source change folded into it would ship
unlisted.

## Verification

Frontend **109 files / 1058 tests**, backend **84 suites / 1868 tests** (2
skipped), typecheck, lint and `check-format` clean, `npm ci --dry-run` resolves.

Also verified against the live engine: `--chain` walks all twelve phases under
one businessKey, with R5.3 reaching only `EndEvent_R54_Oplevering`.

## After merge

`packages/backend` needs its separate deploy script for `/v1/health`'s new
`cache` entry to actually reach ACC — the ACC workflow builds but does not
deploy the backend.
