### PR TITLE
fix(public-site): revalidate the prerendered seed instead of trusting it

### DIFF
--- a/packages/public-site/src/lib/prerenderedData.test.ts
+++ b/packages/public-site/src/lib/prerenderedData.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, afterEach, vi } from 'vitest';
-import { readPrerenderedData } from './prerenderedData';
+import { readPrerenderedData, isSamePayload } from './prerenderedData';
 
 function setBlob(content: string | null) {
   document.getElementById('__PUB_DATA__')?.remove();
@@ -60,5 +60,25 @@ describe('readPrerenderedData', () => {
     } finally {
       vi.unstubAllGlobals();
     }
+  });
+});
+
+describe('isSamePayload', () => {
+  it('treats structurally identical payloads as the same', () => {
+    expect(isSamePayload({ services: [{ uri: 's1' }] }, { services: [{ uri: 's1' }] })).toBe(true);
+  });
+
+  it('spots an extra entry — the retired service the stale seed still carried', () => {
+    const seed = { services: [{ uri: 'normbedragen' }, { uri: 'normbedragen-dh' }] };
+    const fresh = { services: [{ uri: 'normbedragen-jul26-041' }] };
+    expect(isSamePayload(seed, fresh)).toBe(false);
+  });
+
+  it('spots a changed value inside an otherwise identical shape', () => {
+    expect(isSamePayload({ n: 196 }, { n: 204 })).toBe(false);
+  });
+
+  it('treats a null seed as different from any payload', () => {
+    expect(isSamePayload(null, { services: [] })).toBe(false);
   });
 });

--- a/packages/public-site/src/lib/prerenderedData.ts
+++ b/packages/public-site/src/lib/prerenderedData.ts
@@ -21,3 +21,20 @@ export function readPrerenderedData<T>(route: string): T | null {
     return null;
   }
 }
+
+/**
+ * Whether a freshly fetched payload is the same as what is already on screen.
+ *
+ * The seed above is only a build-time snapshot: the RONL graph moves under it,
+ * so every page that seeds from the blob has to revalidate against the API
+ * (issue #88). Swapping state unconditionally would undo the reason the seed
+ * exists — an unchanged response would still re-render and shift the layout —
+ * so the swap is gated on this comparison.
+ *
+ * Both sides originate as JSON from the same backend serialisation, so key
+ * order is stable and comparing the serialised form is a sound equality test
+ * here. A spurious mismatch would cost one extra render, not correctness.
+ */
+export function isSamePayload(a: unknown, b: unknown): boolean {
+  return JSON.stringify(a) === JSON.stringify(b);
+}

--- a/packages/public-site/src/pages/Regelcatalogus.test.tsx
+++ b/packages/public-site/src/pages/Regelcatalogus.test.tsx
@@ -290,16 +290,79 @@ describe('Regelcatalogus', () => {
     expect(screen.queryByText('Toetsingsinkomen')).not.toBeInTheDocument();
     expect(screen.getByText('Vervangingsplicht')).toBeInTheDocument();
   });
