### PR TITLE
docs: record the promotion outcome and correct the go-live checklists

### DIFF
--- a/docs/PA-DEMO-GO-LIVE.md
+++ b/docs/PA-DEMO-GO-LIVE.md
@@ -1,8 +1,8 @@
 # PA-Cockpit demo go-live checklist
 
 Everything needed to take `packages/pa-demo` from "works locally" to live at
-`plato.open-regels.nl` / `acc.plato.open-regels.nl`. **ACC is done; PROD is
-pending** — every PROD item below is unstarted.
+`plato.open-regels.nl` / `acc.plato.open-regels.nl`. **Both are live** — ACC on
+2026-08-28, PROD on 2026-09-12 with the promotion.
 
 `pa-demo` is a public, unauthenticated, **mock-only** instance of the PA Cockpit,
 built so a prospective province can be shown the product without an account. It
@@ -37,20 +37,20 @@ Subscription: **Platform Regelbeheer 2025 — C1427**
         --location westeurope \
         --sku Standard
 
-- [ ] **PROD** equivalents. Nothing exists yet. Suggested names, following the
-      ACC pattern and public-site's: resource group `ronl-pademo-site-prod`, SWA
-      `ronl-business-pademo-site-prod`. Confirm before creating.
+- [x] **PROD** equivalents, created 2026-09-12 with the suggested names:
+      resource group `ronl-pademo-site-prod`, SWA
+      `ronl-business-pademo-site-prod`, westeurope, Standard, `provider: None`.
 
 `Standard` matches `ronl-business-public-site-acc` rather than being required —
 `Free` would very likely suffice for demo traffic, but moving Free → Standard
 later means recreating the resource, not toggling a setting.
 
-|                  | ACC                                         | PROD      |
-| ---------------- | ------------------------------------------- | --------- |
-| Resource group   | `ronl-pademo-site-acc`                      | _pending_ |
-| Static Web App   | `ronl-business-pademo-site-acc`             | _pending_ |
-| Region / SKU     | westeurope / Standard                       | _pending_ |
-| Default hostname | `red-river-0ce4c9803.7.azurestaticapps.net` | _pending_ |
+|                  | ACC                                         | PROD                                          |
+| ---------------- | ------------------------------------------- | --------------------------------------------- |
+| Resource group   | `ronl-pademo-site-acc`                      | `ronl-pademo-site-prod`                       |
+| Static Web App   | `ronl-business-pademo-site-acc`             | `ronl-business-pademo-site-prod`              |
+| Region / SKU     | westeurope / Standard                       | westeurope / Standard                         |
+| Default hostname | `red-river-0ce4c9803.7.azurestaticapps.net` | `black-cliff-0a7103503.6.azurestaticapps.net` |
 
 ## 2. Deployment token secrets
 
@@ -58,7 +58,14 @@ The workflows fail at their final step without these. Names are exact — they a
 already referenced in the YAML.
 
 - [x] `AZURE_STATIC_WEB_APPS_API_TOKEN_PA_DEMO_ACC`
-- [ ] `AZURE_STATIC_WEB_APPS_API_TOKEN_PA_DEMO_PROD`
+- [x] `AZURE_STATIC_WEB_APPS_API_TOKEN_PA_DEMO_PROD` (2026-09-12)
+
+> **Strip the newline when scripting this.** `az … -o tsv` appends one, and a
+> secret carrying it makes the deploy step fail with a bare
+> `An unknown exception has occurred`, after the build steps have all passed —
+> which looks like an Azure fault and is not. Use
+> `az … -o tsv | tr -d '\r\n' | gh secret set <NAME>`. The
+> public site lost one production deploy to exactly this on 2026-09-12.
 
 Retrieve a token with `az staticwebapp secrets list -n <swa> -g <rg> --query
 "properties.apiKey" -o tsv`, then add it under GitHub → Settings → Secrets and
@@ -68,9 +75,12 @@ over worrying about where a copy ended up.
 
 ## 3. DNS and custom domains
 
