### PR TITLE
ci: check formatting in the audit job, not only at pre-push

### DIFF
--- a/.github/workflows/zizmor.yml
+++ b/.github/workflows/zizmor.yml
@@ -98,6 +98,46 @@ jobs:
         # nothing useful.
         run: npx --yes --package renovate@44.50.3 renovate-config-validator --strict
 
+      - name: Install dependencies for the formatter
+        # Needed because the check below must run THIS repository's Prettier,
+        # not a version named here. An `npx prettier@<pinned>` would be a second
+        # version to keep in step with package.json, reintroducing exactly the
+        # drift the check exists to catch. npm ci costs install time and cannot
+        # drift.
+        #
+        # This job had no npm ci at all before: everything in it ran from npx or
+        # plain node. That is the cost of this step, and it buys a check that is
+        # always measuring what developers actually run.
+        if: always()
+        run: npm ci
+
+      - name: Check formatting
+        # Formatting was enforced by the pre-push hook alone, so the rule held
+        # on a developer's machine and not on the shared branch. That gap is not
+        # theoretical: a Prettier 3.7 -> 3.9 upgrade changed how short union
+        # types are formatted, and five files nobody had touched began failing
+        # `prettier --check` the moment the upgrade merged — with every CI check
+        # green. The symptom would have been the next person's `git push`
+        # failing on files they had never opened.
+        #
+        # The ROOT script, matching what the pre-push hook runs. Linked Data
+        # Explorer fans out per workspace because Prettier resolves
+        # .prettierignore relative to the working directory and its packages
+        # each carry their own; this repository has one root .prettierignore and
+        # one root script, so the root run IS the right command here. Copying
+        # either shape into the other repository would be wrong.
+        #
+        # It belongs in this job rather than in a deploy workflow: `audit` has
+        # no paths filter and is the required status check, so every pull
+        # request reaches it — including documentation-only ones, whose markdown
+        # is the most likely thing to drift, since lint-staged only formats
+        # src/** and package.json on commit.
+        #
+        # if: always() for the same reason as the validator above — a zizmor
+        # failure should not hide a formatting failure behind it.
+        if: always()
+        run: npm run check-format
+
       - name: Verify pin truth and register agreement
         # zizmor validates pin FORMAT — that `uses:` names a 40-character SHA.
         # It cannot say the SHA is the RIGHT one, so a wrong or hostile digest


### PR DESCRIPTION
Formatting was enforced by the **pre-push hook alone**, so the rule held on a developer's machine and not on the shared branch.

That gap is not theoretical. A Prettier 3.7 → 3.9 upgrade changed how short union types are formatted, and five files nobody had touched began failing `prettier --check` the moment the upgrade merged — **with every CI check green**. The symptom would have been the next person's `git push` failing on files they had never opened.

Item C4 of the CI alignment against [`ci-posture-across-repos.md`](https://github.com/sgort/linked-data-explorer/blob/acc/docs/ci-posture-across-repos.md), where this repository is the only one of the three without it.

## The change

Two steps in the `audit` job, both `if: always()` so a zizmor failure cannot hide a formatting failure behind it:

| Step | Why |
| --- | --- |
| `npm ci` | The check must run **this repository's** Prettier. An `npx prettier@<pinned>` would be a second version to keep in step with `package.json`, reintroducing exactly the drift the check exists to catch. This job had no `npm ci` at all before — everything ran from `npx` or plain node — so the install time is the real cost of the step. |
| `npm run check-format` | The **root** script, matching what the pre-push hook runs. |

Three decisions worth recording:

- **The root script, not a per-workspace fan-out.** Linked Data Explorer fans out because Prettier resolves `.prettierignore` relative to the working directory and its packages each carry their own. This repository has one root `.prettierignore` and one root script, so the root run *is* the right command here — copying either shape into the other repository would be wrong.
- **In the `audit` job, not a deploy workflow.** `audit` has no `paths:` filter and is the required status check, so every pull request reaches it — including documentation-only ones, whose markdown is the likeliest thing to drift, since `lint-staged` only formats `src/**` and `package.json` on commit.
- **`if: always()` on both**, for the same reason the validator above them carries it: one run should report on every half of the policy rather than stopping at the first failure.

## Verification

- `npm run check-format` across the repository: **clean**, so this lands green rather than red.
- Both new steps are `run:` steps, so no `uses:` line is added — `npm run check-supply-chain` still reports **30 pinned references across 5 actions** with the register agreeing.
- The `audit` job's step order parses as intended: zizmor → validate renovate.json → npm ci → check formatting → verify pin truth.

One thing worth knowing when reading the job: `if: always()` here means "even if an earlier *check* failed", not "unconditionally" — the checkout and Node setup steps carry no condition, so nothing runs if those fail. That is correct and pre-existing.
