### PR TITLE
feat(public-site): identify the build, not just the release, in the footer

### DIFF
--- a/.github/workflows/azure-publicsite-acc.yml
+++ b/.github/workflows/azure-publicsite-acc.yml
@@ -85,6 +85,14 @@ jobs:
 
       - name: Build for ACC (includes prerender + bundle-cleanliness gate)
         working-directory: packages/public-site
+        # Build provenance: the footer answers "which build am I looking at?",
+        # which the hand-bumped version cannot. These belong on the BUILD step
+        # rather than the deploy step because the runner builds this package —
+        # the deploy action gets skip_app_build: true and only uploads dist/.
+        # Nothing is derived from git; a build id that fails to resolve lies.
+        env:
+          VITE_BUILD_SHA: ${{ github.sha }}
+          VITE_BUILD_RUN: ${{ github.run_number }}
         run: |
           npm run build:acc
           test -f dist/index.html || (echo "ERROR: index.html not found!" && exit 1)

--- a/.github/workflows/azure-publicsite-prod.yml
+++ b/.github/workflows/azure-publicsite-prod.yml
@@ -61,6 +61,12 @@ jobs:
 
       - name: Build for production (includes prerender + bundle-cleanliness gate)
         working-directory: packages/public-site
+        # Build provenance — see the fuller note in azure-publicsite-acc.yml.
+        # On the BUILD step because the runner builds; the deploy action gets
+        # skip_app_build: true and only uploads dist/.
+        env:
+          VITE_BUILD_SHA: ${{ github.sha }}
+          VITE_BUILD_RUN: ${{ github.run_number }}
         run: |
           npm run build:prod
           test -f dist/index.html || (echo "ERROR: index.html not found!" && exit 1)

--- a/packages/public-site/src/components/Footer.test.tsx
+++ b/packages/public-site/src/components/Footer.test.tsx
@@ -27,4 +27,44 @@ describe('Footer', () => {
     renderFooter();
     expect(screen.getByText(`v${__APP_VERSION__}`)).toBeInTheDocument();
   });
+
+  // The version above identifies a release; these identify the build of it.
+  // ACC and PROD can serve different builds of one version, so the footer has
+  // to answer "which build am I looking at?" on its own. See
+  // iou-architectuur docs/en/contributing/build-provenance.md.
+  it('shows the injected build identifiers next to the version', () => {
+    vi.stubEnv('VITE_SITE_URL', 'https://acc.publiek.open-regels.nl');
+    vi.stubEnv('VITE_BUILD_SHA', '570fd98a1c4e2b7d3f8a9016c5d4e2b7a3f81c40');
+    vi.stubEnv('VITE_BUILD_RUN', '412');
+    renderFooter();
+    expect(screen.getByText('build 570fd98 · #412')).toBeInTheDocument();
+  });
+
+  it('carries the full SHA on the title attribute, for copying', () => {
+    const sha = '570fd98a1c4e2b7d3f8a9016c5d4e2b7a3f81c40';
+    vi.stubEnv('VITE_SITE_URL', 'https://acc.publiek.open-regels.nl');
+    vi.stubEnv('VITE_BUILD_SHA', sha);
+    vi.stubEnv('VITE_BUILD_RUN', '412');
+    renderFooter();
+    expect(screen.getByText('build 570fd98 · #412')).toHaveAttribute('title', sha);
+  });
+
+  it('reads "local build" when nothing was injected, never a blank slot', () => {
+    vi.stubEnv('VITE_SITE_URL', 'https://acc.publiek.open-regels.nl');
+    vi.stubEnv('VITE_BUILD_SHA', undefined);
+    vi.stubEnv('VITE_BUILD_RUN', undefined);
+    renderFooter();
+    expect(screen.getByText('local build')).toBeInTheDocument();
+    expect(screen.getByText('local build')).not.toHaveAttribute('title');
+  });
+
+  // Half-configured must not render as a deployed artifact: a run number with
+  // no commit behind it implies a provenance the bundle does not have.
+  it('reads "local build" when only a run number was injected', () => {
+    vi.stubEnv('VITE_SITE_URL', 'https://acc.publiek.open-regels.nl');
+    vi.stubEnv('VITE_BUILD_SHA', undefined);
+    vi.stubEnv('VITE_BUILD_RUN', '412');
+    renderFooter();
+    expect(screen.getByText('local build')).toBeInTheDocument();
+  });
 });