-- [ ] `acc.plato` → CNAME → `red-river-0ce4c9803.7.azurestaticapps.net`, in the
+- [x] `acc.plato` → CNAME → `red-river-0ce4c9803.7.azurestaticapps.net`, in the
       `open-regels.nl` Azure DNS zone.
-- [ ] `plato` → CNAME → the PROD SWA's default hostname, once §1 exists.
+- [x] `plato` → CNAME → `black-cliff-0a7103503.6.azurestaticapps.net`
+      (2026-09-12). The hostname previously pointed at an older, unrelated
+      "Parlementair Dashboard" Static Web App; that record and its resources were
+      deleted first, so nothing had to be unbound under a live site.
 
 **Two steps, not one.** The DNS record alone gives a name that resolves and that
 Azure will not serve — which looks like slow propagation and is not. Register the
@@ -129,7 +139,9 @@ runs pa-demo's `type-check` here, rather than surfacing later at an unrelated PR
 ACC runs, in order: install → build shared → lint → type-check → unit tests →
 Playwright browser install → **E2E** → build (with the bundle gate) → deploy.
 **PROD does not run E2E**; if that matters to you, add it before the first
-production deploy rather than after.
+production deploy rather than after. On the first production deploy
+(2026-09-12) it was run by hand against the live domain instead — 11/11 — which
+is the §6 procedure below.
 
 `workflow_dispatch` on both means a deploy can be triggered by hand — useful when
 merging with `[no ci]` in the tip commit to suppress the automatic run.
@@ -166,7 +178,7 @@ is why it runs in the ACC workflow.
 The Playwright suite retargets at a deployed site — no backend, database or
 Keycloak needed, unlike every other suite in this repo:
 
-      E2E_BASE_URL=https://acc.plato.open-regels.nl \
+      E2E_BASE_URL=https://plato.open-regels.nl \
         npm run test:e2e --workspace=@ronl/pa-demo
 
 That runs the same eleven tests against the real domain, including the
@@ -175,12 +187,13 @@ origin check. Prefer it to a manual smoke test.
 
 Quick manual checks that catch the common deploy faults:
 
-- [ ] A deep link (e.g. `/beheer`) returns 200, not 404 — confirms the SWA config
+- [x] A deep link (e.g. `/beheer`) returns 200, not 404 — confirms the SWA config
       shipped inside `dist/` and `navigationFallback` is active.
-- [ ] `/pa/feiten-icons/wonen.png` returns 200 `image/png` — confirms the
+- [x] `/pa/feiten-icons/wonen.png` returns 200 `image/png` — confirms the
       `@ronl/pa-cockpit` static assets deployed.
-- [ ] The response carries `content-security-policy: … connect-src 'self' …`.
-- [ ] Beheer shows **nine** sections, with no IOU group and no Hulpmiddelen.
+- [x] The response carries `content-security-policy: … connect-src 'self' …`.
+- [x] Beheer shows **nine** sections, with no IOU group and no Hulpmiddelen
+      (asserted by the e2e run above, 11/11 against `plato`).
 - [ ] Paste the site URL into a link-preview validator (or Slack) and confirm the
       card renders. The E2E test proves `og:image` resolves to a real PNG on this
       origin; only a scraper proves the preview itself composes. Since the §3b

