### PR TITLE
ci: run the backend suite on pull requests, not only after the merge

### DIFF
--- a/.github/workflows/azure-backend-acc.yml
+++ b/.github/workflows/azure-backend-acc.yml
@@ -1,6 +1,42 @@
 name: Build Backend for ACC
 
 on:
+  # The backend's 2008 tests used to run only AFTER a merge, because this
+  # workflow triggered on push alone. A backend pull request therefore reached
+  # acc with `audit` as its only check -- and audit validates workflows,
+  # renovate.json and the supply-chain register, saying nothing about whether
+  # the code works.
+  #
+  # #86 made that sharper rather than softer: the per-file 80% branch floor it
+  # added to packages/backend/jest.config.js gated nothing before a merge, so a
+  # file dropping below it failed on acc, after the fact, rather than on the
+  # branch that caused it. The floor was real in four workspaces and
+  # retrospective in the fifth. Issue #87.
+  #
+  # Nothing here needs an `if:` guard, unlike linked-data-explorer's equivalent
+  # change (its #82): that workflow deploys to Azure, so it had to gate six
+  # deploy-side steps on the event. This one ends at an uploaded artifact and
+  # contains no deploy step at all -- the real deploy is deploy-backend-to-acc.sh,
+  # run by hand -- so a pull-request run has no external side effect.
+  pull_request:
+    branches:
+      - acc
+    paths:
+      - 'packages/backend/**'
+      - 'packages/shared/**'
+      - '.github/workflows/azure-backend-acc.yml'
+      # The root lockfile and manifest, because every workspace resolves through
+      # them and a hoisted dependency can move under any of them. Without these
+      # a lockfile-only change -- Renovate's lock-file maintenance above all --
+      # is built and tested by nothing.
+      #
+      # Safe to widen HERE and nowhere else: this job claims no Static Web Apps
+      # staging environment, so it cannot exhaust the frontend app's Free-plan
+      # ceiling of three, which five open pull requests did on 2026-08-28. The
+      # three SWA workflows keep their narrow filters for that reason.
+      # linked-data-explorer#97.
+      - 'package-lock.json'
+      - 'package.json'
   push:
     branches:
       - acc
@@ -8,7 +44,19 @@ on:
       - 'packages/backend/**'
       - 'packages/shared/**'
       - '.github/workflows/azure-backend-acc.yml'
+      - 'package-lock.json'
+      - 'package.json'
   workflow_dispatch:
+
+# Serialise runs, so a pull request pushed to twice in quick succession does not
+# run 2008 tests twice over. Keyed on the pull-request NUMBER where there is one
+# and the ref otherwise: keyed on github.ref alone, the push run a merge fires
+# and the pull request's own final run land in the same group and cancel each
+# other at random -- seen in this repository on 2026-08-29 with the Static Web
+# Apps deploys, and fixed there the same way.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
 
 # Default to read-only; jobs opt into more only where required.
 permissions:
@@ -19,6 +67,14 @@ jobs:
     permissions:
       contents: read
     runs-on: ubuntu-latest
+    # Declared for pull-request runs too, following linked-data-explorer rather
+    # than the conditional #87 floats as the tidier alternative. Both
+    # environments in this repository carry no protection rules, so nothing
+    # waits on an approval; the only cost is that a pull-request run records a
+    # deployment against `acc` in the environment's history. The Static Web Apps
+    # preview deploys already do exactly that on every pull request, so the
+    # entry is not a new pattern -- and matching the reference repository is
+    # worth more than avoiding it.
     environment:
       name: acc
       url: https://acc.api.open-regels.nl

--- a/.github/workflows/azure-backend-prod.yml
+++ b/.github/workflows/azure-backend-prod.yml
@@ -1,6 +1,22 @@
 name: Build Backend for Production
 
 on:
+  # No `pull_request` trigger, deliberately. This is the decision #87 asks for,
+  # recorded here rather than left to drift.
+  #
+  # `main` is promoted from `acc`, so every commit arriving here has already run
+  # this same suite on its own acc pull request (since #87 closed that gap).
+  # Re-running 2008 tests on the promotion pull request costs minutes and says
+  # nothing new about the code -- while `audit`, which IS required on `main`,
+  # reports there on every pull request regardless of base.
+  #
+  # Note that linked-data-explorer excludes its production workflow for a
+  # DIFFERENT reason that does not apply here: there, the production
+  # environment carries required reviewers, so a pull_request trigger would put
+  # a human approval in front of the very tests meant to inform it. Both
+  # environments in this repository have no protection rules at all. The
+  # exclusion stands on the promotion argument alone, and would want revisiting
+  # if protection rules were ever added.
   push:
     branches:
       - main