--- a/packages/public-site/src/components/Footer.tsx
+++ b/packages/public-site/src/components/Footer.tsx
@@ -2,6 +2,7 @@
 import { Link } from 'react-router-dom';
 import type { Translations, Lang } from '../i18n';
 import { PUB_SECTIONS, WOORDENBOEK_PATH, sectionLabel } from '../lib/sections';
+import { getBuildInfo } from '../lib/buildInfo';
 
 export default function Footer({ t, lang }: { t: Translations; lang: Lang }) {
   // The site's own origin (per environment — ACC shows the ACC URL, not prod) and
@@ -9,6 +10,9 @@ export default function Footer({ t, lang }: { t: Translations; lang: Lang }) {
   // VITE_SITE_URL is ever unset in a build.
   const siteUrl = import.meta.env.VITE_SITE_URL || 'https://publiek.open-regels.nl';
   const siteHost = siteUrl.replace(/^https?:\/\//, '').replace(/\/+$/, '');
+  // The version beside it names a release, which ACC and PROD can both be
+  // serving different builds of. Cheap and synchronous — see lib/buildInfo.ts.
+  const buildInfo = getBuildInfo();
   return (
     <footer className="pub-footer">
       <div className="pub-wrap">
@@ -50,6 +54,11 @@ export default function Footer({ t, lang }: { t: Translations; lang: Lang }) {
             <a href={siteUrl}>{siteHost}</a>
             {' · '}
             <span>v{__APP_VERSION__}</span>
+            {' · '}
+            {/* Full 40-char SHA on the title so it can be copied for a lookup
+                without cluttering the line. Never blank: an untracked bundle
+                reads 'local build' rather than resembling a deployed one. */}
+            <span title={buildInfo.sha || undefined}>{buildInfo.label}</span>
           </span>
         </div>
       </div>

--- a/packages/public-site/src/lib/buildInfo.test.ts
+++ b/packages/public-site/src/lib/buildInfo.test.ts
@@ -1,0 +1,95 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+import { getBuildInfo } from './buildInfo';
+
+// getBuildInfo reads import.meta.env on every call rather than capturing it at
+// module scope, which is what lets vi.stubEnv reach it. A module-scope capture
+// would be evaluated once at import and the fallback below could not be tested
+// at all without vi.resetModules gymnastics.
+afterEach(() => {
+  vi.unstubAllEnvs();
+});
+
+const SHA = '570fd98a1c4e2b7d3f8a9016c5d4e2b7a3f81c40';
+
+describe('getBuildInfo', () => {
+  it('labels a build that carries both a SHA and a run number', () => {
+    vi.stubEnv('VITE_BUILD_SHA', SHA);
+    vi.stubEnv('VITE_BUILD_RUN', '412');
+
+    const info = getBuildInfo();
+
+    expect(info.isTracked).toBe(true);
+    expect(info.label).toBe('build 570fd98 · #412');
+  });
+
+  it('keeps the full SHA alongside the short one, for copying', () => {
+    vi.stubEnv('VITE_BUILD_SHA', SHA);
+    vi.stubEnv('VITE_BUILD_RUN', '412');
+
+    const info = getBuildInfo();
+
+    expect(info.sha).toBe(SHA);
+    expect(info.shortSha).toBe('570fd98');
+    expect(info.run).toBe('412');
+  });
+
+  it('falls back to "local build" when nothing was injected', () => {
+    vi.stubEnv('VITE_BUILD_SHA', undefined);
+    vi.stubEnv('VITE_BUILD_RUN', undefined);
+
+    const info = getBuildInfo();
+
+    expect(info.isTracked).toBe(false);
+    expect(info.label).toBe('local build');
+    expect(info.sha).toBe('');
+  });
+
+  // Half-configured counts as untracked. A run number with no commit behind it
+  // implies a provenance the bundle does not have, so it must not render as
+  // one — and a SHA with no run number cannot distinguish two builds of the
+  // same commit, which is the whole point of the run number.
+  it('treats a run number without a SHA as untracked', () => {
+    vi.stubEnv('VITE_BUILD_SHA', undefined);
+    vi.stubEnv('VITE_BUILD_RUN', '412');
+
+    expect(getBuildInfo().label).toBe('local build');
+  });
+
+  it('treats a SHA without a run number as untracked', () => {
+    vi.stubEnv('VITE_BUILD_SHA', SHA);
+    vi.stubEnv('VITE_BUILD_RUN', undefined);
+
+    expect(getBuildInfo().label).toBe('local build');
+  });
+
+  // Vite substitutes a missing variable with an empty string in some build
+  // configurations rather than leaving it undefined, so blank must be treated
+  // exactly like absent — otherwise the panel renders "build  · #".
+  it('treats blank and whitespace-only values as absent', () => {
+    vi.stubEnv('VITE_BUILD_SHA', '   ');
+    vi.stubEnv('VITE_BUILD_RUN', '');
+
+    expect(getBuildInfo().isTracked).toBe(false);
+    expect(getBuildInfo().label).toBe('local build');
+  });
+
+  it('trims surrounding whitespace off injected values', () => {
+    vi.stubEnv('VITE_BUILD_SHA', ` ${SHA} `);
+    vi.stubEnv('VITE_BUILD_RUN', ' 412 ');
+
+    const info = getBuildInfo();
+
+    expect(info.sha).toBe(SHA);
+    expect(info.label).toBe('build 570fd98 · #412');
+  });
+
+  // A SHA shorter than 7 characters is not something CI produces, but slicing
+  // must not invent characters or throw if one ever arrives.
+  it('uses the whole SHA when it is shorter than seven characters', () => {
+    vi.stubEnv('VITE_BUILD_SHA', 'abc12');
+    vi.stubEnv('VITE_BUILD_RUN', '7');
+
+    expect(getBuildInfo().label).toBe('build abc12 · #7');
+  });
+});

--- a/packages/public-site/src/lib/buildInfo.ts
+++ b/packages/public-site/src/lib/buildInfo.ts
@@ -1,0 +1,60 @@
+/**
+ * Which BUILD of the site is running, as opposed to which release.
+ *
+ * The version in the footer comes from package.json and is bumped by hand at
+ * release time, so it identifies a release, not a build of it. ACC and PROD
+ * can serve different builds of the same version string, and redeploying
+ * unchanged code produces a new artifact carrying the same version — so
+ * "which build am I looking at?" is not answerable from the version alone.
+ *
+ * The SHA says what was built; the run number distinguishes two builds of
+ * identical code. Both are injected at build time by the deploy workflows
+ * (see .github/workflows/azure-publicsite-{acc,prod}.yml, where the env block
+ * sits on the build step because the runner builds this package — the deploy
+ * action is passed skip_app_build: true); nothing is derived from git here,
+ * because a build id that silently fails to resolve is worse than none — it
+ * lies, and this package is built in CI where .git is not guaranteed.
+ */
+
+export interface BuildInfo {
+  /** Full 40-character commit SHA, or '' when not injected. */
+  sha: string;
+  /** First 7 characters of the SHA, or '' when not injected. */
+  shortSha: string;
+  /** GitHub Actions run number, or '' when not injected. */
+  run: string;
+  /** True only when both values are present — see the half-configured note below. */
+  isTracked: boolean;
+  /** Ready to render. Never blank. */
+  label: string;
+}
+
+const UNTRACKED: BuildInfo = {
+  sha: '',
+  shortSha: '',
+  run: '',
+  isTracked: false,
+  label: 'local build',
+};
+
+/**
+ * Read the injected build identifiers and describe them.
+ *
+ * The env is read here, on every call, rather than captured at module scope:
+ * a module-scope capture is evaluated once at import and cannot be stubbed
+ * per test, which would leave the fallback path untestable.
+ *
+ * Half-configured counts as untracked. A run number with no SHA behind it
+ * implies a provenance the bundle does not have, and a SHA with no run number
+ * cannot tell two builds of the same commit apart — which is the whole reason
+ * the run number is here. Either way the answer is 'local build'.
+ */
+export function getBuildInfo(): BuildInfo {
+  const sha = (import.meta.env.VITE_BUILD_SHA ?? '').trim();
+  const run = (import.meta.env.VITE_BUILD_RUN ?? '').trim();
+
+  if (!sha || !run) return UNTRACKED;
+
+  const shortSha = sha.slice(0, 7);
+  return { sha, shortSha, run, isTracked: true, label: `build ${shortSha} · #${run}` };
+}


### PR DESCRIPTION
Ports the feature documented in `iou-architectuur` `docs/en/contributing/build-provenance.md` to a fourth application — the public site.

## Why

The footer showed its origin and a version read from `package.json`. That version is bumped by hand at release time, so it names a **release**, not a **build** of one. Three cases it cannot answer:

- ACC and PROD can serve **different builds of the same version**, deploying from different branches at different times.
- **Redeploying unchanged code** produces a new artifact carrying an identical version.
- **A release can be rebuilt** after a workflow change or a re-run of a failed job.

The footer's monospace line now ends with the pair that settles it:

```
publiek.open-regels.nl · v2026.09.2 · build 570fd98 · #412
```

| Value | Answers |
|---|---|
| Commit SHA | *What source was built?* |
| Run number | *Which build of that source is this?* |

The full 40-character SHA sits on the `title` attribute so it can be copied for a lookup without cluttering the line. An uninjected bundle reads **`local build`** — never blank, and never resembling a deployed artifact when it is not one.

## What changed

| File | |
|---|---|
| `src/lib/buildInfo.ts` | **new** — ported unchanged from `packages/frontend/src/utils/buildInfo.ts`. Lands in `src/lib/` because this package has no `src/utils/`. |
| `src/lib/buildInfo.test.ts` | **new** — the 8 tests, verbatim |
| `src/components/Footer.tsx` | appends the label to the existing mono line; full SHA on `title` |
| `src/components/Footer.test.tsx` | +4: tracked label, SHA on `title`, `local build` fallback, half-configured fallback |
| `azure-publicsite-acc.yml`, `-prod.yml` | `env:` block on the **build step** |

Both implementation decisions the doc calls out carry over: the module is separate from the component, so the fallback rules are testable without rendering anything; and the environment is read **inside** the function rather than captured at module scope, which is what lets `vi.stubEnv` reach it. Half-configured counts as untracked, and blank is treated as absent because Vite substitutes an empty string rather than `undefined` in some configurations.

## Where the `env:` block goes, and why

On the **build step**, not the deploy step. That follows from *who runs the build*: this package builds on the runner and passes `skip_app_build: true`, so the Static Web Apps action only uploads `dist/` and never sees the variables.

```yaml
- name: Build for ACC (includes prerender + bundle-cleanliness gate)
  working-directory: packages/public-site
  env:
    VITE_BUILD_SHA: ${{ github.sha }}
    VITE_BUILD_RUN: ${{ github.run_number }}
  run: |
    npm run build:acc
```

No `.env` file is touched — CI stays the only source, so every local run falls through to `local build`. Nothing is derived from git at build time: a build id that silently fails to resolve is worse than none, because it lies.

## Verification

Unit tests alone cannot show that an injection reached the artifact, so both directions were built for real and the **whole** of `dist/` was grepped, checking exit codes rather than greps of output:

| | Build 1 (injected) | Build 2 (no env) |
|---|---|---|
| Exit code | 0 | 0 |
| Full SHA in `dist/` | present | absent |
| Run number | present | — |
| `local build` | — | present |
| Main bundle | `index-D7OwJLIv.js` | `index-BmeIZitd.js` |

The bundle hash moving between the two confirms the second build actually ran rather than the grep re-reading the first build's output. The label itself is assembled at runtime from `build ${shortSha} · #${run}`, so the artifact carries the two values separately — grepping for the rendered string would find nothing and look exactly like failure.

Also confirmed programmatically that both workflows parse, that the `env:` sits on the build step, and that the deploy step carries `skip_app_build: true` and no env of its own.

- `npm test --workspace=packages/public-site` — 31 files, 216 tests, all passing
- `buildInfo.ts` and `Footer.tsx` both at 100%; the per-file 80% branch floor holds
- `type-check`, `lint`, repo-wide `check-format` clean
- Full repo suite confirmed green by the maintainer before this PR was opened

## ⚠️ Reading the preview deployment

**On a pull request, `github.sha` is the merge commit GitHub synthesises — not the head of this branch.** The SHA shown on the preview will therefore match no commit in the branch history and cannot be found with `git log`. This is correct: that synthesised commit is genuinely what got built. On the push to `acc` after merge, `github.sha` is the real commit.

Precedent from the earlier rollouts:

| | Preview (synthesised) | After merge (real commit) |
|---|---|---|
| RONL Business API frontend | `build 1224298 · #265` | `build 66940d9 · #266` |
| Linked Data Explorer | `build b669689 · #186` | `build 9db0ab3 · #188` |

Only the deployed preview proves the `env:` block reaches the builder — the local greps prove the code path and nothing more. So the check that matters is: **open the preview, look at the foot of any page, and confirm it reads `build <sha> · #<run>` rather than `local build`.**

## Note

Branched from `acc` before #89 merged. The two touch disjoint files, so it merges cleanly in either order.
