### PR TITLE
perf(infra-board): one request instead of 48, and cache the parsed diagram

### DIFF
--- a/packages/backend/src/routes/rip.routes.test.ts
+++ b/packages/backend/src/routes/rip.routes.test.ts
@@ -30,7 +30,7 @@ jest.mock('@services/operaton.service', () => ({
     getRipInstanceDocuments: jest.fn(),
     getDeployedProcessKeys: jest.fn(),
     getPhaseInstanceCounts: jest.fn(),
-    getPhaseBpmnXml: jest.fn(),
+    getPhaseSwimlaneModel: jest.fn(),
   },
 }));
 jest.mock('@utils/logger', () => ({
@@ -42,6 +42,7 @@ import request from 'supertest';
 import ripRouter from './rip.routes';
 import { operatonService } from '@services/operaton.service';
 import { RIP_PHASE_KEYS } from '@ronl/shared';
+import { parseSwimlane } from '../rip-swimlane/bpmn-swimlane';
 
 /** Every phase modelled as BPMN — the exact list both phase endpoints query. */
 const MODELLED_KEYS = RIP_PHASE_KEYS.map((p) => p.processDefinitionKey).filter(Boolean);
@@ -66,7 +67,7 @@ const svc = operatonService as unknown as {
   getRipInstanceDocuments: jest.Mock;
   getDeployedProcessKeys: jest.Mock;
   getPhaseInstanceCounts: jest.Mock;
-  getPhaseBpmnXml: jest.Mock;
+  getPhaseSwimlaneModel: jest.Mock;
 };
 
 const app = express();
@@ -144,13 +145,21 @@ describe('lists', () => {
   );
 
   it('the fixed /phases routes are not swallowed by /phases/:code', async () => {
-    // deployment-status and counts sit one path segment shorter than
+    // deployment-status, counts and active sit one path segment shorter than
     // /phases/:code/active so they cannot collide, but the arrangement is
     // load-bearing enough to pin.
     svc.getDeployedProcessKeys.mockResolvedValue([]);
     svc.getPhaseInstanceCounts.mockResolvedValue({});
+    svc.getRipPhaseActiveList.mockResolvedValue([]);
     expect((await auth(request(app).get('/v1/rip/phases/deployment-status'))).status).toBe(200);
     expect((await auth(request(app).get('/v1/rip/phases/counts'))).status).toBe(200);
+    const activeRes = await auth(request(app).get('/v1/rip/phases/active'));
+    expect(activeRes.status).toBe(200);
+    // The tell-tale sign of being swallowed by /phases/:code/active would be a
+    // 404 UNKNOWN_PHASE (code="active" is not in the catalogue) — the aggregate
+    // shape below is proof this hit the literal route instead.
+    expect(activeRes.body.error).toBeUndefined();
+    expect(activeRes.body.data).toEqual([]);
   });
 
   it('GET /phases/:code/completed → 500 on service failure', async () => {
@@ -158,6 +167,47 @@ describe('lists', () => {
     const res = await auth(request(app).get('/v1/rip/phases/R2.1/completed'));
     expect(res.status).toBe(500);
     expect(res.body.error.code).toBe('RIP_COMPLETED_LIST_FAILED');
+  });
+});
+
+describe('GET /phases/active', () => {
+  it('401 without a token', async () => {
+    const res = await request(app).get('/v1/rip/phases/active');
+    expect(res.status).toBe(401);
+  });
+
+  it('aggregates active instances across every modelled phase, tagging each row with its phaseCode', async () => {
+    svc.getRipPhaseActiveList.mockImplementation((key: string) =>
+      Promise.resolve(key === 'RipR21Process' ? [{ id: 'i1' }] : [])
+    );
+    const res = await auth(request(app).get('/v1/rip/phases/active'));
+    expect(res.status).toBe(200);
+    expect(res.body.success).toBe(true);
+    expect(res.body.data).toEqual([{ id: 'i1', phaseCode: 'R2.1' }]);
+    expect(svc.getRipPhaseActiveList).toHaveBeenCalledTimes(MODELLED_KEYS.length);
+    expect(svc.getRipPhaseActiveList).toHaveBeenCalledWith('RipR21Process', 'flevoland');
+    expect(svc.getRipPhaseActiveList).toHaveBeenCalledWith('RipR22Process', 'flevoland');
+  });
+
+  it('omits a failing phase rather than blanking the rest of the aggregate', async () => {
+    svc.getRipPhaseActiveList.mockImplementation((key: string) => {
+      if (key === 'RipR22Process') return Promise.reject('socket hang up'); // non-Error rejection
+      return Promise.resolve(key === 'RipR21Process' ? [{ id: 'i1' }] : []);
+    });
+    const res = await auth(request(app).get('/v1/rip/phases/active'));
+    expect(res.status).toBe(200);
+    expect(res.body.success).toBe(true);
+    expect(res.body.data).toEqual([{ id: 'i1', phaseCode: 'R2.1' }]);
+    expect(
+      (res.body.data as Array<{ phaseCode: string }>).some((r) => r.phaseCode === 'R2.2')
+    ).toBe(false);
+  });
+
+  it('500s with RIP_ACTIVE_AGGREGATE_FAILED when every modelled phase fails', async () => {
+    svc.getRipPhaseActiveList.mockRejectedValue(new Error('boom'));
+    const res = await auth(request(app).get('/v1/rip/phases/active'));
+    expect(res.status).toBe(500);
+    expect(res.body.error.code).toBe('RIP_ACTIVE_AGGREGATE_FAILED');
   });
 });
 
@@ -248,6 +298,7 @@ describe('handler guards for an authenticated request without a user', () => {
   const noUser = (r: request.Test) => r.set('x-test-no-user', '1');
 
   it.each([
+    ['/v1/rip/phases/active'],
     ['/v1/rip/phases/R2.1/active'],
     ['/v1/rip/phases/deployment-status'],
     ['/v1/rip/phases/counts'],
@@ -269,6 +320,13 @@ describe('non-Error rejections', () => {
     const res = await auth(request(app).get('/v1/rip/phases/R2.1/active'));
     expect(res.status).toBe(500);
     expect(res.body.error.code).toBe('RIP_LIST_FAILED');
+  });
+
+  it('GET /phases/active still answers 500 when every phase rejects without an Error', async () => {
+    svc.getRipPhaseActiveList.mockRejectedValue('socket hang up');
+    const res = await auth(request(app).get('/v1/rip/phases/active'));
+    expect(res.status).toBe(500);
+    expect(res.body.error.code).toBe('RIP_ACTIVE_AGGREGATE_FAILED');
   });
 
   it('GET /phases/deployment-status still answers 500', async () => {
@@ -301,7 +359,7 @@ describe('non-Error rejections', () => {
   });
 
   it('GET /phases/:code/model still answers 500', async () => {
-    svc.getPhaseBpmnXml.mockRejectedValue('socket hang up');
+    svc.getPhaseSwimlaneModel.mockRejectedValue('socket hang up');
     const res = await auth(request(app).get('/v1/rip/phases/R2.1/model'));
     expect(res.status).toBe(500);
     expect(res.body.error.code).toBe('PHASE_MODEL_FAILED');
@@ -323,10 +381,15 @@ describe('tenant isolation when the instance has no municipality', () => {
 });
 
 describe('GET /phases/:code/model', () => {
+  // The route now delegates fetch+parse+cache to operatonService.getPhaseSwimlaneModel
+  // (operaton.service.test.ts covers that pipeline against this same fixture,
+  // including the cache itself); here the mock resolves with the real parsed
+  // model so the route-layer assertions below still catch wrong-shape wiring.
   const r22Xml = readFileSync(
     join(__dirname, '../rip-swimlane/__fixtures__/RipR22Process.bpmn'),
     'utf-8'
   );
+  const r22Model = parseSwimlane(r22Xml, 'R2.2');
 
   it('401 without a token', async () => {
     const res = await request(app).get('/v1/rip/phases/R2.2/model');
@@ -334,7 +397,7 @@ describe('GET /phases/:code/model', () => {
   });
 
   it('returns a swimlane model derived from the deployed BPMN', async () => {
-    svc.getPhaseBpmnXml.mockResolvedValue(r22Xml);
+    svc.getPhaseSwimlaneModel.mockResolvedValue(r22Model);
 
     const res = await auth(request(app).get('/v1/rip/phases/R2.2/model'));
 
@@ -352,25 +415,25 @@ describe('GET /phases/:code/model', () => {
     ]);
     expect(res.body.data.nodes).toHaveLength(17);
     expect(res.body.data.edges).toHaveLength(21);
-    expect(svc.getPhaseBpmnXml).toHaveBeenCalledWith('RipR22Process', 'flevoland');
+    expect(svc.getPhaseSwimlaneModel).toHaveBeenCalledWith('RipR22Process', 'R2.2', 'flevoland');
   });
 
   it('404s an unknown phase code without touching the engine', async () => {
     const res = await auth(request(app).get('/v1/rip/phases/R9.9/model'));
     expect(res.status).toBe(404);
     expect(res.body.error.code).toBe('UNKNOWN_PHASE');
-    expect(svc.getPhaseBpmnXml).not.toHaveBeenCalled();
+    expect(svc.getPhaseSwimlaneModel).not.toHaveBeenCalled();
   });
 
   itIfUnmodelled('409s a known but unmodelled phase without touching the engine', async () => {
     const res = await auth(request(app).get(`/v1/rip/phases/${UNMODELLED_CODE}/model`));
     expect(res.status).toBe(409);
     expect(res.body.error.code).toBe('PHASE_NOT_MODELLED');
-    expect(svc.getPhaseBpmnXml).not.toHaveBeenCalled();
+    expect(svc.getPhaseSwimlaneModel).not.toHaveBeenCalled();
   });
 
   it('500s with PHASE_MODEL_FAILED rather than half-rendering when the engine is unreachable', async () => {
-    svc.getPhaseBpmnXml.mockRejectedValue(new Error('ECONNREFUSED'));
+    svc.getPhaseSwimlaneModel.mockRejectedValue(new Error('ECONNREFUSED'));
     const res = await auth(request(app).get('/v1/rip/phases/R2.2/model'));
     expect(res.status).toBe(500);
     expect(res.body.error.code).toBe('PHASE_MODEL_FAILED');

--- a/packages/backend/src/routes/rip.routes.ts
+++ b/packages/backend/src/routes/rip.routes.ts
@@ -5,7 +5,6 @@ import { tenantMiddleware } from '@middleware/tenant.middleware';
 import { operatonService } from '@services/operaton.service';
 import { createLogger } from '@utils/logger';
 import { RIP_PHASE_KEYS } from '@ronl/shared';
-import { parseSwimlane } from '../rip-swimlane/bpmn-swimlane';
 
 const router = express.Router();
 const logger = createLogger('rip-routes');
@@ -49,6 +48,76 @@ function resolvePhaseKey(code: string, res: Response): string | null {
   }
   return phase.processDefinitionKey;
 }
+
+/**
+ * GET /v1/rip/phases/active
+ * Active instances of EVERY modelled RIP phase in one response, each row
+ * tagged with the phase code it belongs to -- the aggregate the Infra-board
+ * needs so `useRipActiveAcrossPhases()` can collapse its twelve per-phase
+ * requests into one. Registered ahead of `/phases/:code/active` below, on the
+ * same "literal before parameterised" principle as `/phases/deployment-status`
+ * and `/phases/counts` further down -- though this pair cannot actually
+ * collide: `/phases/active` is two path segments, `/phases/:code/active` is
+ * three, so Express's own routing already keeps them apart (see the "not
+ * swallowed" test in rip.routes.test.ts, which pins this for all four).
+ *
+ * One phase failing must not blank the rest: each modelled phase is fetched
+ * independently via Promise.allSettled, a rejection is logged and that
+ * phase's rows are simply omitted, and the response still succeeds as long
+ * as at least one phase came back. Only a total failure (every modelled
+ * phase rejected) answers 500 -- mirroring the frontend's own
+ * fetchActiveAcrossPhases, which today does the fan-out and per-request
+ * catch itself (infra.api.ts) and reports success iff at least one phase
+ * succeeded.
+ */
+router.get('/phases/active', async (req, res) => {
+  if (!req.user) {
+    return res.status(401).json({
+      success: false,
+      error: { code: 'UNAUTHORIZED', message: 'Authentication required' },
+    });
+  }
+  const tenantId = req.user.tenantId;
+  const phases = RIP_PHASE_KEYS.filter(
+    (p): p is typeof p & { processDefinitionKey: string } => !!p.processDefinitionKey
+  );
+  const settled = await Promise.allSettled(
+    phases.map((p) => operatonService.getRipPhaseActiveList(p.processDefinitionKey, tenantId))
+  );
+  const rows: Array<
+    Awaited<ReturnType<typeof operatonService.getRipPhaseActiveList>>[number] & {
+      phaseCode: string;
+    }
+  > = [];
+  let anySucceeded = false;
+  settled.forEach((result, i) => {
+    if (result.status === 'fulfilled') {
+      anySucceeded = true;
+      for (const instance of result.value) {
+        rows.push({ ...instance, phaseCode: phases[i].code });
+      }
+    } else {
+      logger.error('Failed to list active RIP phase instances for the aggregate', {
+        phaseCode: phases[i].code,
+        tenantId,
+        error:
+          result.reason instanceof Error
+            ? result.reason.message
+            : String(result.reason ?? 'Unknown error'),
+      });
+    }
+  });
+  if (!anySucceeded) {
+    return res.status(500).json({
+      success: false,
+      error: {
+        code: 'RIP_ACTIVE_AGGREGATE_FAILED',
+        message: 'Failed to retrieve active RIP phase instances for any modelled phase',
+      },
+    });
+  }
+  res.json({ success: true, data: rows });
+});
 
 /**
  * GET /v1/rip/phases/:code/active
@@ -131,8 +200,8 @@ router.get('/phases/:code/model', async (req, res) => {
   const key = resolvePhaseKey(code, res);
   if (!key) return;
   try {
-    const xml = await operatonService.getPhaseBpmnXml(key, req.user.tenantId);
-    res.json({ success: true, data: parseSwimlane(xml, code) });
+    const model = await operatonService.getPhaseSwimlaneModel(key, code, req.user.tenantId);
+    res.json({ success: true, data: model });
   } catch (error) {
     logger.error('Failed to build RIP phase swimlane model', {
       code,

--- a/packages/backend/src/services/operaton.service.test.ts
+++ b/packages/backend/src/services/operaton.service.test.ts
@@ -34,6 +34,8 @@ jest.mock('@utils/config', () => ({
 const mockLogger = { info: jest.fn(), warn: jest.fn(), error: jest.fn(), debug: jest.fn() };
 jest.mock('@utils/logger', () => ({ createLogger: () => mockLogger }));
 
+import { readFileSync } from 'fs';
+import { join } from 'path';
 import { OperatonService } from './operaton.service';
 import type { OperatonVariable, ProcessStartRequest } from '@ronl/shared';
 
@@ -800,6 +802,62 @@ describe('getPhaseBpmnXml', () => {
     mockClient.get.mockResolvedValueOnce({ data: { bpmn20Xml: '<definitions/>' } });
     await expect(svc.getPhaseBpmnXml('RipR22Process')).resolves.toBe('<definitions/>');
     expect(mockClient.get).toHaveBeenCalledTimes(2);
+  });
+});
+
+describe('getPhaseSwimlaneModel', () => {
+  const r22Xml = readFileSync(
+    join(__dirname, '../rip-swimlane/__fixtures__/RipR22Process.bpmn'),
+    'utf-8'
+  );
+
+  it('parses the phase XML (fetched via getPhaseBpmnXml) into a swimlane model', async () => {
+    mockClient.get.mockResolvedValue({ data: { bpmn20Xml: r22Xml } });
+    const model = await svc.getPhaseSwimlaneModel('RipR22Process', 'R2.2', 'flevoland');
+    // Fixture-verified (bpmn-swimlane.test.ts): same counts pinned in
+    // rip.routes.test.ts for the route that calls this method.
+    expect(model.phaseCode).toBe('R2.2');
+    expect(model.lanes.map((l) => l.label)).toEqual([
+      'Projectleider',
+      'Ontwerper',
+      'RIP-team, Aandrager, Adviseur',
+      'Omgevingsmanager',
+    ]);
+    expect(model.nodes).toHaveLength(17);
+    expect(model.edges).toHaveLength(21);
+    expect(mockClient.get).toHaveBeenCalledWith(
+      '/process-definition/key/RipR22Process/tenant-id/flevoland/xml'
+    );
+  });
+
+  it('caches the parsed model, short-circuiting even the XML fetch on a repeat call', async () => {
+    mockClient.get.mockResolvedValue({ data: { bpmn20Xml: r22Xml } });
+    const xmlSpy = jest.spyOn(svc, 'getPhaseBpmnXml');
+    await svc.getPhaseSwimlaneModel('RipR22Process', 'R2.2', 'flevoland');
+    await svc.getPhaseSwimlaneModel('RipR22Process', 'R2.2', 'flevoland'); // cache hit
+    // Not just "the network wasn't hit again" (getPhaseBpmnXml's own cache
+    // already gives that) -- getPhaseBpmnXml itself is never called the
+    // second time, proving the swimlane-model cache is checked first.
+    expect(xmlSpy).toHaveBeenCalledTimes(1);
+    expect(mockClient.get).toHaveBeenCalledTimes(1);
+  });
+
+  it('caches tenant-scoped and untenanted lookups of the same key separately', async () => {
+    mockClient.get.mockResolvedValue({ data: { bpmn20Xml: r22Xml } });
+    const xmlSpy = jest.spyOn(svc, 'getPhaseBpmnXml');
+    await svc.getPhaseSwimlaneModel('RipR22Process', 'R2.2'); // caches under '::RipR22Process'
+    await svc.getPhaseSwimlaneModel('RipR22Process', 'R2.2', 'flevoland'); // 'flevoland::RipR22Process'
+    expect(xmlSpy).toHaveBeenCalledTimes(2);
+  });
+
+  it('rethrows on lookup failure rather than caching or swallowing it', async () => {
+    mockClient.get.mockRejectedValue(new Error('xml down'));
+    await expect(svc.getPhaseSwimlaneModel('RipR22Process', 'R2.2')).rejects.toThrow('xml down');
+    // Nothing was cached for the failed call, so a retry re-fetches and re-parses.
+    mockClient.get.mockResolvedValueOnce({ data: { bpmn20Xml: r22Xml } });
+    await expect(svc.getPhaseSwimlaneModel('RipR22Process', 'R2.2')).resolves.toMatchObject({
+      phaseCode: 'R2.2',
+    });
   });
 });
 

--- a/packages/backend/src/services/operaton.service.ts
+++ b/packages/backend/src/services/operaton.service.ts
@@ -9,7 +9,9 @@ import {
   Task,
   ActivityHistoryItem,
 } from '@ronl/shared';
+import type { PhaseSwimlaneModel } from '@ronl/shared';
 import type { DocumentTemplate } from '@services/document/documentTemplate.types';
+import { parseSwimlane } from '../rip-swimlane/bpmn-swimlane';
 
 const logger = createLogger('operaton-service');
 
@@ -43,6 +45,16 @@ export class OperatonService {
    * separately from bpmnXmlCache, which is keyed by definition id.
    */
   private phaseBpmnCache = new Map<string, string>();
+
+  /**
+   * Cache of `${tenantId}::${processKey}` → parsed swimlane model (see
+   * getPhaseSwimlaneModel), keyed identically to phaseBpmnCache above. The
+   * model derived from a definition's XML is exactly as immutable as the XML
+   * itself, so this cache never needs invalidating either -- it just saves
+   * re-running parseSwimlane's shape/edge parsing, back-edge walk and
+   * layering (up to 74 shapes and 68 edges) on every diagram view.
+   */
+  private phaseSwimlaneCache = new Map<string, PhaseSwimlaneModel>();
 
   constructor(baseUrl?: string, username?: string, password?: string) {
     const resolvedBaseUrl = baseUrl ?? config.operaton.baseUrl;
@@ -1523,6 +1535,26 @@ export class OperatonService {
     const xml = res.data.bpmn20Xml;
     this.phaseBpmnCache.set(cacheKey, xml);
     return xml;
+  }
+
+  /**
+   * Swimlane model for a phase, parsed from its deployed BPMN (getPhaseBpmnXml)
+   * and cached under the same `${tenantId}::${processKey}` key. Checked before
+   * the XML fetch, not after: on a hit this returns without ever calling
+   * getPhaseBpmnXml, so a diagram view neither re-fetches nor re-parses.
+   */
+  async getPhaseSwimlaneModel(
+    processKey: string,
+    phaseCode: string,
+    tenantId?: string
+  ): Promise<PhaseSwimlaneModel> {
+    const cacheKey = `${tenantId ?? ''}::${processKey}`;
+    const cached = this.phaseSwimlaneCache.get(cacheKey);
+    if (cached) return cached;
+    const xml = await this.getPhaseBpmnXml(processKey, tenantId);
+    const model = parseSwimlane(xml, phaseCode);
+    this.phaseSwimlaneCache.set(cacheKey, model);
+    return model;
   }
 
   /**

--- a/packages/frontend/src/components/InfraBoardDashboard/RipActiveAcrossPhasesProvider.tsx
+++ b/packages/frontend/src/components/InfraBoardDashboard/RipActiveAcrossPhasesProvider.tsx
@@ -1,0 +1,35 @@
+import type { ReactNode } from 'react';
+import {
+  RipActiveAcrossPhasesContext,
+  useRipActiveAcrossPhasesResource,
+} from '../../services/infra.api';
+
+/**
+ * Fetches active RIP instances across every modelled phase ONCE and shares
+ * the result with every consumer under it, instead of each one calling
+ * `useRipActiveAcrossPhases` and firing its own request — the fan-out this
+ * whole change removes (see infra.api.ts's `fetchActiveAcrossPhases`).
+ *
+ * Shape follows this repo's existing precedent for exactly this,
+ * `PaDataProvider` (pa-cockpit/src/pages/public-affairs-v2/PaDataProvider.tsx):
+ * a context whose consuming hook (`useRipActiveAcrossPhases`, `usePaData`)
+ * throws when read outside its provider rather than silently falling back to
+ * a private fetch of its own.
+ *
+ * Mounted once, at the Infra-board root (InfraBoardDashboard.tsx), wrapping
+ * its whole tree. That covers every real consumer: Portfolio.tsx and
+ * ProjectDetail.tsx only ever render via InfraSectionRouter, which only
+ * InfraBoardDashboard.tsx imports (`grep -rln` for their importers turns up
+ * nothing else), and InfraCommandPalette.tsx is mounted directly by
+ * InfraBoardDashboard.tsx too. So all four of today's callers —
+ * Portfolio, InfraCommandPalette, ProjectDetail and the page root itself —
+ * end up under this one provider and share its one request.
+ */
+export function RipActiveAcrossPhasesProvider({ children }: { children: ReactNode }) {
+  const resource = useRipActiveAcrossPhasesResource();
+  return (
+    <RipActiveAcrossPhasesContext.Provider value={resource}>
+      {children}
+    </RipActiveAcrossPhasesContext.Provider>
+  );
+}

--- a/packages/frontend/src/pages/InfraBoardDashboard.tsx
+++ b/packages/frontend/src/pages/InfraBoardDashboard.tsx
@@ -33,6 +33,7 @@ import InfraSectionRouter from '../components/InfraBoardDashboard/InfraSectionRo
 import InfraCommandPalette from '../components/InfraBoardDashboard/InfraCommandPalette';
 import InfraDock from '../components/InfraBoardDashboard/InfraDock';
 import InfraNoAccessPanel from '../components/InfraBoardDashboard/InfraNoAccessPanel';
+import { RipActiveAcrossPhasesProvider } from '../components/InfraBoardDashboard/RipActiveAcrossPhasesProvider';
 import SessionExpiryWarning from '../components/SessionExpiryWarning';
 import ChangelogPanel from './ChangelogPanel';
 import {
@@ -69,7 +70,24 @@ export interface ProjectRef {
   instanceId?: string;
 }
 
+/**
+ * Wraps the actual dashboard in `RipActiveAcrossPhasesProvider` so its one
+ * fetch of active RIP instances is shared by the page itself and everything
+ * it renders — Portfolio, InfraCommandPalette and ProjectDetail all call
+ * `useRipActiveAcrossPhases()` too, and without a shared provider each would
+ * fire its own request. The provider has to sit above `InfraBoardDashboardContent`
+ * rather than inside it, since that component's own call to the hook needs
+ * the context already in scope.
+ */
 export default function InfraBoardDashboard() {
+  return (
+    <RipActiveAcrossPhasesProvider>
+      <InfraBoardDashboardContent />
+    </RipActiveAcrossPhasesProvider>
+  );
+}
+
+function InfraBoardDashboardContent() {
   const navigate = useNavigate();
   const [isAuthenticated] = useState<boolean>(() => !!keycloak.authenticated);
   const [user, setUser] = useState<KeycloakUser | null>(null);

--- a/packages/frontend/src/services/api.test.ts
+++ b/packages/frontend/src/services/api.test.ts
@@ -443,6 +443,46 @@ describe('businessApi.rip', () => {
     expect(seen).toContain('/rip/phases/R2.2/active');
   });
 
+  it('phasesActive fetches the aggregate of every modelled phase in one request', async () => {
+    let seen = '';
+    server.use(
+      http.get('*/rip/phases/active', ({ request }) => {
+        seen = new URL(request.url).pathname;
+        return HttpResponse.json({
+          success: true,
+          data: [
+            {
+              id: 'i1',
+              businessKey: null,
+              startTime: '2026-01-01T00:00:00Z',
+              projectNumber: '11111',
+              projectName: 'Live',
+              edocsWorkspaceId: 'w1',
+              leadRole: 'projectleider',
+              phaseCode: 'R2.1',
+            },
+          ],
+        });
+      })
+    );
+    expect(await businessApi.rip.phasesActive()).toEqual({
+      success: true,
+      data: [
+        {
+          id: 'i1',
+          businessKey: null,
+          startTime: '2026-01-01T00:00:00Z',
+          projectNumber: '11111',
+          projectName: 'Live',
+          edocsWorkspaceId: 'w1',
+          leadRole: 'projectleider',
+          phaseCode: 'R2.1',
+        },
+      ],
+    });
+    expect(seen).toBe('/v1/rip/phases/active');
+  });
+
   it('instanceDocuments fetches an instance document bundle', async () => {
     server.use(
       http.get('*/rip/instances/pi-1/documents', () =>

--- a/packages/frontend/src/services/api.ts
+++ b/packages/frontend/src/services/api.ts
@@ -329,6 +329,27 @@ export const businessApi = {
       return response.data;
     },
 
+    /** Active instances of EVERY modelled RIP phase in one request, each row
+     *  already tagged with its `phaseCode` — the aggregate that lets
+     *  useRipActiveAcrossPhases() collapse its former per-phase fan-out. */
+    phasesActive: async (): Promise<
+      ApiResponse<
+        Array<{
+          id: string;
+          businessKey: string | null;
+          startTime: string;
+          projectNumber: string;
+          projectName: string;
+          edocsWorkspaceId: string;
+          leadRole: string;
+          phaseCode: string;
+        }>
+      >
+    > => {
+      const response = await api.get('/rip/phases/active');
+      return response.data;
+    },
+
     instanceDocuments: async (
       instanceId: string
     ): Promise<

--- a/packages/frontend/src/services/infra.api.test.ts
+++ b/packages/frontend/src/services/infra.api.test.ts
@@ -2,7 +2,7 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { renderHook, waitFor } from '@testing-library/react';
 import type { Task } from '@ronl/shared';
-import { ripPhaseByCode } from '../pages/infra-board/rip-phases.catalog';
+import { RipActiveAcrossPhasesProvider } from '../components/InfraBoardDashboard/RipActiveAcrossPhasesProvider';
 import {
   groupTasksByHorizon,
   useActivityHistory,
@@ -24,6 +24,7 @@ const mockBusinessApi = vi.hoisted(() => ({
     instanceDocuments: vi.fn(),
     deploymentStatus: vi.fn(),
     phasesCounts: vi.fn(),
+    phasesActive: vi.fn(),
   },
   process: { activityHistory: vi.fn() },
 }));
@@ -257,82 +258,59 @@ describe('useRipActiveAcrossPhases', () => {
     vi.restoreAllMocks();
   });
 
-  const inst = (id: string) => ({
+  const inst = (id: string, phaseCode: string) => ({
     id,
     startTime: '2026-01-01T00:00:00Z',
     projectNumber: '11111',
     projectName: 'Live',
     edocsWorkspaceId: 'w1',
     leadRole: 'projectleider',
+    phaseCode,
   });
 
-  it('tags each instance with the phase it came from', async () => {
-    mockBusinessApi.rip.phaseActive.mockClear();
-    mockBusinessApi.rip.phaseActive.mockImplementation((code: string) =>
-      Promise.resolve({ success: true, data: [inst(`i-${code}`)] })
-    );
+  const renderInProvider = () =>
+    renderHook(() => useRipActiveAcrossPhases(), { wrapper: RipActiveAcrossPhasesProvider });
 
-    const { result } = renderHook(() => useRipActiveAcrossPhases());
+  it('throws when rendered outside RipActiveAcrossPhasesProvider', () => {
+    // Suppress the noisy React error-boundary console.error this triggers --
+    // the throw itself is what the test asserts on.
+    const consoleError = vi.spyOn(console, 'error').mockImplementation(() => {});
+    expect(() => renderHook(() => useRipActiveAcrossPhases())).toThrow(
+      'useRipActiveAcrossPhases must be used inside RipActiveAcrossPhasesProvider'
+    );
+    consoleError.mockRestore();
+  });
+
+  it('fetches once, via the aggregate endpoint, and passes the rows through unchanged', async () => {
+    // The backend (GET /v1/rip/phases/active) does the per-phase fan-out and
+    // tagging now -- see rip.routes.ts and its "aggregates active instances
+    // across every modelled phase, tagging each row with its phaseCode" test.
+    // The frontend's job shrinks to one request with no reshaping, which this
+    // pins via reference equality: if anything downstream started mapping the
+    // rows again, this would catch it.
+    mockBusinessApi.rip.phasesActive.mockClear();
+    const rows = [inst('i-1', 'R2.1'), inst('i-2', 'R2.2')];
+    mockBusinessApi.rip.phasesActive.mockResolvedValue({ success: true, data: rows });
+
+    const { result } = renderInProvider();
     await waitFor(() => expect(result.current.loading).toBe(false));
 
-    const rows = result.current.data ?? [];
-
-    // Two concrete pairings, so the assertion is not purely derived from the
-    // same catalogue the hook reads.
-    expect(rows).toEqual(
-      expect.arrayContaining([
-        expect.objectContaining({ id: 'i-R2.1', phaseCode: 'R2.1' }),
-        expect.objectContaining({ id: 'i-R2.2', phaseCode: 'R2.2' }),
-      ])
-    );
-
-    // The invariant that actually matters and does not churn as phases deploy:
-    // every row is tagged with the phase whose request produced it. The mock
-    // ids embed the requested code, so a mis-paired codes[i] shows up here --
-    // which an exact-list assertion could only catch by being rewritten on
-    // every deployment.
-    for (const row of rows) {
-      expect(row.id).toBe(`i-${row.phaseCode}`);
-      expect(ripPhaseByCode(row.phaseCode)?.processDefinitionKey).toBeDefined();
-    }
-
-    // ...and no phase without a process model was asked for at all.
-    const asked = mockBusinessApi.rip.phaseActive.mock.calls.map((c: unknown[]) => c[0] as string);
-    expect(asked).toEqual(rows.map((r) => r.phaseCode));
-    for (const code of asked) {
-      expect(ripPhaseByCode(code)?.processDefinitionKey).toBeDefined();
-    }
-
+    expect(result.current.data).toBe(rows);
     expect(result.current.error).toBe(false);
+    expect(mockBusinessApi.rip.phasesActive).toHaveBeenCalledTimes(1);
+    expect(mockBusinessApi.rip.phaseActive).not.toHaveBeenCalled();
   });
 
-  it('keeps the phases that answered when another one rejects', async () => {
-    // A non-2xx rejects the axios promise, it does not resolve
-    // { success: false } -- so an unguarded Promise.all would reject here and
-    // the portfolio would show no live rows at all. This is the regression
-    // that made R2.1's live project vanish while the backend still served
-    // the old routes.
-    mockBusinessApi.rip.phaseActive.mockClear();
-    mockBusinessApi.rip.phaseActive.mockImplementation((code: string) =>
-      code === 'R2.1'
-        ? Promise.resolve({ success: true, data: [inst('i-1')] })
-        : Promise.reject(new Error('404'))
-    );
+  it('reports an error when the aggregate request fails', async () => {
+    // One phase failing without blanking the rest is now the backend's
+    // property (rip.routes.ts's Promise.allSettled + anySucceeded), pinned in
+    // rip.routes.test.ts's "omits a failing phase rather than blanking the
+    // rest of the aggregate". This request is a single call: if it fails at
+    // all, there is nothing partial left to keep.
+    mockBusinessApi.rip.phasesActive.mockClear();
+    mockBusinessApi.rip.phasesActive.mockRejectedValue(new Error('backend down'));
 
-    const { result } = renderHook(() => useRipActiveAcrossPhases());
-    await waitFor(() => expect(result.current.loading).toBe(false));
-
-    expect(result.current.data).toEqual([
-      expect.objectContaining({ id: 'i-1', phaseCode: 'R2.1' }),
-    ]);
-    expect(result.current.error).toBe(false);
-  });
-
-  it('reports an error only when every phase fails', async () => {
-    mockBusinessApi.rip.phaseActive.mockClear();
-    mockBusinessApi.rip.phaseActive.mockRejectedValue(new Error('backend down'));
-
-    const { result } = renderHook(() => useRipActiveAcrossPhases());
+    const { result } = renderInProvider();
     await waitFor(() => expect(result.current.loading).toBe(false));
 
     expect(result.current.error).toBe(true);

--- a/packages/frontend/src/services/infra.api.ts
+++ b/packages/frontend/src/services/infra.api.ts
@@ -7,10 +7,9 @@
  * RipR21Process tasks/instances flow straight in.
  */
 
-import { useEffect, useState } from 'react';
+import { createContext, useContext, useEffect, useState } from 'react';
 import { businessApi } from './api';
 import type { Task, ActivityHistoryItem, PhaseSwimlaneModel } from '@ronl/shared';
-import { RIP_PHASE_KEYS } from '@ronl/shared';
 import type { StatusKey } from '../pages/infra-board/rip-model';
 import { RIP_PHASES } from '../pages/infra-board/rip-phases.catalog';
 
@@ -82,12 +81,6 @@ export const useLivePhaseCounts = () =>
     []
   );
 
-/** Phase codes whose process is modelled as BPMN — the only ones the
- *  phase endpoints accept. An unmodelled code answers 409, deliberately:
- *  callers must not confuse "not deployed" with "deployed, no instances". */
-const modelledPhaseCodes = () =>
-  RIP_PHASE_KEYS.filter((p) => p.processDefinitionKey).map((p) => p.code);
-
 /** Running instances of one RIP phase. Pass null to skip the request —
  *  for a phase with no process model there is nothing to ask for. */
 export const useRipPhaseActive = (phaseCode: string | null) =>
@@ -120,36 +113,74 @@ export const useRipPhaseCompleted = (phaseCode: string | null) =>
   );
 
 /**
- * Running instances across every modelled phase, flattened and tagged.
+ * Running instances across every modelled phase, tagged with the phase each
+ * row belongs to.
  *
  * One phase failing does not blank the others — the portfolio showing R2.1's
- * projects is strictly better than showing none because R2.2's request
- * timed out. Only an across-the-board failure is reported as an error.
+ * projects is strictly better than showing none because R2.2's request timed
+ * out. That property now lives entirely on the backend: GET
+ * /v1/rip/phases/active fans out to every modelled phase itself
+ * (rip.routes.ts), omits a phase that rejects, tags every surviving row with
+ * `phaseCode` and only answers non-2xx when every phase failed. This used to
+ * be twelve requests issued from here, one per phase, each wrapped in its own
+ * `.catch` to keep a single failure from rejecting the whole `Promise.all` —
+ * see rip.routes.test.ts's "omits a failing phase rather than blanking the
+ * rest of the aggregate" for the property's new home. The rows the backend
+ * returns are already `RipPhaseInstanceRow`s, so nothing here reshapes them.
  */
 async function fetchActiveAcrossPhases(): Promise<{
   success: boolean;
   data?: RipPhaseInstanceRow[];
 }> {
-  const codes = modelledPhaseCodes();
-  if (codes.length === 0) return { success: true, data: [] };
-  const results = await Promise.all(
-    codes.map((code) =>
-      // The per-request catch is what actually makes one phase survivable:
-      // a non-2xx rejects the axios promise rather than resolving
-      // { success: false }, so without it a single failing phase rejects the
-      // whole Promise.all and the portfolio renders no live rows at all.
-      businessApi.rip.phaseActive(code).catch(() => ({ success: false as const, data: undefined }))
-    )
-  );
-  const rows = results.flatMap((res, i) =>
-    res.success && res.data ? res.data.map((inst) => ({ ...inst, phaseCode: codes[i] })) : []
-  );
-  return { success: results.some((r) => r.success), data: rows };
+  return businessApi.rip.phasesActive();
 }
 
-/** Running instances portfolio-wide, across every deployed phase. */
-export const useRipActiveAcrossPhases = () =>
+/**
+ * The actual fetch behind `useRipActiveAcrossPhases`, exposed only so
+ * `RipActiveAcrossPhasesProvider` can run it once and publish the result via
+ * `RipActiveAcrossPhasesContext` — not meant to be called directly by a
+ * component, which is why it lives here rather than being exported as a
+ * second public hook name.
+ */
+export const useRipActiveAcrossPhasesResource = () =>
   useAsync<RipPhaseInstanceRow[]>(fetchActiveAcrossPhases, []);
+
+/** Context backing `useRipActiveAcrossPhases` — see
+ *  `RipActiveAcrossPhasesProvider` (components/InfraBoardDashboard) for the
+ *  component that populates it. */
+export const RipActiveAcrossPhasesContext = createContext<AsyncState<RipPhaseInstanceRow[]> | null>(
+  null
+);
+
+/**
+ * Running instances portfolio-wide, across every deployed phase.
+ *
+ * Reads a single shared fetch out of `RipActiveAcrossPhasesContext` rather
+ * than triggering its own request: Portfolio, InfraCommandPalette,
+ * ProjectDetail and the Infra-board page root all called this hook
+ * independently, and since `useAsync` has no cache or dedup that meant four
+ * separate requests for the same data on every render of the board.
+ * `RipActiveAcrossPhasesProvider`, mounted once at the Infra-board root,
+ * fetches once and every one of those four now reads the same result here.
+ *
+ * Called with no provider in scope, this throws rather than silently falling
+ * back to its own fetch — the same choice `usePaData` makes in
+ * `PaDataProvider.tsx`. Every real consumer today is inside the provider (see
+ * `RipActiveAcrossPhasesProvider`'s own comment for how that was checked:
+ * Portfolio/ProjectDetail only ever render via `InfraSectionRouter`, which
+ * only `InfraBoardDashboard` imports, and `InfraCommandPalette` is mounted
+ * directly by it too), so a call outside the provider is a wiring mistake —
+ * a new consumer added somewhere else in the tree — worth failing loudly on
+ * immediately rather than quietly reintroducing the fan-out this hook exists
+ * to remove.
+ */
+export const useRipActiveAcrossPhases = (): AsyncState<RipPhaseInstanceRow[]> => {
+  const ctx = useContext(RipActiveAcrossPhasesContext);
+  if (!ctx) {
+    throw new Error('useRipActiveAcrossPhases must be used inside RipActiveAcrossPhasesProvider');
+  }
+  return ctx;
+};
 
 /** A project that finished the preceding phase and can start this one. */
 export interface RipPhaseCandidate {


### PR DESCRIPTION
Closes #75.

The Infra-board fired up to **48 HTTP requests** to render one screen, and rebuilt every process diagram from XML on each request. Confirmed faster on localhost by the reviewer before this was opened.

## What was slow

`useRipActiveAcrossPhases()` issued **one request per modelled phase — twelve** — because only `/phases/:code/active` existed. Four components called it independently, since `useAsync` has no cache or dedup: the page, `Portfolio`, `InfraCommandPalette`, and `ProjectDetail`.

Browsers allow roughly six connections per host, so those queued about eight deep and the swimlane model request waited behind them. That is the likely explanation for a diagram occasionally needing a page refresh to appear — the request was not lost, it was starved.

Separately, `parseSwimlane` ran on every request. The XML was cached; the parse was not. Each diagram view re-read up to 74 shapes and 68 edges, re-ran the depth-first back-edge walk and re-layered the graph, then discarded the result.

## What changed

1. **`GET /v1/rip/phases/active`** — every modelled phase's active instances in one response, each row tagged with its phase code so the caller reshapes nothing.
2. **The parsed model is cached** — beside `phaseBpmnCache`, keyed the same tenant-inclusive way. A key without the tenant would reintroduce the cross-tenant leak that convention exists to prevent.
3. **A provider at the board root** — one fetch shared by all four consumers, following the existing `PaDataProvider` precedent.

**48 requests → 1** for the portfolio-plus-detail view.

## Properties deliberately preserved

**One failing phase must not blank the portfolio.** The frontend's per-request `.catch` provided that; the backend owns it now via `Promise.allSettled` — a rejected phase is logged and omitted, the response stays 200, and only total failure answers 500. Verified against the endpoint's own test rather than assumed.

**Three of four call sites are unchanged.** `useRipActiveAcrossPhases()` keeps its name and signature and reads context instead.

## Worth knowing before merge

- `InfraBoardDashboard.tsx` needed a genuine component split, not a hook swap: its own hook call has to sit below the provider it mounts. Its default export is now a thin wrapper around the unchanged body — the largest part of this diff.
- **Calling the hook outside the provider throws**, matching `usePaData`. Every consumer renders inside the board's tree and every relevant test mocks the `infra.api` module wholesale, so nothing trips over it today. It is a deliberate trade toward loud failure over a quiet duplicate fetch — but nothing at compile time enforces that wiring, so moving one of these components would fail only at runtime.
- The aggregate queries every *modelled* phase rather than only *deployed* ones, matching the frontend's previous behaviour. All twelve are deployed today, so there is no present cost.

## Testing

| | |
| --- | --- |
| Backend | 2008 passed / 3 skipped |
| Frontend | 1096 passed, 109 files |
| Typecheck | clean, both packages |

Per-file branch coverage, all above the 80% floor: `rip.routes.ts` 94.11%, `operaton.service.ts` 91.37%, `api.ts` 89.66%, `infra.api.ts` 89.19%, `InfraBoardDashboard.tsx` 83.18%.