-  it('renders straight from the prerendered blob, without fetching', async () => {
+  it('paints from the prerendered blob on the first frame, then revalidates', async () => {
     // The whole point of the blob is that /regels paints its full catalogue on
-    // the first frame. A fetch here would mean the placeholder is still shown
-    // first, which is the layout shift this page was measured on.
+    // the first frame. A placeholder here would mean the layout shift this page
+    // was measured on is back. The revalidation runs underneath it, so the blob
+    // stops being the last word — see issue #88.
     setBlob(JSON.stringify({ route: '/regels', data: DATA }));
     try {
       renderPage();
       expect(screen.getByRole('tab', { name: /Organisaties/ })).toBeInTheDocument();
       expect(screen.queryByText('Laden…')).not.toBeInTheDocument();
-      await waitFor(() => expect(api.getRegelcatalogus).not.toHaveBeenCalled());
+      await waitFor(() => expect(api.getRegelcatalogus).toHaveBeenCalled());
+    } finally {
+      setBlob(null);
+    }
+  });
+
+  it('replaces a seed that the graph has moved on from', async () => {
+    // The shipped bug: the blob was baked when SZW still had two separate
+    // services that happened to share a title, and both had since been retired
+    // in favour of one. Without revalidation the page showed them forever.
+    const STALE = {
+      ...DATA,
+      services: [
+        ...DATA.services,
+        {
+          uri: 'normbedragen-dh',
+          title: 'Normenbrief - Informatie voor gemeenten',
+          description: '',
+        },
+      ],
+    };
+    setBlob(JSON.stringify({ route: '/regels', data: STALE }));
+    try {
+      renderPage();
+      // First frame still shows the stale count — that is the seed doing its job.
+      expect(screen.getByRole('tab', { name: /Diensten/ })).toHaveTextContent('3');
+      await waitFor(() =>
+        expect(screen.getByRole('tab', { name: /Diensten/ })).toHaveTextContent('2')
+      );
+      fireEvent.click(screen.getByRole('tab', { name: /Diensten/ }));
+      expect(screen.queryByText('Normenbrief - Informatie voor gemeenten')).not.toBeInTheDocument();
+    } finally {
+      setBlob(null);
+    }
+  });
+
+  it('leaves the view untouched when the revalidation matches the seed', async () => {
+    // An unchanged response must not swap state: a re-render here is exactly the
+    // layout shift the seed exists to prevent. The fetch resolves with a distinct
+    // object that is structurally equal, so only a value comparison can tell.
+    vi.mocked(api.getRegelcatalogus).mockResolvedValue(JSON.parse(JSON.stringify(DATA)));
+    setBlob(JSON.stringify({ route: '/regels', data: DATA }));
+    try {
+      renderPage();
+      const tabsBefore = screen.getByRole('tab', { name: /Diensten/ }).textContent;
+      await waitFor(() => expect(api.getRegelcatalogus).toHaveBeenCalled());
+      expect(screen.getByRole('tab', { name: /Diensten/ }).textContent).toBe(tabsBefore);
+      expect(screen.queryByText('Laden…')).not.toBeInTheDocument();
+    } finally {
+      setBlob(null);
+    }
+  });
+
+  it('keeps the seed on screen when the revalidation fails', async () => {
+    // A backend blip must not blank a page that already has content. Before the
+    // fetch existed this could not happen; now it can, so it is pinned.
+    vi.mocked(api.getRegelcatalogus).mockRejectedValue(new Error('backend down'));
+    setBlob(JSON.stringify({ route: '/regels', data: DATA }));
+    try {
+      renderPage();
+      await waitFor(() => expect(api.getRegelcatalogus).toHaveBeenCalled());
+      expect(screen.getByRole('tab', { name: /Diensten/ })).toHaveTextContent('2');
+      expect(screen.queryByText('Laden…')).not.toBeInTheDocument();
     } finally {
       setBlob(null);
     }

--- a/packages/public-site/src/pages/Regelcatalogus.tsx
+++ b/packages/public-site/src/pages/Regelcatalogus.tsx
@@ -5,7 +5,7 @@ import { Link } from 'react-router-dom';
 import type { Translations, Lang } from '../i18n';
 import { sectionForType, sectionLabel, sectionSub } from '../lib/sections';
 import { getRegelcatalogus, type RegelcatalogusData, type CatalogService } from '../lib/api';
-import { readPrerenderedData } from '../lib/prerenderedData';
+import { readPrerenderedData, isSamePayload } from '../lib/prerenderedData';
 import { slugify, hrefFor } from '../lib/slug';
 import Crumbs from '../components/Crumbs';
 import Tabs from '../components/Tabs';
@@ -32,11 +32,27 @@ export default function Regelcatalogus({ t, lang }: { t: Translations; lang: Lan
   const [begrippenService, setBegrippenService] = useState('');
 
   useEffect(() => {
-    // Already seeded from the prerendered blob (initial load) — skip the fetch.
-    if (data) return;
-    getRegelcatalogus().then(setData);
-    // Runs once on mount; `data` here is the seed value, intentionally not a dep.
-    // eslint-disable-next-line react-hooks/exhaustive-deps
+    // Revalidate even when the blob seeded us: it was baked when the site was
+    // last built, and the RONL graph moves independently of deploys — that is
+    // how /regels kept showing two services SZW had already retired (#88).
+    // The seed still paints the first frame; the swap only happens when the
+    // API disagrees with it, so an unchanged catalogue causes no re-render and
+    // the no-layout-shift guarantee the seed exists for survives.
+    let cancelled = false;
+    getRegelcatalogus()
+      .then((fresh) => {
+        if (cancelled) return;
+        setData((current) => (isSamePayload(current, fresh) ? current : fresh));
+      })
+      .catch(() => {
+        // Keep whatever is on screen. With a seed that is the full catalogue,
+        // slightly stale but correct-looking; without one the placeholder
+        // stays, exactly as before this revalidation existed.
+      });
+    return () => {
+      cancelled = true;
+    };
+    // Runs once on mount.
   }, []);
 
   if (!data) {

--- a/packages/public-site/src/pages/SectionIndex.test.tsx
+++ b/packages/public-site/src/pages/SectionIndex.test.tsx
@@ -126,10 +126,82 @@ describe('SectionIndex — prerendered seeding', () => {
         <SectionIndex t={t} lang="nl" type="bericht" />
       </MemoryRouter>
     );
-    // Present synchronously — seeded during render, no "Laden…" then fetch.
+    // Present synchronously — seeded during render, no "Laden…" first.
     expect(screen.getByRole('link', { name: /Seeded bericht/ })).toBeInTheDocument();
     expect(screen.getByText('1 items')).toBeInTheDocument();
-    expect(api.getBerichten).not.toHaveBeenCalled();
+  });
+
+  it('revalidates the seed and replaces it when the section has moved on', async () => {
+    // Same defect as the Regelcatalogus one in issue #88: the blob is baked at
+    // build time, so every section route froze at the last deploy.
+    vi.mocked(api.getBerichten).mockResolvedValue({
+      items: [
+        {
+          id: 'b9',
+          subject: 'Fresh bericht',
+          preview: '',
+          content: null,
+          publishedAt: '2026-07-02',
+          sender: { id: 'x', name: 'X' },
+        },
+      ],
+      total: 1,
+    });
+    setBlob('/berichten', [
+      {
+        id: 'b1',
+        slug: 'b1',
+        type: 'bericht',
+        title: 'Stale bericht',
+        summary: 'x',
+        org: 'Provincie Flevoland',
+        date: '2026-07-01',
+        audience: [],
+        external: null,
+        facts: [],
+        tech: [],
+      },
+    ]);
+    render(
+      <MemoryRouter initialEntries={['/berichten']}>
+        <SectionIndex t={t} lang="nl" type="bericht" />
+      </MemoryRouter>
+    );
+    // The seed paints first, with no loading placeholder in between.
+    expect(screen.getByRole('link', { name: /Stale bericht/ })).toBeInTheDocument();
+    expect(screen.queryByText('Laden…')).not.toBeInTheDocument();
+
+    await waitFor(() =>
+      expect(screen.getByRole('link', { name: /Fresh bericht/ })).toBeInTheDocument()
+    );
+    expect(screen.queryByRole('link', { name: /Stale bericht/ })).not.toBeInTheDocument();
+  });
+
+  it('keeps the seed on screen when the revalidation fails', async () => {
+    vi.mocked(api.getBerichten).mockRejectedValue(new Error('backend down'));
+    setBlob('/berichten', [
+      {
+        id: 'b1',
+        slug: 'b1',
+        type: 'bericht',
+        title: 'Seeded bericht',
+        summary: 'x',
+        org: 'Provincie Flevoland',
+        date: '2026-07-01',
+        audience: [],
+        external: null,
+        facts: [],
+        tech: [],
+      },
+    ]);
+    render(
+      <MemoryRouter initialEntries={['/berichten']}>
+        <SectionIndex t={t} lang="nl" type="bericht" />
+      </MemoryRouter>
+    );
+    await waitFor(() => expect(api.getBerichten).toHaveBeenCalled());
+    expect(screen.getByRole('link', { name: /Seeded bericht/ })).toBeInTheDocument();
+    expect(screen.queryByText('Laden…')).not.toBeInTheDocument();
   });
 
   it('still fetches when no blob is present (cold load)', async () => {

--- a/packages/public-site/src/pages/SectionIndex.tsx
+++ b/packages/public-site/src/pages/SectionIndex.tsx
@@ -4,7 +4,7 @@ import type { Translations, Lang } from '../i18n';
 import { sectionForType, sectionLabel, sectionSub, type PubType } from '../lib/sections';
 import { getBerichten, getNieuws, getProducten, getProcessen, type PublicHit } from '../lib/api';
 import { mapToHits } from '../lib/sectionHits';
-import { readPrerenderedData } from '../lib/prerenderedData';
+import { readPrerenderedData, isSamePayload } from '../lib/prerenderedData';
 import SearchForm from '../components/SearchForm';
 import Hit from '../components/Hit';
 import Crumbs from '../components/Crumbs';
@@ -48,19 +48,27 @@ export default function SectionIndex({
 
   useEffect(() => {
     const seed = readPrerenderedData<PublicHit[]>(sectionForType(type).path);
-    if (seed) {
-      setAll(seed);
-      setLoading(false);
-      return;
-    }
     let cancelled = false;
-    setLoading(true);
-    loadItems(type).then((items) => {
-      if (!cancelled) {
-        setAll(items);
+    if (seed) {
+      // Paint the seed, then revalidate underneath it — the blob is a snapshot
+      // of the last build, so without this the section froze at deploy time
+      // (issue #88). Never flip back to the placeholder once there is content.
+      setAll((current) => (isSamePayload(current, seed) ? current : seed));
+      setLoading(false);
+    } else {
+      setLoading(true);
+    }
+    loadItems(type)
+      .then((items) => {
+        if (cancelled) return;
+        setAll((current) => (isSamePayload(current, items) ? current : items));
         setLoading(false);
-      }
-    });
+      })
+      .catch(() => {
+        // A failed revalidation must not blank a seeded list; a cold load falls
+        // through to the empty state rather than spinning forever.
+        if (!cancelled) setLoading(false);
+      });
     return () => {
       cancelled = true;
     };


### PR DESCRIPTION
Closes #88.

## The bug

`acc.publiek.open-regels.nl/regels` showed **two identical "Normenbrief - Informatie voor gemeenten"** entries under Sociale Zaken en Werkgelegenheid and a Diensten count of **14**. The caseworker dashboard's Regelcatalogus, reading the very same API, correctly showed **one** and **13**.

| Source | Diensten | SZW entries | Begrippen |
| --- | --- | --- | --- |
| TriplyDB SPARQL (live) | 13 | 1 × `normbedragen-jul26-041` | — |
| `GET /v1/public/regelcatalogus` on ACC (live) | 13 | 1 × `normbedragen-jul26-041` | 204 |
| Caseworker dashboard | 13 | 1 | 204 |
| `acc.publiek.open-regels.nl/regels` | **14** | **2** | **196** |

The `__PUB_DATA__` blob pulled off the live ACC page carries 14 services, and the two SZW entries are **two genuinely different service URIs** — `normbedragen` and `normbedragen-dh` — not one row emitted twice. Both have since been retired in the RONL graph in favour of `normbedragen-jul26-041`. So this was never a data-quality problem in TriplyDB, nor a missing `DISTINCT` in any SPARQL query.

## Root cause

`scripts/prerender.ts` embeds each route's data into the static HTML so the first client render already has content and the page does not shift — the CLS fix that seeding was introduced for. Both consuming pages then treated that seed as the *final* value rather than a first paint:

```ts
// Regelcatalogus.tsx, before
useEffect(() => {
  // Already seeded from the prerendered blob (initial load) — skip the fetch.
  if (data) return;
  getRegelcatalogus().then(setData);
}, []);
```

`SectionIndex.tsx` had the same early return. Seed present → no fetch, ever. The public site therefore rendered a snapshot frozen at the last build, changing only on redeploy. The caseworker page has no seed — it fetches on mount and offers a Vernieuwen button that passes `?refresh=true` to bypass the 5-minute server cache — which is exactly why it was right.

This affected **every** prerendered content route, not just the Regelcatalogus: Berichten, Nieuws, Producten & Diensten and Processen all go through `SectionIndex`. The Begrippen delta (196 vs 204) is the same staleness surfacing on a second counter.

## The fix — stale-while-revalidate

- **`lib/prerenderedData.ts`** — new `isSamePayload(a, b)`, comparing the serialised form. Both sides originate as JSON from the same backend serialisation, so key order is stable; a spurious mismatch would cost one extra render, not correctness.
- **`Regelcatalogus.tsx`** — the seed still paints the first frame, the fetch now always runs, and state is swapped **only** when the API disagrees with the seed. Gating on `isSamePayload` is what keeps the no-layout-shift guarantee intact: an unchanged catalogue causes no re-render at all.
- **`SectionIndex.tsx`** — same treatment for all four section routes. `setLoading(true)` only on a cold load, so a seeded list never flips back to "Laden…".
- Both gained a `.catch` that keeps whatever is on screen. A backend blip could not affect a seeded page while the fetch was skipped; now it can, so it is handled and pinned by a test.

Rebuilding and redeploying the site would clear today's symptom, but the drift returns on the next graph change, so it is not the fix.

## Tests

Written test-first — 10 red, then green.

New coverage on both pages: a stale seed is replaced (modelled directly on the two-Normenbrief case), an identical revalidation leaves the view untouched, a failed revalidation keeps the seed, and a cold load behaves as before. Four unit tests on the helper.

Two existing tests asserted `expect(api.getRegelcatalogus).not.toHaveBeenCalled()` / `expect(api.getBerichten).not.toHaveBeenCalled()`. Those encoded the defect, so they now assert both halves of the intended behaviour: the seed paints synchronously **and** the revalidation fires.

## Verification

- `npm test --workspace=packages/public-site` — 30 files, 213 tests, all passing
- Per-file 80% branch floor holds: `Regelcatalogus.tsx` 96.61%, `SectionIndex.tsx` 88.88%, no file below 80%
- `type-check`, `lint` and repo-wide `check-format` clean
- Full repo suite confirmed green by the maintainer before this PR was opened

## Note for after merge

The bundle currently deployed to ACC still contains the old blob and the old skip-fetch code, so the two Normenbriefs remain visible there until this ships.