--- a/docs/PUBLIC-SITE-GO-LIVE.md
+++ b/docs/PUBLIC-SITE-GO-LIVE.md
@@ -14,7 +14,8 @@ different integration), `docs/superpowers/plans/2026-08-06-public-site.md` (the
 The CI workflows
 ([azure-publicsite-acc.yml](../.github/workflows/azure-publicsite-acc.yml),
 [azure-publicsite-prod.yml](../.github/workflows/azure-publicsite-prod.yml)) will
-fail on first push without the resource + token secret. **ACC done; PROD pending.**
+fail on first push without the resource + token secret. **Both done** — ACC on
+2026-08-07, PROD on 2026-09-12.
 
 Create each SWA with deployment **Source: `Other`** (not GitHub) — that yields just
 the resource + a deployment token and does **not** generate a competing workflow;
@@ -22,13 +23,24 @@ our hand-tuned workflow already deploys the pre-built `dist` via `skip_app_build
 
 - [x] Create the **ACC** Static Web App in Azure (matches `azure-frontend-acc.yml`'s
       resource for the pattern to copy).
-- [ ] Create the **PROD** Static Web App in Azure.
+- [x] Create the **PROD** Static Web App in Azure. Done 2026-09-12:
+      `ronl-business-public-site-prod` in resource group `ronl-public-site-prod`,
+      subscription C1427, westeurope, Standard, default hostname
+      `thankful-sand-05d1a7c03.3.azurestaticapps.net`, `provider: None`.
 - [x] Copy the **ACC** deployment token (Azure Portal → the SWA resource → "Manage
-      deployment token", or `az staticwebapp secrets list`). PROD token pending.
-- [ ] Add both tokens as GitHub repo secrets, **exact names** (already referenced
+      deployment token", or `az staticwebapp secrets list`).
+- [x] Add both tokens as GitHub repo secrets, **exact names** (already referenced
       by the workflows):
   - [x] `AZURE_STATIC_WEB_APPS_API_TOKEN_PUBLIC_SITE_ACC`
-  - [ ] `AZURE_STATIC_WEB_APPS_API_TOKEN_PUBLIC_SITE_PROD`
+  - [x] `AZURE_STATIC_WEB_APPS_API_TOKEN_PUBLIC_SITE_PROD`
+
+> **Do not pipe the token straight from `az … -o tsv` into `gh secret set`.** The
+> CLI appends a newline, the secret stores 120 bytes where the key is 119, and the
+> Static Web Apps action then fails with nothing more specific than
+> `An unknown exception has occurred` after printing a DeploymentId — the build
+> steps all pass, so it reads like an Azure fault rather than a bad secret. Strip
+> it: `az … -o tsv | tr -d '\r\n' | gh secret set <NAME>`. This cost one failed
+> production deploy on 2026-09-12.
 
 > **Resolved in this branch** (`fix(public-site): ship staticwebapp.config.json in
 the build output`): the SWA config previously lived at the package root, which
@@ -39,14 +51,15 @@ the build output`): the SWA config previously lived at the package root, which
 > manual step needed; noted here because it directly affects the SWA deploy this
 > section sets up.
 
-## 2. Backend deploy — ACC and PROD (**ACC done; PROD pending**)
+## 2. Backend deploy — ACC and PROD (**both done**)
 
 Phase 1 (`GET /v1/public/processen`, `GET /v1/public/zoeken`, the
 `/v1/public/{nieuws,producten,regels}/:slug` detail routes) is **deployed and live
 on ACC** (`acc.api.open-regels.nl`) — verified by the smoke-test below.
-`feature/public-site` was merged into `acc` and deleted. PROD is still pending:
-until Phase 1 is on `api.open-regels.nl`, a prod public-site build's prerender step
-will 404 (exactly as an early ACC build did).
+`feature/public-site` was merged into `acc` and deleted. PROD followed on
+2026-09-12: until Phase 1 was on `api.open-regels.nl`, a prod public-site build's
+prerender step would 404 (exactly as an early ACC build did), which is why the
+backend went first.
 
 **Deploy order matters — backend before the push.** The backend is deployed by
 `deploy-backend-to-acc.sh` (a local `az webapp deploy` from a clean `acc` checkout;
@@ -63,9 +76,13 @@ between merging locally and pushing:
       real data, not 404.
 - [x] `git push origin acc` — triggered the frontend + public-site Actions; both
       deployed successfully (public-site live at `acc.publiek.open-regels.nl`).
-- [ ] Repeat for prod once ACC is verified: merge to prod's deploy branch, run
-      `deploy-backend-to-prod.sh`, smoke-test, then push to trigger the prod
-      Actions.
+- [x] Repeat for prod once ACC is verified. Done 2026-09-12 as Phase 6 of
+      `docs/promote-ACC-to-PROD.md`, with one refinement: rather than pushing and
+      letting the SWA workflows race the backend, the three production SWA
+      workflows were **disabled** before the promotion merge, the backend was
+      deployed from a clean `main` (`deploy-backend-to-prod.sh`,
+      `RuntimeSuccessful`), smoke-tested, and only then was each site re-enabled
+      and dispatched by hand.
 
 > The caseworker frontend has no such dependency — it's a runtime-fetch SPA with no
 > prerender, so its build never calls the backend. Only public-site does. And if you
@@ -80,22 +97,27 @@ this branch do not by themselves fix ACC/prod. Set these in each backend App
 Service's Configuration blade (Azure Portal → App Service → Configuration →
 Application settings) — not in any file in this repo.
 