@@ -8,6 +24,11 @@ on:
       - 'packages/backend/**'
       - 'packages/shared/**'
       - '.github/workflows/azure-backend-prod.yml'
+      # Mirrors the acc workflow: the root lockfile and manifest feed every
+      # workspace, so a lockfile-only promotion must still build and test the
+      # backend rather than reaching production untested.
+      - 'package-lock.json'
+      - 'package.json'
   workflow_dispatch:
 
 # Default to read-only; jobs opt into more only where required.


### PR DESCRIPTION
Closes #87.

The backend's **2008 tests** ran on `push` alone, so a backend pull request reached `acc` with `audit` as its only check — and `audit` validates workflows, `renovate.json` and the supply-chain register, saying nothing about whether the code works.

#86 made that sharper rather than softer: the per-file 80% branch floor it added to `packages/backend/jest.config.js` gated nothing before a merge. A file dropping below it failed on `acc`, after the fact, rather than on the branch that caused it. The floor was real in four workspaces and retrospective in the fifth.

## The change

**`azure-backend-acc.yml`**

- `pull_request` on `acc`, with the same paths as `push`.
- **No `if:` guards**, unlike [linked-data-explorer#82](https://github.com/sgort/linked-data-explorer/pull/82), which had to gate six deploy-side steps on the event because that workflow deploys to Azure. This one ends at `Upload deployment artifact` and contains no deploy step — the real deploy is `deploy-backend-to-acc.sh`, run by hand — so a pull-request run has no external side effect.
- **`environment: acc` stays declared** on pull-request runs, following the same reference repository rather than the conditional #87 floats. Both environments here have no protection rules, so nothing waits on an approval; the only cost is a deployment entry against `acc`, which the Static Web Apps previews already create on every pull request.
- **Both filters gain `package-lock.json` and `package.json`.** Every workspace resolves through them, so a lockfile-only change — Renovate's lock-file maintenance above all — was previously built and tested by nothing (linked-data-explorer#97 lost 338 packages that way, 82 of them runtime). Safe to widen **here and nowhere else**: this job claims no Static Web Apps staging environment, so it cannot exhaust the frontend app's Free-plan ceiling of three, which five open pull requests did on 2026-08-28.
- A **`concurrency` group** keyed on the pull-request number, falling back to the ref, so a branch pushed to twice does not run 2008 tests twice. Keyed on `github.ref` alone, a merge's push run and the pull request's final run land in one group and cancel each other at random — seen here on 2026-08-29.

**`azure-backend-prod.yml`**

- The decision #87 also asks for, written down: **no `pull_request` trigger**. `main` is promoted from `acc`, so every commit arriving has already run this suite on its `acc` pull request, and `audit` — required on `main` — reports on the promotion pull request regardless of base.
- Recorded explicitly: linked-data-explorer excludes its production workflow for a **different** reason (required reviewers would stand in front of the tests), which does not apply here. The exclusion rests on the promotion argument alone and wants revisiting if protection rules are ever added.
- Filters mirrored, so a lockfile-only promotion still builds and tests the backend.

## Verification

Proved by making the gate fail, not by trusting a green run:

```
Jest: ".../packages/backend/src/__threshold-probe.ts" coverage threshold for branches (80%) not met: 0%
Test Suites: 86 passed | Tests: 3 skipped, 2008 passed, 2011 total
npm error code 1
```

It **names the file**, which is what demonstrates per-file rather than package-average behaviour. The probe was deleted and never staged.

Also checked: both workflows parse and carry the intended triggers; `npm run check-supply-chain` still agrees — 30 pinned references across 5 actions, since this adds no `uses:` line.

**This pull request is the remaining acceptance criterion**: the backend workflow reporting a check on a pull request for the first time. The three skipped tests are #85's permanently-skipped `PHASE_NOT_MODELLED` trio, now visible on every backend pull request.

Part of aligning this repository with `ci-posture-across-repos.md`; the manual backend deploy (#34/#35) stays out of scope.
