### PR TITLE
feat(frontend): identify the build, not just the release, in the changelog

### DIFF
--- a/.github/workflows/azure-frontend-acc.yml
+++ b/.github/workflows/azure-frontend-acc.yml
@@ -92,6 +92,19 @@ jobs:
 
       - name: Build frontend for ACC
         working-directory: packages/frontend
+        # Stamps the bundle with which BUILD it is, not just which release —
+        # the changelog version comes from package.json and is bumped by hand,
+        # so ACC and PROD can serve different builds of the same version. Vite
+        # merges VITE_-prefixed process.env over .env.acceptance, so these
+        # reach import.meta.env without touching the mode file. Absent (local
+        # builds, forks), src/utils/buildInfo.ts renders 'local build'.
+        #
+        # On a pull request github.sha is the merge commit GitHub synthesises,
+        # so a preview's SHA matches no commit in the branch. That is the
+        # commit that was built, and is expected — not a bug to chase.
+        env:
+          VITE_BUILD_SHA: ${{ github.sha }}
+          VITE_BUILD_RUN: ${{ github.run_number }}
         run: |
           npm run build:acc
 

--- a/.github/workflows/azure-frontend-prod.yml
+++ b/.github/workflows/azure-frontend-prod.yml
@@ -66,6 +66,12 @@ jobs:
 
       - name: Build frontend for production
         working-directory: packages/frontend
+        # See azure-frontend-acc.yml for why these are injected rather than
+        # derived from git at build time. PROD deploys from a push, so
+        # github.sha is a real commit here, never a synthesised merge commit.
+        env:
+          VITE_BUILD_SHA: ${{ github.sha }}
+          VITE_BUILD_RUN: ${{ github.run_number }}
         run: |
           npm run build:prod
 

--- a/packages/frontend/src/pages/ChangelogPanelContent.tsx
+++ b/packages/frontend/src/pages/ChangelogPanelContent.tsx
@@ -10,6 +10,7 @@ import {
   type FeedbackItem,
   type ScopeTag,
 } from './changelog-data';