-| Variable                    | ACC                                                                                   | PROD                                                      | Why                                                                                                                                                                                                      |
-| --------------------------- | ------------------------------------------------------------------------------------- | --------------------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `CORS_ORIGIN`               | append `https://acc.publiek.open-regels.nl`                                           | append `https://publiek.open-regels.nl`                   | Whatever ACC/prod's `CORS_ORIGIN` is already set to, **plus** the new origin — replacing it outright would break the existing caseworker frontend.                                                       |
-| `LDE_API_URL`               | leave unset (code default already `https://acc.backend.linkeddata.open-regels.nl/v1`) | **must set explicitly** — code default is the ACC LDE URL | Without this, prod's process library would silently proxy ACC's LDE data instead of prod's. Likely value: `https://backend.linkeddata.open-regels.nl/v1` (matches the frontend's own `.env.production`). |
-| `PUBLIC_SHOW_WIP_PROCESSES` | `true` (already agreed — preview WIP processes on ACC)                                | leave unset (defaults to `false`)                         | ACC-only escape hatch; must never be true in prod.                                                                                                                                                       |
+| Variable                    | ACC                                                                                   | PROD                                                                              | Why                                                                                                                                                                                                      |
+| --------------------------- | ------------------------------------------------------------------------------------- | --------------------------------------------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `CORS_ORIGIN`               | append `https://acc.publiek.open-regels.nl`                                           | set to `mijn` + `publiek`; `localhost:5173` dropped (D5 of the promotion runbook) | Whatever ACC/prod's `CORS_ORIGIN` is already set to, **plus** the new origin — replacing it outright would break the existing caseworker frontend.                                                       |
+| `LDE_API_URL`               | leave unset (code default already `https://acc.backend.linkeddata.open-regels.nl/v1`) | **must set explicitly** — code default is the ACC LDE URL                         | Without this, prod's process library would silently proxy ACC's LDE data instead of prod's. Likely value: `https://backend.linkeddata.open-regels.nl/v1` (matches the frontend's own `.env.production`). |
+| `PUBLIC_SHOW_WIP_PROCESSES` | `true` (already agreed — preview WIP processes on ACC)                                | leave unset (defaults to `false`)                                                 | ACC-only escape hatch; must never be true in prod.                                                                                                                                                       |
 
-**ACC done** (set on `ronl-business-api-acc` / `rg-ronl-acc` via
-`az webapp config appsettings set`, which restarts the App Service automatically —
-no manual restart needed). **PROD pending.**
+**Both done** (set via `az webapp config appsettings set`, which restarts the App
+Service automatically — no manual restart needed). PROD was done on 2026-09-12,
+before the promotion merge, while 3.8.2 was still serving.
 
 - [x] `CORS_ORIGIN` updated on ACC backend App Service
-- [ ] `CORS_ORIGIN` updated on PROD backend App Service
-- [ ] `LDE_API_URL` set explicitly on PROD backend App Service
-- [x] `PUBLIC_SHOW_WIP_PROCESSES=true` set on ACC backend App Service
-- [x] ACC App Service restarted (automatic on `appsettings set`); PROD restart still
-      pending after its settings are saved
+- [x] `CORS_ORIGIN` updated on PROD backend App Service — final value
+      `https://mijn.open-regels.nl,https://publiek.open-regels.nl`. Verified by
+      request: `publiek` and `mijn` receive an `access-control-allow-origin`
+      header, `http://localhost:5173` receives none.
+- [x] `LDE_API_URL` set explicitly on PROD backend App Service
+      (`https://backend.linkeddata.open-regels.nl/v1`)
+- [x] `PUBLIC_SHOW_WIP_PROCESSES=true` set on ACC backend App Service; left unset
+      on PROD, so it defaults to `false`
+- [x] ACC App Service restarted (automatic on `appsettings set`); PROD likewise,
+      and 3.8.2 came back healthy on the first probe after each restart
 
 ## 4. Caddy deploy — Skosmos CSP fix (✅ done — blocking for the Gegevenswoordenboek page)
 
