### PR TITLE
ci: enforce the per-file 80% branch floor, and run pa-cockpit in CI

### DIFF
--- a/.github/workflows/azure-frontend-acc.yml
+++ b/.github/workflows/azure-frontend-acc.yml
@@ -82,6 +82,20 @@ jobs:
         working-directory: packages/frontend
         run: npm run lint
 
+      # @ronl/pa-cockpit has no deploy workflow of its own — it is a library
+      # this frontend consumes — so until now its 476 tests ran nowhere in CI.
+      # This workflow's paths filter already includes packages/pa-cockpit/**,
+      # so a change there triggers this run; it just did not test it. Placed
+      # before the frontend's own suite because the frontend imports it: a
+      # break here explains a break there.
+      #
+      # It also makes the per-file 80% branch floor mean the same thing in
+      # every workspace. A threshold that only fires on someone's laptop is a
+      # convention wearing a gate's clothes. See issue #80.
+      - name: Unit tests (pa-cockpit)
+        working-directory: packages/pa-cockpit
+        run: npm test
+
       - name: Unit tests
         working-directory: packages/frontend
         run: npm test

--- a/.github/workflows/azure-frontend-prod.yml
+++ b/.github/workflows/azure-frontend-prod.yml
@@ -56,6 +56,13 @@ jobs:
         working-directory: packages/frontend
         run: npm run lint
 
+      # See azure-frontend-acc.yml for why pa-cockpit's suite runs here: it is
+      # a library with no deploy workflow of its own, already inside this
+      # workflow's paths filter, and its tests ran nowhere in CI before this.
+      - name: Unit tests (pa-cockpit)
+        working-directory: packages/pa-cockpit
+        run: npm test
+
       - name: Unit tests
         working-directory: packages/frontend
         run: npm test

--- a/packages/backend/jest.config.js
+++ b/packages/backend/jest.config.js
@@ -12,6 +12,29 @@ module.exports = {
     '!src/types/**',
     '!src/index.ts',
   ],
+  // The per-file 80% branch floor, enforced rather than remembered.
+  //
+  // v2026.09.2 took 53 files below the line to none across all five tested
+  // workspaces, and nothing mechanical held it afterwards: a file could drop
+  // to 40% branches and fail no run, no hook and no pipeline. Issue #80.
+  //
+  // A GLOB key, not `global`. Jest applies a glob threshold to each matching
+  // file individually, which is the unit the campaign was measured in — a
+  // package-wide average hides exactly the regression this is for, since one
+  // file falling to 40% barely moves 92%.
+  //
+  // BRANCHES ONLY, deliberately. A functions floor at 80 would fail 31 files
+  // across the other four workspaces today (frontend 11, pa-cockpit 10,
+  // pa-demo 7, public-site 3; backend happens to be 0). Adding `functions: 80`
+  // here would pass and mislead the next person into adding it there.
+  //
+  // `npm test` is `jest --coverage`, and both backend deploy workflows run it,
+  // so this gates CI as well as local runs without a separate coverage job.
+  coverageThreshold: {
+    './src/**/*.ts': {
+      branches: 80,
+    },
+  },
   transform: {
     '^.+\\.tsx?$': ['ts-jest', {
       tsconfig: {

--- a/packages/frontend/vite.config.ts
+++ b/packages/frontend/vite.config.ts
@@ -73,6 +73,21 @@ export default defineConfig({
       reportOnFailure: true,
       include: ['src/**/*.{ts,tsx}'],
       exclude: ['src/**/*.test.{ts,tsx}', 'src/main.tsx', 'src/vite-env.d.ts', 'src/test/**'],
+      // The per-file 80% branch floor, enforced rather than remembered.
+      // v2026.09.2 took 53 files below the line to none, and nothing
+      // mechanical held it afterwards. Issue #80.
+      //
+      // perFile is the whole point: without it the threshold applies to the
+      // package average, which is 89.78% here — one file dropping to 40%
+      // barely moves that, and the regression this exists to catch passes.
+      //
+      // BRANCHES ONLY, deliberately. A functions floor at 80 would fail 11
+      // files in this package today. Do not add `functions: 80` on the
+      // assumption it is equally safe; measure first.
+      thresholds: {
+        branches: 80,
+        perFile: true,
+      },
     },
   },
 });

--- a/packages/pa-cockpit/vitest.config.ts
+++ b/packages/pa-cockpit/vitest.config.ts
@@ -24,6 +24,19 @@ export default defineConfig({
       reportOnFailure: true,
       include: ['src/**/*.{ts,tsx}'],
       exclude: ['src/**/*.test.{ts,tsx}', 'src/test/**', 'src/index.ts'],
+      // The per-file 80% branch floor. See issue #80 and the fuller note in
+      // packages/frontend/vite.config.ts.
+      //
+      // perFile matters most here: the package average is 88.52%, comfortably
+      // clear, while this package's suite runs in CI only because
+      // azure-frontend-{acc,prod}.yml were given an explicit step for it —
+      // it has no deploy workflow of its own.
+      //
+      // BRANCHES ONLY. A functions floor at 80 would fail 10 files here today.
+      thresholds: {
+        branches: 80,
+        perFile: true,
+      },
     },
   },
 });