+import { getBuildInfo } from '../utils/buildInfo';
 
 export interface ChangelogPanelProps {
   isOpen: boolean;
@@ -19,6 +20,11 @@ export interface ChangelogPanelProps {
 export default function ChangelogPanelContent({ isOpen, onClose }: ChangelogPanelProps) {
   // Only the latest (first) entry starts expanded — matches the Regeleditor/
   // LDE/CPSV Editor changelog pattern of one open card, the rest collapsed.
+  // Which build is being served, as opposed to which release the version
+  // strings below name. Cheap and synchronous — see utils/buildInfo.ts for why
+  // it is a call rather than a module-scope constant.
+  const buildInfo = getBuildInfo();
+
   const [expanded, setExpanded] = useState<Set<string>>(
     () => new Set(changelog.versions[0] ? [changelog.versions[0].version] : [])
   );
@@ -91,6 +97,15 @@ export default function ChangelogPanelContent({ isOpen, onClose }: ChangelogPane
                 </h2>
                 <p className="text-sm" style={{ color: 'rgba(255,255,255,0.78)' }}>
                   RONL Business API Updates
+                </p>
+                {/* title carries the full 40-char SHA so it can be copied for a
+                    lookup; the visible label stays short. */}
+                <p
+                  className="text-xs font-mono mt-0.5"
+                  style={{ color: 'rgba(255,255,255,0.65)' }}
+                  title={buildInfo.sha || undefined}
+                >
+                  {buildInfo.label}
                 </p>
               </div>
             </div>

--- a/packages/frontend/src/utils/buildInfo.test.ts
+++ b/packages/frontend/src/utils/buildInfo.test.ts
@@ -1,0 +1,95 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+import { getBuildInfo } from './buildInfo';
+
+// getBuildInfo reads import.meta.env on every call rather than capturing it at
+// module scope, which is what lets vi.stubEnv reach it. A module-scope capture
+// would be evaluated once at import and the fallback below could not be tested
+// at all without vi.resetModules gymnastics.
+afterEach(() => {
+  vi.unstubAllEnvs();
+});
+
+const SHA = '570fd98a1c4e2b7d3f8a9016c5d4e2b7a3f81c40';
+
+describe('getBuildInfo', () => {
+  it('labels a build that carries both a SHA and a run number', () => {
+    vi.stubEnv('VITE_BUILD_SHA', SHA);
+    vi.stubEnv('VITE_BUILD_RUN', '412');
+
+    const info = getBuildInfo();
+
+    expect(info.isTracked).toBe(true);
+    expect(info.label).toBe('build 570fd98 · #412');
+  });
+
+  it('keeps the full SHA alongside the short one, for copying', () => {
+    vi.stubEnv('VITE_BUILD_SHA', SHA);
+    vi.stubEnv('VITE_BUILD_RUN', '412');
+
+    const info = getBuildInfo();
+
+    expect(info.sha).toBe(SHA);
+    expect(info.shortSha).toBe('570fd98');
+    expect(info.run).toBe('412');
+  });
+
+  it('falls back to "local build" when nothing was injected', () => {
+    vi.stubEnv('VITE_BUILD_SHA', undefined);
+    vi.stubEnv('VITE_BUILD_RUN', undefined);
+
+    const info = getBuildInfo();
+
+    expect(info.isTracked).toBe(false);
+    expect(info.label).toBe('local build');
+    expect(info.sha).toBe('');
+  });
+
+  // Half-configured counts as untracked. A run number with no commit behind it
+  // implies a provenance the bundle does not have, so it must not render as
+  // one — and a SHA with no run number cannot distinguish two builds of the
+  // same commit, which is the whole point of the run number.
+  it('treats a run number without a SHA as untracked', () => {
+    vi.stubEnv('VITE_BUILD_SHA', undefined);
+    vi.stubEnv('VITE_BUILD_RUN', '412');
+
+    expect(getBuildInfo().label).toBe('local build');
+  });
+
+  it('treats a SHA without a run number as untracked', () => {
+    vi.stubEnv('VITE_BUILD_SHA', SHA);
+    vi.stubEnv('VITE_BUILD_RUN', undefined);
+
+    expect(getBuildInfo().label).toBe('local build');
+  });
+
+  // Vite substitutes a missing variable with an empty string in some build
+  // configurations rather than leaving it undefined, so blank must be treated
+  // exactly like absent — otherwise the panel renders "build  · #".
+  it('treats blank and whitespace-only values as absent', () => {
+    vi.stubEnv('VITE_BUILD_SHA', '   ');
+    vi.stubEnv('VITE_BUILD_RUN', '');
+
+    expect(getBuildInfo().isTracked).toBe(false);
+    expect(getBuildInfo().label).toBe('local build');
+  });
+
+  it('trims surrounding whitespace off injected values', () => {
+    vi.stubEnv('VITE_BUILD_SHA', ` ${SHA} `);
+    vi.stubEnv('VITE_BUILD_RUN', ' 412 ');
+
+    const info = getBuildInfo();
+
+    expect(info.sha).toBe(SHA);
+    expect(info.label).toBe('build 570fd98 · #412');
+  });
+
+  // A SHA shorter than 7 characters is not something CI produces, but slicing
+  // must not invent characters or throw if one ever arrives.
+  it('uses the whole SHA when it is shorter than seven characters', () => {
+    vi.stubEnv('VITE_BUILD_SHA', 'abc12');
+    vi.stubEnv('VITE_BUILD_RUN', '7');
+
+    expect(getBuildInfo().label).toBe('build abc12 · #7');
+  });
+});

--- a/packages/frontend/src/utils/buildInfo.ts
+++ b/packages/frontend/src/utils/buildInfo.ts
@@ -1,0 +1,58 @@
+/**
+ * Which BUILD of the app is running, as opposed to which release.
+ *
+ * The version in the changelog comes from package.json and is bumped by hand
+ * at release time, so it identifies a release, not a build of it. ACC and PROD
+ * can serve different builds of the same version string, and redeploying
+ * unchanged code produces a new artifact carrying the same version — so
+ * "which build am I looking at?" is not answerable from the version alone.
+ *
+ * The SHA says what was built; the run number distinguishes two builds of
+ * identical code. Both are injected at build time by the deploy workflows
+ * (see .github/workflows/azure-frontend-{acc,prod}.yml); nothing is derived
+ * from git here, because a build id that silently fails to resolve is worse
+ * than none — it lies.
+ */
+
+export interface BuildInfo {
+  /** Full 40-character commit SHA, or '' when not injected. */
+  sha: string;
+  /** First 7 characters of the SHA, or '' when not injected. */
+  shortSha: string;
+  /** GitHub Actions run number, or '' when not injected. */
+  run: string;
+  /** True only when both values are present — see the half-configured note below. */
+  isTracked: boolean;
+  /** Ready to render. Never blank. */
+  label: string;
+}
+
+const UNTRACKED: BuildInfo = {
+  sha: '',
+  shortSha: '',
+  run: '',
+  isTracked: false,
+  label: 'local build',
+};
+
+/**
+ * Read the injected build identifiers and describe them.
+ *
+ * The env is read here, on every call, rather than captured at module scope:
+ * a module-scope capture is evaluated once at import and cannot be stubbed
+ * per test, which would leave the fallback path untestable.
+ *
+ * Half-configured counts as untracked. A run number with no SHA behind it
+ * implies a provenance the bundle does not have, and a SHA with no run number
+ * cannot tell two builds of the same commit apart — which is the whole reason
+ * the run number is here. Either way the answer is 'local build'.
+ */
+export function getBuildInfo(): BuildInfo {
+  const sha = (import.meta.env.VITE_BUILD_SHA ?? '').trim();
+  const run = (import.meta.env.VITE_BUILD_RUN ?? '').trim();
+
+  if (!sha || !run) return UNTRACKED;
+
+  const shortSha = sha.slice(0, 7);
+  return { sha, shortSha, run, isTracked: true, label: `build ${shortSha} · #${run}` };
+}

--- a/packages/frontend/src/vite-env.d.ts
+++ b/packages/frontend/src/vite-env.d.ts
@@ -8,6 +8,10 @@ interface ImportMetaEnv {
   readonly VITE_PA_SIGNALS_MOCK?: string;
   readonly VITE_PA_DOSSIERS_MOCK?: string;
   readonly VITE_PA_AGENDA_MOCK?: string;
+  /** Commit SHA of the build, injected by the deploy workflows. Absent locally. */
+  readonly VITE_BUILD_SHA?: string;
+  /** GitHub Actions run number, injected by the deploy workflows. Absent locally. */
+  readonly VITE_BUILD_RUN?: string;
 }
 
 interface ImportMeta {


### PR DESCRIPTION
## The problem

The version in the Changelog tab comes from `package.json` and is bumped by hand at release time, so it identifies a **release**, not a **build** of it. ACC and PROD can serve different builds of the same version string, and redeploying unchanged code produces a new artifact carrying the same version. So "which build am I looking at?" was not answerable from the running app.

The commit SHA says what was built. The run number distinguishes two builds of identical code — that is what makes this a build id rather than a code id.

## What it looks like

One small monospace line under the changelog heading:

```
📋  Changelog
    RONL Business API Updates
    build 570fd98 · #412
```

The full 40-character SHA is on the `title` attribute so it can be copied for a lookup. With nothing injected the line reads `local build`. It is never blank and never looks like a deployed artifact.

## Design notes

**A separate module, not logic in the component.** `src/utils/buildInfo.ts` exposes `getBuildInfo()`; the fallback rules are then testable without rendering anything.

**The env is read inside the function, not captured at module scope.** A module-scope capture is evaluated once at import and cannot be stubbed per test, which would leave the fallback untestable. `vi.stubEnv` + `vi.unstubAllEnvs` works cleanly against a per-call read.

**Half-configured counts as untracked.** A run number with no SHA renders `local build`, not `#412` — showing a run number with no commit behind it implies a provenance the bundle does not have. A SHA with no run number is equally untracked, since it cannot tell two builds of one commit apart. Blank and whitespace-only values are treated as absent.

**Nothing is derived from git at build time.** The values are injected by the deploy workflows. A build id that silently fails to resolve is worse than none, because it lies.

## Verification

A build-time injection is exactly the kind of change that passes unit tests and puts nothing in the artifact, so this was checked against real builds, not only stubbed tests:

| Check | Result |
|---|---|
| `VITE_BUILD_SHA=… VITE_BUILD_RUN=412 npm run build:acc` | both values present in the bundle |
| `npm run build:acc` (no env) | `local build` present, zero stale SHA |
| Unit tests | 8/8, 100% statements / **100% branches (8/8)** / functions / lines |
| Full frontend suite | green |
| Lint / Prettier | clean |

Both injected values land in the lazily-loaded `ChangelogPanelContent-*.js` chunk, not `index.js` — grepping only the entry chunk shows nothing and looks like a failure.

The greps prove the code path. They do not prove the workflow `env:` block reaches the builder — only a deployed preview does that, which is the thing worth looking at on this PR.

## Expected oddity on this PR

On a pull request `github.sha` is the **merge commit GitHub synthesises**, not the head of the branch, so the SHA shown on the preview deployment will match no commit in this branch's history. That is normal and it is what got built. On a push to `acc` it is the real commit.

## Scope

`packages/frontend` only, plus its two deploy workflows. `packages/pa-demo` keeps its own changelog panel untouched. The backend ships its version separately — this line describes the frontend bundle being viewed.

No env file defines `VITE_BUILD_SHA` / `VITE_BUILD_RUN`, by design: the only source is CI, so every local run falls through to `local build`.