@@ -120,14 +142,15 @@ the public site (`publiek` / `acc.publiek`), and both dev servers
       `http://localhost:5175/woordenboek`: the Skosmos thesaurus renders in the
       iframe._
 
-## 5. DNS — Azure DNS zone `open-regels.nl` (blocking — **ACC done; PROD pending**)
+## 5. DNS — Azure DNS zone `open-regels.nl` (blocking — **both done**)
 
-You own this zone in Azure DNS, which matters for `publiek.open-regels.nl`
-specifically: it's an **apex/root record**, and a plain CNAME is not valid at a
-zone apex per DNS spec. Azure DNS's **Alias record** feature solves this natively —
-an Alias record at the apex can point directly at an Azure resource (the Static
-Web App), unlike a plain CNAME. `acc.publiek.open-regels.nl` is an ordinary
-subdomain and a plain CNAME works fine there.
+You own this zone in Azure DNS. Both hostnames are ordinary subdomains of
+`open-regels.nl`, so a plain CNAME works for each.
+
+> **Correction (2026-09-12).** This section used to call `publiek.open-regels.nl`
+> an apex/root record needing an Azure **Alias** record. It is not: the zone is
+> `open-regels.nl`, so `publiek` is a subdomain like `acc.publiek`, and it was
+> bound with a plain CNAME. No alias record was needed or created.
 
 - [x] In the Azure Static Web App resource (ACC), add the custom domain
       `acc.publiek.open-regels.nl` — Azure will show the exact validation record
@@ -137,15 +160,17 @@ subdomain and a plain CNAME works fine there.
       shows this on the custom domain screen). _Verified 2026-08-07:
       `https://acc.publiek.open-regels.nl/` resolves with valid TLS and serves the
       SWA (the Azure placeholder page — real content lands once §2's push runs)._
-- [ ] Repeat domain validation for the PROD Static Web App, root domain
-      `publiek.open-regels.nl`.
-- [ ] Add an **Alias record** (not a plain A/CNAME) at the zone apex pointing at
-      the PROD Static Web App resource — in the Azure DNS zone UI this is "Add
-      record set" → type `A` → "Alias record set" toggled on → target set to the
-      SWA resource (not an IP).
-- [ ] Wait for DNS propagation, then confirm both custom domains show "Ready" /
+- [x] Repeat domain validation for the PROD Static Web App, subdomain
+      `publiek.open-regels.nl` (2026-09-12, CNAME validation in the portal).
+- [x] Add a `CNAME` record: `publiek` →
+      `thankful-sand-05d1a7c03.3.azurestaticapps.net`. No alias record — see the
+      correction above.
+- [x] Wait for DNS propagation, then confirm both custom domains show "Ready" /
       valid TLS in the Azure Portal (Azure auto-provisions the certificate once
-      DNS validates).
+      DNS validates). _Verified 2026-09-12: `https://publiek.open-regels.nl/`
+      serves the site, its footer reads
+      `publiek.open-regels.nl · v2026.09.6 · build 04840ed · #2`, and the e2e
+      suite passes 6/6 against it._
 
 ## 6. Post-deploy verification (not blocking, don't skip)
 
@@ -185,6 +210,12 @@ These need a real live URL, so they can only happen after steps 1–5.
 
 ## 7. PROD promotion — the rest of the `acc` → `main` delta (read before merging)
 
