### PR TITLE
chore: bump release to v2026.09.5

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "ronl-business-api",
-  "version": "2026.09.4",
+  "version": "2026.09.5",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "ronl-business-api",
-      "version": "2026.09.4",
+      "version": "2026.09.5",
       "hasInstallScript": true,
       "license": "EUPL-1.2",
       "workspaces": [
@@ -17226,7 +17226,7 @@
     },
     "packages/backend": {
       "name": "@ronl/backend",
-      "version": "2026.09.4",
+      "version": "2026.09.5",
       "license": "EUPL-1.2",
       "dependencies": {
         "@anthropic-ai/sdk": "^0.122.0",
@@ -17354,7 +17354,7 @@
     },
     "packages/frontend": {
       "name": "@ronl/frontend",
-      "version": "2026.09.4",
+      "version": "2026.09.5",
       "dependencies": {
         "@bpmn-io/form-js": "^1.20.1",
         "@ronl/pa-cockpit": "*",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ronl-business-api",
-  "version": "2026.09.4",
+  "version": "2026.09.5",
   "description": "Secure, multi-tenant Business API for Dutch municipality BPMN/DMN services",
   "private": true,
   "workspaces": [

--- a/packages/backend/package.json
+++ b/packages/backend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ronl/backend",
-  "version": "2026.09.4",
+  "version": "2026.09.5",
   "description": "Secure Business API layer for Dutch municipality BPMN services",
   "main": "dist/index.js",
   "scripts": {

--- a/packages/frontend/package.json
+++ b/packages/frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ronl/frontend",
-  "version": "2026.09.4",
+  "version": "2026.09.5",
   "description": "Municipality portal (MijnOmgeving) with identity provider selection",
   "type": "module",
   "scripts": {

--- a/packages/frontend/src/pages/changelog-data.ts
+++ b/packages/frontend/src/pages/changelog-data.ts
@@ -112,6 +112,37 @@ export const changelog: Changelog = {
   versions: [
     {
       format: 'commits',
+      version: '2026.09.5',
+      status: 'Released',
+      date: '4 sep 2026',
+      scope: ['backend', 'frontend'],
+      commits: [
+        {
+          sha: 'f2bf68e',
+          author: 'Steven Gort',
+          type: 'perf',
+          subject: 'The board fetches its live instances once, not forty-eight times',
+          details: [
+            'Rendering one Infra-board screen fired up to 48 HTTP requests. The active-across-phases hook issued one request per modelled phase — twelve — and four components called it independently, since useAsync has no cache or dedup: the page itself, Portfolio, the command palette, and ProjectDetail.',
+            'Browsers allow roughly six connections per host, so those queued about eight deep and the swimlane model request waited behind them. That is the likely reason a diagram sometimes needed a page refresh before it appeared — the request was never lost, it was starved.',
+            'The fan-out now calls the single aggregate endpoint, and a provider at the board root shares one fetch across all four consumers, following the PaDataProvider precedent. useRipActiveAcrossPhases keeps its name and signature and reads context instead, so three of the four call sites do not change at all; InfraBoardDashboard needed a real split, because its own hook call has to sit below the provider it mounts. Calling the hook outside that provider throws rather than quietly issuing a duplicate fetch — a deliberate trade toward loud failure, and one nothing at compile time enforces.',
+          ],
+        },
+        {
+          sha: '4cb0873',
+          author: 'Steven Gort',
+          type: 'perf',
+          subject: 'Active instances come in one call, and the parsed diagram is cached',
+          details: [
+            'The board asked for active instances one phase at a time because only a per-phase endpoint existed. A new aggregate returns every modelled phase in one response, each row tagged with the phase it belongs to so the caller reshapes nothing.',
+            'One phase failing must not blank the rest — the property the frontend’s per-request catch used to provide, now owned by the backend. Promise.allSettled over every modelled phase: a rejected phase is logged and omitted, the response stays 200, and only a total failure answers 500.',
+            'The swimlane model was also rebuilt on every request: the XML was cached but the parse was not, so each diagram view re-read up to 74 shapes and 68 edges, re-ran the depth-first back-edge walk and re-layered the graph before throwing the result away. It is cached now, beside the XML cache and keyed the same tenant-inclusive way — a key without the tenant would reintroduce exactly the cross-tenant leak that convention exists to prevent. A definition’s BPMN is immutable, so it never needs invalidating.',
+          ],
+        },
+      ],
+    },
+    {
+      format: 'commits',
       version: '2026.09.4',
       status: 'Released',
       date: '4 sep 2026',


### PR DESCRIPTION
Cuts **v2026.09.5**. Scope: `backend`, `frontend`.

## What ships

The performance work from #76, closing #75. Rendering one Infra-board screen fired up to **48 HTTP requests**; it now makes one.

The active-across-phases hook asked for one phase at a time because only a per-phase endpoint existed, and four components each did that independently. Browsers allow roughly six connections per host, so the swimlane model request queued behind the rest — the likely reason a diagram occasionally needed a page refresh before it appeared.

A new aggregate endpoint returns every modelled phase in one response, a provider at the board root shares one fetch across all four consumers, and the parsed diagram is cached rather than rebuilt from XML on every request.

Confirmed faster on localhost before release.

## Versions

| Bumped to `2026.09.5` | Left behind |
| --- | --- |
| root `package.json` | `packages/shared` — `2026.09.4` |
| `packages/backend` | `packages/public-site` — `2026.09.2` |
| `packages/frontend` | `packages/pa-demo` — `2026.09.2` |
| `package-lock.json` — root, `packages[""]`, 2 workspaces | |

`packages/shared` was bumped last release because that one changed it; this one does not touch it, so it stays behind and reconciles on the next release that does.

## Verification

| | |
| --- | --- |
| `npm run lint` | exit 0, **0 warnings** |
| `npm run check-format` | clean |
| `npm ci --dry-run` | exit 0 — lockfile resolves |
| Backend | 2008 passed / 3 skipped |
| Frontend | 1096 passed, 109 files |

Endpoint map checked and unchanged: `/phases/active` is a new route under the existing `/v1/rip` mount, so the advertised map is unaffected.

## Merging

Use a **merge commit** — the changelog names each commit by SHA, and squash and rebase both rewrite those hashes.

Merging redeploys frontend and pa-demo. Public-site does not move: `azure-publicsite-acc.yml` watches only its own package, and nothing here touches `packages/shared` either.

The backend is deployed separately by script after merge.