--- a/packages/pa-demo/vite.config.ts
+++ b/packages/pa-demo/vite.config.ts
@@ -79,6 +79,14 @@ export default defineConfig(({ mode }) => ({
       // by that package's own suite, so these figures are this package's own
       // code and nothing else.
       exclude: ['src/**/*.test.{ts,tsx}', 'src/main.tsx', 'src/vite-env.d.ts', 'src/test/**'],
+      // The per-file 80% branch floor. See issue #80 and the fuller note in
+      // packages/frontend/vite.config.ts.
+      //
+      // BRANCHES ONLY. A functions floor at 80 would fail 7 files here today.
+      thresholds: {
+        branches: 80,
+        perFile: true,
+      },
     },
   },
 }));

--- a/packages/public-site/vite.config.ts
+++ b/packages/public-site/vite.config.ts
@@ -42,6 +42,16 @@ export default defineConfig({
       reportOnFailure: true,
       include: ['src/**/*.{ts,tsx}'],
       exclude: ['src/**/*.test.{ts,tsx}', 'src/main.tsx', 'src/vite-env.d.ts', 'src/test/**'],
+      // The per-file 80% branch floor. See issue #80 and the fuller note in
+      // packages/frontend/vite.config.ts.
+      //
+      // BRANCHES ONLY. A functions floor at 80 would fail 3 files here today —
+      // TopBar.tsx among them, which sits at 100% branches and 66% functions,
+      // a good illustration of why the two are not interchangeable.
+      thresholds: {
+        branches: 80,
+        perFile: true,
+      },
     },
   },
 });


### PR DESCRIPTION
Closes #80.

Makes the per-file 80% branch floor mechanical instead of remembered, and closes the one workspace where it would otherwise have bound nothing.

## The change

Per-file **branch** thresholds in all five runner configs — Jest via a glob key (which it applies per matching file), Vitest via `thresholds: { branches: 80, perFile: true }`. Each carries a comment recording the decision, so someone opening `jest.config.js` and wondering why there is a threshold finds the answer beside it rather than in a plan document. That is the issue's *"decision recorded in the repository, not only in a plan document"* box.

`perFile` is the mechanism, not a detail. Against a package average the threshold is inert: frontend sits at 89.78%, and one file dropping to 40% barely moves it. The campaign was measured per file, so the gate is too.

## Two premises in the issue that did not survive checking

**1. "No workflow runs coverage" — they do.** None *mentions* coverage, but `npm test` is `jest --coverage` / `vitest run --coverage`, and eight workflows run exactly that. So these thresholds gate CI as well as local runs, with no separate coverage job. Most of the issue's option 2 arrives free with option 1.

**2. Except for `pa-cockpit`, which ran nowhere in CI at all.** It is a library with no deploy workflow of its own, so its 476 tests were never executed by any pipeline — a threshold there would have bound only somebody's laptop.

| Workspace | `npm test` in CI, before | after |
|---|---|---|
| backend, frontend, pa-demo, public-site | ✅ acc + prod | unchanged |
| **pa-cockpit** | ❌ none | ✅ both frontend workflows |

Both frontend workflows already carried `packages/pa-cockpit/**` in their paths filter — a change there triggered the run without testing it. Its suite is placed **before** the frontend's own, because the frontend imports it and a break there explains a break here.

**Also worth recording:** the pre-push hook does not run tests (it builds shared, type-checks, lints, checks formatting). The issue assumed pre-push would catch regressions. Adding the suites to it was considered and rejected — ~4.5 minutes on every push including WIP pushes, duplicating what CI now catches, with no legitimate escape given the no-bypass rule.

## Branches only — deliberately

A functions floor at 80 would fail **31 files** today:

| Workspace | files < 80% functions |
|---|---|
| frontend | 11 |
| pa-cockpit | 10 |
| pa-demo | 7 |
| public-site | 3 |
| backend | 0 |

`functions: 80` therefore looks like an obvious companion addition and is not one. The comments say so. `public-site/TopBar.tsx` is the illustration recorded there: **100% branches, 66% functions** — the two are not interchangeable.

## Verification

All five suites pass with thresholds active: backend 2008, frontend 1104, pa-cockpit 476, public-site 204, pa-demo 106.

More importantly, **the gate was proven by making it fail**, not by trusting a green run. A temporary file with four uncovered branches, added to pa-demo and backend:

```
Vitest: ERROR: Coverage for branches (0%) does not meet global threshold (80%) for src/__threshold-probe.ts
Jest:   ".../src/__threshold-probe.ts" coverage threshold for branches (80%) not met: 0%
```

Both exit 1, both **name the file** — the issue's acceptance criterion. Vitest says "global threshold" even in per-file mode; that is its wording, not a misconfiguration, and naming the file rather than reporting pa-demo's 95.65% package average is what demonstrates the per-file behaviour.

Probes removed, suites green again. Lint, type-check and check-format clean. The supply-chain register still agrees — the new steps add no `uses:` line, so 30 references across 9 workflows holds.

## Deliberately not addressed

- **#84** — `@ronl/shared` has no runner, so logic placed there stays unmeasurable by construction. It currently holds no executable logic at all, which is why that issue recommends keeping it declarations-only rather than measuring an empty set.
- **#85** — three backend tests skip permanently now that every RIP phase is modelled, leaving an unreachable `PHASE_NOT_MODELLED` branch. This floor will now count that branch against `rip.routes.ts`, so it is worth removing — but that is a behaviour change and does not belong in a config PR.