+> **Executed on 2026-09-12.** PROD went from 3.8.2 to **v2026.09.6** — 51
+> releases, 646 commits — following `docs/promote-ACC-to-PROD.md`, which
+> superseded this section and carries the verified state, the six decisions and
+> the rollback. The figures below are the August snapshot and are kept as a
+> record of what this section said at the time; do not read them as current.
+
 §1–6 cover the **public-site** slice. But PROD currently runs **v3.8.2 (17 Jul)** and
 `acc` is **2026.08.23** — merging `acc → main` deploys **342 commits / 21 releases**
 across the **backend, the caseworker frontend, and the public-site**, not just the public
@@ -208,15 +239,22 @@ is still the manual `deploy-backend-to-prod.sh` (unchanged in this delta: builds
 then `az webapp deploy` → `ronl-business-api-prod` / `rg-ronl-prod`). Push first and the
 new frontends call a v3.8.2 backend that lacks their routes.
 
-- [ ] **CI is green on `acc` first.** `28ab6ca` gated all three PROD workflows on lint +
+- [x] **CI is green on `acc` first.** `28ab6ca` gated all three PROD workflows on lint +
       unit tests, and the frontend additionally on `npm run test:perf` (performance
       budget), public-site on lint + type-check + tests. A failing gate means the deploy
       step never runs — you get a half-promoted `main`, backend deployed and frontends not.
-- [ ] Merge `acc → main` **locally** (do not push yet).
-- [ ] `bash deploy-backend-to-prod.sh` — backend live on PROD first.
-- [ ] Smoke-test the PROD backend (`/v1/health` reports the new version; a `/v1/public/*`
-      route responds, not 404).
-- [ ] **Then** push `main` — triggers both SWA deploys against the now-current backend.
+- [ ] Merge `acc → main` **locally** (do not push yet). **Superseded on
+      2026-09-12:** `main` is now protected by the `main promotion gate` ruleset, so
+      the promotion went through a pull request instead of a local merge.
+- [x] `bash deploy-backend-to-prod.sh` — backend live on PROD first
+      (`RuntimeSuccessful`, 2026-09-12).
+- [x] Smoke-test the PROD backend (`/v1/health` reports the new version; a `/v1/public/*`
+      route responds, not 404). _Verified: 2026.09.6, 17 endpoints, `cache: up`,
+      `/v1/public/processen` and `/v1/public/zoeken` both 200._
+- [ ] **Then** push `main` — triggers both SWA deploys against the now-current
+      backend. **Superseded on 2026-09-12:** the three production SWA workflows were
+      disabled before the merge and dispatched by hand afterwards, so the backend
+      could not be raced.
 
 ### 7b. Backend env vars on the PROD App Service
 
