### PR TITLE
ci: adopt check-supply-chain as a non-blocking step in the audit job

### DIFF
--- a/.github/workflows/zizmor.yml
+++ b/.github/workflows/zizmor.yml
@@ -97,3 +97,52 @@ jobs:
         # this file actually is -- it will happily validate and tell you
         # nothing useful.
         run: npx --yes --package renovate@44.50.3 renovate-config-validator --strict
+
+      - name: Verify pin truth and register agreement
+        # zizmor validates pin FORMAT — that `uses:` names a 40-character SHA.
+        # It cannot say the SHA is the RIGHT one, so a wrong or hostile digest
+        # carrying a plausible "# v7.0.1" comment passes zizmor, Prettier and
+        # review alike. This resolves every digest against the GitHub API and
+        # compares SECURITY-PIPELINE.md's register with the workflows —
+        # digests, versions, the (×N) multiplicities, and the totals headline.
+        #
+        # The multiplicities are not decoration here: setup-node silently went
+        # from ×8 to ×9 when the config-validator step above was added, and the
+        # register still said ×8 with every gate green. That is the drift this
+        # step now catches.
+        #
+        # if: always() for the same reason as the validator above — one run
+        # should report on every half of the policy, not stop at the first.
+        if: always()
+        # NON-BLOCKING to start with, and not merely out of caution.
+        #
+        # Renovate rewrites workflow pins and never touches
+        # SECURITY-PIPELINE.md, so every action-bump pull request fails the
+        # register half until the register is updated by hand. Blocking on
+        # that would fail a required check on routine dependency updates,
+        # which is how gates get resented and then bypassed.
+        #
+        # The answer, proven in linked-data-explorer over two bumps
+        # (sgort/linked-data-explorer#66 and #67): update the register ON the
+        # bump's branch, before merging, so the check is green on the pull
+        # request rather than only on acc afterwards. Promote to blocking once
+        # that habit holds here too — see issue #81.
+        #
+        # Do not leave it non-blocking indefinitely. continue-on-error does
+        # not merely keep the job green: it rewrites the STEP's reported
+        # conclusion too, and the honest result (outcome: failure) is not
+        # exposed by the REST API. A finding is then visible ONLY in this
+        # step's log — the checks list, the job and the step all read
+        # "success". Observed on sgort/linked-data-explorer#66.
+        #
+        # The other reason to start non-blocking: this makes a network call
+        # inside a job the ruleset requires, so an API outage or rate limit
+        # could fail a gate unrelated to the change under review. If that
+        # proves to be a problem, add --offline rather than restoring
+        # continue-on-error: it keeps the register half blocking and drops
+        # only the network-dependent half.
+        continue-on-error: true
+        env:
+          # contents: read suffices — this only resolves public refs.
+          GITHUB_TOKEN: ${{ github.token }}
+        run: npm run check-supply-chain

--- a/SECURITY-PIPELINE.md
+++ b/SECURITY-PIPELINE.md
@@ -179,34 +179,67 @@ exception above, it is fixable from our side — see "Queued CI improvements".
 ## What the audit cannot see
 
 zizmor validates pin **format**, never pin **truth**. A wrong or hostile digest
-carrying a plausible `# v4.4.0` comment passes the gate, Prettier and review
-alike. Nothing here re-checks that a digest resolves to the tag it claims, and
-nothing checks that this document still matches the workflows — Renovate updates
-pins and never touches it. A `scripts/check-supply-chain.mjs` preflight covering
-both is planned.
+carrying a plausible `# v7.0.1` comment passes zizmor, Prettier and review alike,
+because nothing in that gate re-resolves the reference. Nor does zizmor check
+that this document still matches the workflows.
 