@@ -234,9 +272,11 @@ code in at least one place (it ships `EDOCS_MCP_ENABLED=true`; the code default 
 | `DOCCLE_*` (new `/v1/doccle` route)             | `DOCCLE_STUB_MODE` `true` | leave stubbed unless real Doccle is wanted (then base URL + creds + `STUB_MODE=false`) |
 | `PUBLIC_SHOW_WIP_PROCESSES`                     | `false`                   | keep unset/false in PROD                                                               |
 
-- [ ] Set `DEPLOYMENT_ENV=production` on the PROD App Service (display-only, non-blocking,
+- [x] Set `DEPLOYMENT_ENV=production` on the PROD App Service (display-only, non-blocking,
       but `/v1/health` is what 7a's smoke test reads).
-- [ ] Confirm eDOCS-MCP + Doccle are off/stubbed (or configured deliberately).
+- [x] Confirm eDOCS-MCP + Doccle are off/stubbed (or configured deliberately).
+      Verified 2026-09-12: the `EDOCS_MCP_*` and `DOCCLE_*` settings are unset on
+      PROD, so both fall through to their disabled/stubbed code defaults.
 
 **Blocking — the required-env checks now actually fire.** `e28dc19` found that the
 `DATABASE_URL` / `OPERATON_BASE_URL` guards were dead code: both resolve through a
@@ -246,7 +286,9 @@ localhost. They now test `process.env` and gate on production, and `validateConf
 **throws at import** — so a missing value is no longer a silent misconfiguration, it is a
 backend that will not boot.
 
-- [ ] Confirm `DATABASE_URL` **and** `OPERATON_BASE_URL` are set in PROD App Settings.
+- [x] Confirm `DATABASE_URL` **and** `OPERATON_BASE_URL` are set in PROD App Settings.
+      _Verified 2026-09-12, together with `KEYCLOAK_CLIENT_SECRET` and
+      `ANTHROPIC_API_KEY`; the backend booted cleanly, so `validateConfig()` passed._
       (Both were verified present on `ronl-business-api-prod` when the check was written —
       this is a confirm, but a boot-blocking one if it is wrong.)
 
@@ -266,10 +308,13 @@ starts 429-ing.
 still exist, but only as the **build-time default** — `PA_MOCK_DEFAULT` ORs them, and a
 `paV2.mock` **localStorage** entry (`'1'`/`'0'`) overrides it per browser.
 
-- [ ] Both `VITE_PA_DOSSIERS_MOCK` and `VITE_PA_SIGNALS_MOCK` are `false` in the frontend's
+- [x] Both `VITE_PA_DOSSIERS_MOCK` and `VITE_PA_SIGNALS_MOCK` are `false` in the frontend's
       `.env.production` — either one at `true` puts the whole cockpit in mock. They are
       already `false` there; this is a confirm, not a change.
-- [ ] Real PA data still depends on the new backend from 7a being live.
+- [x] Real PA data still depends on the new backend from 7a being live — which it now
+      is. Note this was **not** a confirm on the day: `main` carried
+      `VITE_PA_DOSSIERS_MOCK=true` from `171f32b`, and a three-way merge keeps that
+      side silently. It was flipped deliberately on the promotion branch (decision D1).
 
 Two things the old single-var checkbox did not capture:
 

--- a/docs/promote-ACC-to-PROD.md
+++ b/docs/promote-ACC-to-PROD.md
@@ -28,6 +28,7 @@ two minutes and tells you whether anything moved overnight.
 8. [After PROD: aligning CI with the cross-repo posture](#8-after-prod-aligning-ci-with-the-cross-repo-posture)
 9. [Open issues walkthrough](#9-open-issues-walkthrough)
 10. [T-0 re-verification](#10-t-0-re-verification)
+11. [Outcome — executed 12 September 2026](#11-outcome--executed-12-september-2026)
 
 ---
 
@@ -1298,3 +1299,55 @@ git -C "$S/tm" diff --name-only --diff-filter=U        # expect nothing
 git -C "$S/tm" diff origin/acc --stat                  # expect only packages/frontend/.env.production
 git worktree remove --force "$S/tm" && git worktree prune
 ```
+
+---
+
+## 11. Outcome — executed 12 September 2026
+
+PROD went from **3.8.2 (17 July)** to **v2026.09.6**. The promotion merge is
+`04840ed`; the release it carries is `5f1091e`.
+
+| Surface                 | Result                                                                                          |
+| ----------------------- | ----------------------------------------------------------------------------------------------- |
+| Backend                 | `RuntimeSuccessful`; `/` reports 2026.09.6, 17 endpoints; `/v1/health` healthy with `cache: up` |
+| Caseworker (`mijn`)     | `build 04840ed · #12` in the changelog drawer, confirmed by eye                                 |
+| Public site (`publiek`) | live; footer `publiek.open-regels.nl · v2026.09.6 · build 04840ed · #2`; e2e 6/6                |
+| PA demo (`plato`)       | live; production card byte-identical to the committed PNG; e2e 11/11                            |
+| Keycloak                | 28 roles created, `test-infra-flevoland` at 37 (matching ACC); 3 token-claim mappers            |
+| Mirror                  | `acc` and `main` fast-forwarded; both remotes match                                             |
+
+All six decisions applied as recorded: the cockpit reads live (D1), all four
+surfaces shipped (D2), v2026.09.6 was cut first (D3), the `main promotion gate`
+ruleset was created and **reported `BLOCKED` on the promotion pull request until
+`audit` passed** (D4), `CORS_ORIGIN` is `mijn` + `publiek` with `localhost:5173`
+removed and verified by request (D5), and the RIP roles went to
+`test-infra-flevoland` (D6).
+
+### What differed from the plan
+
+- **A production deploy failed on a trailing newline.** `az … -o tsv | gh secret set`
+  stores 120 bytes where the key is 119, and the Static Web Apps action reports
+  only `An unknown exception has occurred` after the build steps pass. Re-set with
+  `tr -d '\r\n'` and the re-dispatch succeeded. Both go-live docs now carry the
+  warning.
+- **The container failed to start once, at 07:44**, while the deploy was replacing
+  `wwwroot`; Azure retried, and the final restart produced a clean boot. Every
+  later status line repeats that timestamp as `LastError`, which reads alarming
+  and is historical. Uptime sampling is what distinguishes a settled instance from
+  a loop.
+- **The PA demo e2e suite fails when pointed at the default `*.azurestaticapps.net`
+  hostname**, because it asserts the social card's origin equals the origin under
+  test, and a production build correctly advertises `plato`. That is the test
+  working. Run it against the real domain after the CNAME is bound.
+
+### Left open
+
+- `KEYCLOAK_CLIENT_SECRET` on the PROD App Service is still
+  `change-me-in-keycloak-console`. It does not block boot, and it does not affect
+  the MCP providers (all four connected), but anything authenticating **as** the
+  `ronl-business-api` client — the smoke script's Tier 2 leg, `/v1/m2m` — will
+  fail until it is regenerated in Keycloak and set on the App Service.
+- `EP teksten fetch complete, total: 0` on PROD — relevant to #57, which assumed
+  that host is reachable from PROD's egress range.
+- The startup log still advertises `/v1/docs`, which is never mounted (#67).
+- The backend still deploys by hand, outside CI (#34/#35, item C9 below).


### PR DESCRIPTION
## What

Records the outcome of the ACC → PROD promotion of 12 September 2026 and brings the two go-live checklists in line with what is actually live. Documentation only.

## `docs/promote-ACC-to-PROD.md`

New §11 — what shipped, what differed from the plan, what was left open:

- PROD went 3.8.2 → **v2026.09.6** (promotion merge `04840ed`, carrying release `5f1091e`).
- All six decisions applied as recorded, including the `main promotion gate` ruleset reporting `BLOCKED` on the promotion pull request until `audit` passed — the gate proving itself on the pull request it was created for.
- Three deviations worth keeping: a production deploy lost to a **trailing newline in a deploy-token secret**; a `ContainerStartupFailure` during the `wwwroot` swap that Azure retried into a clean boot; and the PA demo e2e suite failing against the temporary `*.azurestaticapps.net` hostname, because it asserts the social card's origin equals the origin under test — the test working, not the build.

## `PUBLIC-SITE-GO-LIVE.md`

- PROD Static Web App, deploy token, backend deploy, env vars and DNS ticked with their evidence.
- **Correction:** §5 called `publiek.open-regels.nl` an apex record needing an Azure Alias record. It is a subdomain of the `open-regels.nl` zone and was bound with a plain CNAME; no alias record was involved.
- Two §7a steps are marked **superseded** rather than ticked — "merge locally, do not push" and "then push `main`" — because the promotion went through a pull request under the `main` ruleset, with the production SWA workflows disabled and dispatched by hand afterwards. Ticking them would misrepresent what happened.
- `CORS_ORIGIN` on PROD is recorded as its final value (`mijn` + `publiek`, `localhost:5173` dropped), verified by request rather than by reading the setting.

## `PA-DEMO-GO-LIVE.md`

- PROD resources, token, both CNAMEs and the §6 verification items ticked; the link-preview scraper check is left open, because nobody has run it.
- The `plato` hostname's previous occupant is recorded, along with the fact that it was deleted before the CNAME moved.

## Both checklists

A warning against `az … -o tsv | gh secret set <NAME>`: the CLI appends a newline, the secret stores 120 bytes where the key is 119, and the Static Web Apps action then fails with nothing more specific than `An unknown exception has occurred` — after every build step has passed, so it reads like an Azure fault. `tr -d '\r\n'` is the fix.

No package paths are touched, so no deploy workflow runs.