-**That second gap is not hypothetical — it already bit.** Between the v7 action
-upgrades (`2026.08.33`) and 29 August 2026, this document's Pinned table still
-listed the superseded v4 digests for `actions/checkout`, `actions/setup-node` and
-`actions/upload-artifact`. The workflows had moved; the register had not, and
-every gate stayed green throughout — which is exactly the failure mode described
-above.
-
-A second, quieter drift came with it: `setup-node` had gone from ×8 to ×9 when
-the `renovate-config-validator` step was added, and the `renovate@44.50.3` pin
-that step introduced was absent from the table entirely. A count is as easy to
-falsify as a digest, and neither the audit nor review catches it.
-
-The reconciliation was manual, prompted by a documentation review rather than by
-any check in this repository. Until the planned preflight exists, **treat "the
-register matches the workflows" as an assumption, not a guarantee** — and
-re-derive the table from the workflow files whenever a pin changes.
+Both of those gaps are now covered by `scripts/check-supply-chain.mjs` — see
+[Keeping this register true](#keeping-this-register-true) below. What follows
+here is what remains outside any check.
 
 **Production is not yet protected.** The `*-prod.yml` files are pinned by this
 change, but GitHub Actions runs the workflow file _from the branch being pushed_.
 Measured on `origin/main`, 29 August 2026: **4 workflows, 13 `uses:` references,
 0 digest-pinned.** `main` will keep using those copies until `acc` is promoted.
 Pinning the file is not the same as pinning the branch that runs it.
+
+## Keeping this register true
+
+The Pinned table is the only part of this document a machine reads.
+`scripts/check-supply-chain.mjs` runs in the `audit` job and compares it with
+the workflows — digests, versions, the `(×N)` multiplicities, and the
+`30 uses: references across 9 workflows` headline — then resolves every digest
+against the GitHub API to confirm it is the version its comment claims. Run it
+by hand with `npm run check-supply-chain`; `--offline` skips the API and checks
+format and register agreement only.
+
+**This repository is why the count half exists.** Between the v7 upgrades
+(`2026.08.33`) and 29 August 2026 the table still listed superseded v4 digests
+for `actions/checkout`, `actions/setup-node` and `actions/upload-artifact`: the
+workflows had moved, the register had not, and every gate stayed green
+throughout. A quieter drift came with it — `setup-node` had gone from ×8 to ×9
+when the `renovate-config-validator` step was added, and the `renovate@44.50.3`
+pin that step introduced was missing from the table entirely. A count is as easy
+to falsify as a digest, and neither the audit nor review caught it. That
+reconciliation was manual, prompted by a documentation review rather than by any
+check here. It is no longer an assumption.
+
+**Renovate does not maintain this table.** It rewrites workflow pins and their
+version comments together, honestly and correctly, and never touches this file.
+So an action-bump pull request leaves the register describing a policy the
+workflows no longer follow — the same drift as above, arriving by the most
+routine route there is.
+
+**So: when a Renovate pull request bumps an action, update this table on that
+pull request's branch, before merging it.** Not afterwards. The check runs on the
+pull request, so a register fixed after the merge leaves the check red for that
+pull request's entire life — and makes the step impossible to promote to
+blocking, because no bump could ever show a green result to merge on.
+
+Adding or removing a workflow step that carries a `uses:` line also moves the
+`(×N)` count and the totals headline. That is the ×8→×9 case above, and the check
+now fails on it rather than leaving it to a reader.
+
+The step is `continue-on-error: true` for now. It was proven in
+linked-data-explorer over two bumps
+([#66](https://github.com/sgort/linked-data-explorer/pull/66),
+[#67](https://github.com/sgort/linked-data-explorer/pull/67)) and promoted to
+blocking there; promote it here once the same habit holds. Do not leave it
+non-blocking indefinitely: `continue-on-error` rewrites the _step's_ reported
+conclusion as well as the job's, and the honest result is not exposed by the REST
+API — so a finding is visible only in the step's log while the checks list, the
+job and the step all read "success". See issue
+[#81](https://github.com/sgort/ronl-business-api/issues/81).
 
 ## Pending work
 

--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
     "build:pa-demo": "npm run build --workspace=@ronl/pa-demo",
     "lint": "npm run lint --workspaces --if-present",
     "lint:fix": "npm run lint:fix --workspaces --if-present",
+    "check-supply-chain": "node scripts/check-supply-chain.mjs",
     "check-format": "prettier --check \"**/*.{ts,tsx,json,md}\" --ignore-path .gitignore",
     "format": "prettier --write \"**/*.{ts,tsx,json,md}\" --ignore-path .gitignore",
     "test": "npm run test --workspaces --if-present",

--- a/scripts/check-supply-chain.mjs
+++ b/scripts/check-supply-chain.mjs
@@ -1,0 +1,438 @@
+#!/usr/bin/env node
+/**
+ * check-supply-chain.mjs — the preflight zizmor cannot be.
+ *
+ * zizmor validates pin FORMAT: it will tell you that `uses:` names a 40-character
+ * commit SHA. It cannot tell you that the SHA is the right one. A wrong — or
+ * hostile — digest carrying a plausible `# v4.4.0` comment passes zizmor,
+ * Prettier and human review alike, because nothing re-resolves the reference.
+ *
+ * Two gaps are recorded in SECURITY-PIPELINE.md as the motivation for this
+ * script, and it closes both:
+ *
+ *   1. PIN TRUTH  — does each pinned digest actually resolve to the version its
+ *                   trailing comment claims? The comment is not decorative:
+ *                   Renovate reads and rewrites it, and a human reviewer trusts
+ *                   it. If comment and digest disagree, one of them is lying.
+ *
+ *   2. REGISTER   — does SECURITY-PIPELINE.md still describe the workflows?
+ *      AGREEMENT    Renovate updates workflow pins and never touches the
+ *                   register, and nothing checked that the two agree. They
+ *                   drifted within a week of the register predicting they would:
+ *                   the workflows moved to checkout v7.0.1 / setup-node v7.0.0
+ *                   while the register still listed v3.7.0 / v4.4.0.
+ *
+ * Usage:
+ *   node scripts/check-supply-chain.mjs            # full check (needs a token)
+ *   node scripts/check-supply-chain.mjs --offline  # skip the API, check format
+ *                                                  # and register agreement only
+ *
+ * Transport: GITHUB_TOKEN or GH_TOKEN over plain fetch when present (that is the
+ * CI path — the workflow token is enough, this only reads public refs), else
+ * `gh api`, which handles its own auth. Shelling out to `gh` rather than
+ * scraping a token out of it keeps the credential out of this process
+ * entirely, and works on older `gh` builds with no `auth token` subcommand.
+ *
+ * Exit code 0 when everything agrees, 1 when it does not. Anything the script
+ * cannot check is reported explicitly rather than passed over in silence: a
+ * preflight that quietly skips things is how the register drifted in the first
+ * place.
+ */
+
+import { execFileSync } from 'node:child_process';
+import { readFileSync, readdirSync } from 'node:fs';
+import { join } from 'node:path';
+
+const WORKFLOW_DIR = '.github/workflows';
+const REGISTER = 'SECURITY-PIPELINE.md';
+
+/**
+ * References that cannot be resolved as a tag, with the reason recorded inline.
+ * This mirrors how renovate.json carries its exceptions: an exception without a
+ * reason is indistinguishable from an oversight six months later.
+ */
+const EXCEPTIONS = {
+  'Azure/static-web-apps-deploy': {
+    resolveAs: 'branch',
+    reason:
+      'v1 is published as BOTH a 2021 tag (1a947af…) and a 2024 branch head. ' +
+      'The workflows deliberately pin the BRANCH head, resolved from a real ' +
+      'Actions run log; the tag would be 3.5-year-old code. See SECURITY-PIPELINE.md.',
+  },
+};
+
+const findings = [];
+const notes = [];
+const offline = process.argv.includes('--offline');
+
+function fail(check, detail) {
+  findings.push({ check, detail });
+}
+
+// ---------------------------------------------------------------- token
+
+/**
+ * Pick a transport, or null when neither is available.
+ *   'fetch' — an env token is present (the CI path)
+ *   'gh'    — the gh CLI is installed and authenticated (the local path)
+ */
+function transport() {
+  if (process.env.GITHUB_TOKEN || process.env.GH_TOKEN) return 'fetch';
+  try {
+    execFileSync('gh', ['auth', 'status'], { stdio: 'ignore' });
+    return 'gh';
+  } catch {
+    return null;
+  }
+}
+
+// ---------------------------------------------------------------- collect
+
+/**
+ * Every `uses:` line across the workflows, with the digest and the version the
+ * trailing comment claims.
+ */
+function collectPins() {
+  const pins = [];
+  const files = readdirSync(WORKFLOW_DIR).filter((f) => /\.ya?ml$/.test(f));
+
+  for (const file of files) {
+    const lines = readFileSync(join(WORKFLOW_DIR, file), 'utf8').split(/\r?\n/);
+    lines.forEach((line, i) => {
+      const m = line.match(/^\s*(?:-\s*)?uses:\s*([^@\s]+)@(\S+)(?:\s*#\s*(\S+))?/);
+      if (!m) return;
+      const [, action, ref, comment] = m;
+      pins.push({ file, line: i + 1, action, ref, comment: comment ?? null });
+    });
+  }
+  return pins;
+}
+
+/**
+ * The `Pinned` table in SECURITY-PIPELINE.md.
+ *
+ * Returns { rows: { action: {digest, version, count} }, totals } where `count`
+ * is the "(×N)" multiplicity some registers record beside the dependency name,
+ * and `totals` is the "N `uses:` references across M workflows" headline where
+ * one is present.
+ *
+ * Both are checked, because a count is as easy to falsify as a digest and
+ * neither the audit nor review catches it: in ronl-business-api, setup-node
+ * silently went from ×8 to ×9 when the config-validator step was added, and the
+ * register still said ×8 with every gate green.
+ */
+function readRegister() {
+  let text;
+  try {
+    text = readFileSync(REGISTER, 'utf8');
+  } catch {
+    fail('register', `${REGISTER} not found — the exceptions register is missing`);
+    return null;
+  }
+
+  const rows = {};
+  for (const line of text.split(/\r?\n/)) {
+    if (!line.trim().startsWith('|')) continue;
+    const cells = line.split('|').map((c) => c.trim());
+    // | dependency | pin | version | maintained by |
+    if (cells.length < 5) continue;
+    const depCell = cells[1].replace(/`/g, '').trim();
+    const pin = cells[2].replace(/`/g, '').trim();
+    const version = cells[3].trim();
+
+    // "actions/checkout" or "actions/checkout (×9)" — the multiplicity is
+    // optional, and a row that carries one gets it verified.
+    const m = depCell.match(/^([\w.-]+\/[\w.-]+)(?:\s*\(\s*[×x]\s*(\d+)\s*\))?$/);
+    if (!m) continue; // prose rows: "zizmor itself", "npm dependencies", …
+
+    // An action can legitimately be pinned at MORE THAN ONE digest -- different
+    // workflows in the same repo may sit on different majors mid-upgrade, and a
+    // good register records every one. linked-data-explorer does exactly this
+    // with actions/checkout (v4.4.0 in three workflows, v3.7.0 in four). Keying
+    // by action alone silently kept the last row and invented a mismatch
+    // against the others, so rows are collected per action.
+    (rows[m[1]] ??= []).push({
+      digest: pin.replace(/[.…]+$/, ''),
+      version,
+      count: m[2] ? Number(m[2]) : null,
+    });
+  }
+
+  // "**30 `uses:` references across 9 workflows**" — optional headline.
+  const t = text.match(/(\d+)\s*`?uses:`?\s*references?\s+across\s+(\d+)\s+workflows?/i);
+  const totals = t ? { refs: Number(t[1]), workflows: Number(t[2]) } : null;
+
+  return { rows, totals };
+}
+
+// ---------------------------------------------------------------- resolve
+
+async function api(path, via) {
+  if (via === 'gh') {
+    try {
+      return JSON.parse(execFileSync('gh', ['api', path], { encoding: 'utf8' }));
+    } catch (err) {
+      // gh exits non-zero on 404; treat "not found" as an absent ref rather
+      // than as a transport failure, so a missing tag is reported as such.
+      if (/HTTP 404|Not Found/i.test(String(err.stderr ?? err.message))) return null;
+      throw new Error(
+        String(err.stderr ?? err.message)
+          .trim()
+          .split('\n')[0]
+      );
+    }
+  }
+
+  const tok = process.env.GITHUB_TOKEN || process.env.GH_TOKEN;
+  const res = await fetch(`https://api.github.com${path}`, {
+    headers: {
+      accept: 'application/vnd.github+json',
+      'user-agent': 'check-supply-chain',
+      ...(tok ? { authorization: `Bearer ${tok}` } : {}),
+    },
+  });
+  if (res.status === 404) return null;
+  if (!res.ok) throw new Error(`${res.status} ${res.statusText} for ${path}`);
+  return res.json();
+}
+
+/** Resolve a tag (dereferencing annotated tags) or a branch head to a commit SHA. */
+async function resolveRef(action, version, via) {
+  const mode = EXCEPTIONS[action]?.resolveAs ?? 'tag';
+  const path =
+    mode === 'branch'
+      ? `/repos/${action}/git/ref/heads/${encodeURIComponent(version)}`
+      : `/repos/${action}/git/ref/tags/${encodeURIComponent(version)}`;
+
+  const ref = await api(path, via);
+  if (!ref) return null;
+
+  // An annotated tag points at a tag object; dereference it to the commit.
+  if (ref.object?.type === 'tag') {
+    const tag = await api(`/repos/${action}/git/tags/${ref.object.sha}`, via);
+    return tag?.object?.sha ?? null;
+  }
+  return ref.object?.sha ?? null;
+}
+
+// ---------------------------------------------------------------- checks
+
+function checkFormat(pins) {
+  for (const p of pins) {
+    if (!/^[0-9a-f]{40}$/.test(p.ref)) {
+      fail('format', `${p.file}:${p.line} — ${p.action}@${p.ref} is not a 40-character commit SHA`);
+      continue;
+    }
+    if (!p.comment) {
+      fail(
+        'format',
+        `${p.file}:${p.line} — ${p.action}@${p.ref.slice(0, 12)}… has no ` +
+          `trailing "# version" comment. Renovate parses that comment to know ` +
+          `which version the digest represents, and rewrites it on update.`
+      );
+    }
+  }
+}
+
+/**
+ * A register's version cell may carry an annotation the workflow comment does
+ * not -- "v1 (branch head)" against a bare "v1". Compare the leading token, so
+ * the register can explain itself without tripping the check.
+ */
+function versionToken(v) {
+  return String(v ?? '')
+    .trim()
+    .split(/[\s(]/)[0];
+}
+
+function checkRegister(pins, register, workflowCount) {
+  if (!register) return;
+  const { rows, totals } = register;
+  const rowsFor = (action) => rows[action] ?? [];
+
+  // Group workflow pins by action AND digest: the same action at two digests is
+  // two distinct things to verify, not one.
+  const byActionDigest = new Map(); // "action@digest" -> {action, digest, comment, count}
+  const uses = new Map(); // action -> total references, across all its digests
+  for (const p of pins) {
+    if (!/^[0-9a-f]{40}$/.test(p.ref)) continue;
+    const k = `${p.action}@${p.ref}`;
+    const seen = byActionDigest.get(k);
+    if (seen) seen.count += 1;
+    else
+      byActionDigest.set(k, {
+        action: p.action,
+        digest: p.ref,
+        comment: p.comment,
+        count: 1,
+        file: p.file,
+      });
+    uses.set(p.action, (uses.get(p.action) ?? 0) + 1);
+  }
+  const inWorkflows = byActionDigest;
+
+  if (totals) {
+    if (totals.refs !== pins.length) {
+      fail(
+        'register',
+        `${REGISTER} says ${totals.refs} "uses:" references; the workflows have ` + `${pins.length}`
+      );
+    }
+    if (totals.workflows !== workflowCount) {
+      fail(
+        'register',
+        `${REGISTER} says ${totals.workflows} workflows; ${WORKFLOW_DIR}/ has ` + `${workflowCount}`
+      );
+    }
+  }
+
+  const claimed = new Set(); // register rows a workflow pin accounted for
+
+  for (const wf of inWorkflows.values()) {
+    const candidates = rowsFor(wf.action);
+    if (candidates.length === 0) {
+      fail(
+        'register',
+        `${wf.action} is pinned in ${wf.file} but absent from ${REGISTER}'s Pinned table`
+      );
+      continue;
+    }
+
+    // Rows are matched by digest, not by action: an action pinned at two
+    // digests has two rows, and each workflow pin must find its own.
+    const row = candidates.find((r) => wf.digest.startsWith(r.digest));
+    if (!row) {
+      const listed = candidates.map((r) => `${r.digest.slice(0, 12)}… (${r.version})`).join(', ');
+      fail(
+        'register',
+        `${wf.action}: workflow pins ${wf.digest.slice(0, 12)}… (${wf.comment}) but ` +
+          `${REGISTER} records only ${listed}`
+      );
+      continue;
+    }
+    claimed.add(row);
+
+    if (wf.comment && row.version && versionToken(wf.comment) !== versionToken(row.version)) {
+      fail(
+        'register',
+        `${wf.action}: digests agree but versions do not — workflow says ` +
+          `${wf.comment}, ${REGISTER} says ${row.version}`
+      );
+    }
+
+    // A ×N on a row counts THAT digest's references, not the action's total --
+    // an action at two digests has its uses split across two rows.
+    if (row.count !== null && row.count !== wf.count) {
+      fail(
+        'register',
+        `${wf.action} at ${wf.digest.slice(0, 12)}…: ${REGISTER} records ` +
+          `×${row.count} but the workflows reference it ${wf.count} time(s)`
+      );
+    }
+  }
+
+  for (const [action, candidates] of Object.entries(rows)) {
+    for (const row of candidates) {
+      if (!claimed.has(row)) {
+        notes.push(
+          `${REGISTER} lists ${action} at ${row.digest.slice(0, 12)}… (${row.version}), ` +
+            `which no workflow currently uses`
+        );
+      }
+    }
+  }
+}
+
+async function checkPinTruth(pins, via) {
+  const seen = new Set();
+  for (const p of pins) {
+    if (!/^[0-9a-f]{40}$/.test(p.ref) || !p.comment) continue;
+    const key = `${p.action}@${p.ref}#${p.comment}`;
+    if (seen.has(key)) continue;
+    seen.add(key);
+
+    let actual;
+    try {
+      actual = await resolveRef(p.action, p.comment, via);
+    } catch (err) {
+      fail('pin-truth', `${p.action}@${p.comment}: API error — ${err.message}`);
+      continue;
+    }
+
+    const exc = EXCEPTIONS[p.action];
+    if (actual === null) {
+      fail(
+        'pin-truth',
+        `${p.action}: ${exc?.resolveAs === 'branch' ? 'branch' : 'tag'} ` +
+          `"${p.comment}" does not exist on GitHub`
+      );
+      continue;
+    }
+    if (actual !== p.ref) {
+      fail(
+        'pin-truth',
+        `${p.action}: comment claims ${p.comment}, which resolves to ` +
+          `${actual.slice(0, 12)}… — but the workflow pins ${p.ref.slice(0, 12)}…` +
+          (exc ? `\n      (exception in force: ${exc.reason})` : '')
+      );
+    } else if (exc) {
+      notes.push(
+        `${p.action}@${p.comment} verified against the ${exc.resolveAs}, per its ` +
+          `recorded exception`
+      );
+    }
+  }
+}
+
+// ---------------------------------------------------------------- main
+
+const pins = collectPins();
+if (pins.length === 0) {
+  console.error(`No "uses:" references found under ${WORKFLOW_DIR}/ — is the path right?`);
+  process.exit(1);
+}
+
+const workflowCount = readdirSync(WORKFLOW_DIR).filter((f) => /\.ya?ml$/.test(f)).length;
+
+checkFormat(pins);
+checkRegister(pins, readRegister(), workflowCount);
+
+if (offline) {
+  notes.push('--offline: pin truth was NOT verified against GitHub');
+} else {
+  const via = transport();
+  if (!via) {
+    fail(
+      'pin-truth',
+      'No GitHub transport available: set GITHUB_TOKEN or GH_TOKEN, or ' +
+        'authenticate the gh CLI. Pin truth was NOT verified. Pass --offline ' +
+        'to acknowledge that gap deliberately rather than failing on it.'
+    );
+  } else {
+    await checkPinTruth(pins, via);
+  }
+}
+
+// ---------------------------------------------------------------- report
+
+const actions = new Set(pins.map((p) => p.action));
+console.log(
+  `check-supply-chain: ${pins.length} pinned reference(s) across ` +
+    `${actions.size} action(s) in ${WORKFLOW_DIR}/`
+);
+
+for (const n of notes) console.log(`  note: ${n}`);
+
+if (findings.length === 0) {
+  console.log('\nOK — digests, version comments and the register all agree.');
+  process.exit(0);
+}
+
+console.error(`\n${findings.length} finding(s):\n`);
+for (const f of findings) console.error(`  [${f.check}] ${f.detail}`);
+console.error(
+  '\nA digest that does not resolve to the version its comment claims is the ' +
+    'failure this script exists to catch. Fix the pin or the comment — do not ' +
+    'silence the check.'
+);
+process.exit(1);


### PR DESCRIPTION
Closes #81.

Adopts `scripts/check-supply-chain.mjs`, adds `npm run check-supply-chain`, and wires it into the existing `audit` job as a **non-blocking** step.

## What it checks that zizmor cannot

zizmor validates pin **format** — that a `uses:` names a 40-character SHA. It cannot say the SHA is the *right* one, so a wrong or hostile digest carrying a plausible `# v7.0.1` comment passes zizmor, Prettier and human review alike. This resolves every digest against the GitHub API and compares the register with the workflows.

Copied verbatim from ttl-editor `acc` after [ttl-editor#86](https://github.com/sgort/ttl-editor/pull/86), byte-identical to the copy adopted in [linked-data-explorer#77](https://github.com/sgort/linked-data-explorer/pull/77). Left unformatted deliberately — Prettier doesn't cover `scripts/` here, and reformatting would diverge from upstream.

## Re-derived for this repository, not copied

The shape differs from linked-data-explorer in ways that matter:

| | linked-data-explorer | this repository |
|---|---|---|
| Pinned references | 23 across 5 actions, 7 workflows | **30 across 5 actions, 9 workflows** |
| `(×N)` multiplicities | none | **×9, ×9, ×9, ×2** — all checked |
| Totals headline | none | **`30 uses: references across 9 workflows`** — checked |
| Prettier covers `.md` | no | **yes** |

I ran the script here before wiring anything in, which is what the issue advises. It reports clean:

```
check-supply-chain: 30 pinned reference(s) across 5 action(s) in .github/workflows/
  note: Azure/static-web-apps-deploy@v1 verified against the branch, per its recorded exception

OK — digests, version comments and the register all agree.
```

## Acceptance

**A planted wrong digest fails**, naming the recorded digest, the count mismatch it causes, and the pin-truth failure:

```
[register] actions/checkout: workflow pins deadbeef1234… (v7.0.1) but SECURITY-PIPELINE.md records only 3d3c42e5aac5… (v7.0.1)
[register] actions/checkout at 3d3c42e5aac5…: SECURITY-PIPELINE.md records ×9 but the workflows reference it 8 time(s)
[pin-truth] actions/checkout: comment claims v7.0.1, which resolves to 3d3c42e5aac5… — but the workflow pins deadbeef1234…
```

**A drifted count fails** — and this is the case worth having here, because it is the one that already bit this repository. `setup-node` silently went from ×8 to ×9 when the `renovate-config-validator` step was added, and the register still said ×8 with every gate green:

```
[register] actions/setup-node at 820762786026…: SECURITY-PIPELINE.md records ×8 but the workflows reference it 9 time(s)
```

This step adds no `uses:` line, so 30/9 and every `×N` stay accurate.

## Why non-blocking to start

Renovate rewrites workflow pins and never touches `SECURITY-PIPELINE.md`, so every action-bump pull request fails the register half until the register is updated by hand. Blocking on that would fail a required check on routine dependency updates — how gates get resented and then bypassed.

The answer, proven in linked-data-explorer over two bumps ([#66](https://github.com/sgort/linked-data-explorer/pull/66), [#67](https://github.com/sgort/linked-data-explorer/pull/67)): update the register **on the bump's branch, before merging**, so the check is green on the pull request rather than only on `acc` afterwards. Promoted to blocking there in [#81](https://github.com/sgort/linked-data-explorer/pull/81) once that held twice.

**Do not leave it non-blocking indefinitely.** `continue-on-error` does not merely keep the job green — it rewrites the **step's** reported conclusion too, and the honest result (`outcome: failure`) is not exposed by the REST API. On linked-data-explorer#66 the checks list, the job and the step all read `success` while that step's own log carried a real finding. A check nobody can see fail is not protecting anything.

## SECURITY-PIPELINE.md

*What the audit cannot see* claimed this preflight was "planned" and told readers to treat register agreement as "an assumption, not a guarantee". Both are now false, so that passage is rewritten to point at a new **Keeping this register true** section.

The v4-digest drift and the ×8→×9 incident are kept there as the motivation for what the check does, rather than deleted as stale history — they are the evidence that the count half earns its place.

## Placement

A **step** in the existing `audit` job, not a new job: the `acc` ruleset requires the check named `audit`, so a step is covered automatically, while a new job would silently not block until someone added it to the ruleset. `if: always()` for the same reason as the config-validator step above it — one run should report on every half of the policy rather than stopping at the first failure.

## Also verified

semgrep clean over 487 rules; the workflow parses with `continue-on-error: true` and `if: always()` retained; Prettier clean — worth stating because `.md` **is** in this repository's Prettier scope, unlike linked-data-explorer's, and the register was conforming before this change.
