### PR TITLE
ci: make the supply-chain check blocking

### DIFF
--- a/.github/workflows/zizmor.yml
+++ b/.github/workflows/zizmor.yml
@@ -154,34 +154,46 @@ jobs:
         # if: always() for the same reason as the validator above — one run
         # should report on every half of the policy, not stop at the first.
         if: always()
-        # NON-BLOCKING to start with, and not merely out of caution.
+        # BLOCKING. It ran with continue-on-error: true from its adoption in
+        # #81 until #83 promoted it, once the thing it was waiting on had been
+        # shown to work here rather than only in linked-data-explorer.
         #
-        # Renovate rewrites workflow pins and never touches
-        # SECURITY-PIPELINE.md, so every action-bump pull request fails the
-        # register half until the register is updated by hand. Blocking on
-        # that would fail a required check on routine dependency updates,
-        # which is how gates get resented and then bypassed.
+        # What it was waiting on: Renovate rewrites workflow pins and their
+        # version comments together, and never touches SECURITY-PIPELINE.md, so
+        # every action-bump pull request fails the register half until the
+        # register is updated by hand. Blocking on that would fail a required
+        # check on routine dependency updates, which is how gates get resented
+        # and then bypassed.
         #
-        # The answer, proven in linked-data-explorer over two bumps
-        # (sgort/linked-data-explorer#66 and #67): update the register ON the
-        # bump's branch, before merging, so the check is green on the pull
-        # request rather than only on acc afterwards. Promote to blocking once
-        # that habit holds here too — see issue #81.
+        # What resolved it: the register is updated ON the bump's branch,
+        # before merging, so the check is green on the pull request rather than
+        # only on acc afterwards. Exercised here on #101 (zizmor-action v0.6.2
+        # -> v0.6.4), which is also this repository's own drift mode rather
+        # than a borrowed one.
         #
-        # Do not leave it non-blocking indefinitely. continue-on-error does
-        # not merely keep the job green: it rewrites the STEP's reported
-        # conclusion too, and the honest result (outcome: failure) is not
-        # exposed by the REST API. A finding is then visible ONLY in this
-        # step's log — the checks list, the job and the step all read
-        # "success". Observed on sgort/linked-data-explorer#66.
+        # Why NOT staying non-blocking, which is the part that is easy to get
+        # wrong: continue-on-error does not merely keep the job green, it
+        # rewrites the STEP's reported conclusion too, and the honest result
+        # (outcome: failure) is not exposed by the REST API at all. Observed on
+        # #101 before its register was fixed -- the step, the job and the pull
+        # request's checks list ALL read "success" while this step's own log
+        # carried:
         #
-        # The other reason to start non-blocking: this makes a network call
-        # inside a job the ruleset requires, so an API outage or rate limit
-        # could fail a gate unrelated to the change under review. If that
-        # proves to be a problem, add --offline rather than restoring
-        # continue-on-error: it keeps the register half blocking and drops
-        # only the network-dependent half.
-        continue-on-error: true
+        #   1 finding(s):
+        #     [register] zizmorcore/zizmor-action: workflow pins cc914d7f3750…
+        #                (v0.6.4) but SECURITY-PIPELINE.md records only
+        #                3dc1ecc9bcb9… (v0.6.2)
+        #
+        # A check nobody can see fail is not protecting anything; it is a check
+        # that has to be remembered, which is the condition the register
+        # drifted in to begin with.
+        #
+        # This does put a network call inside a job the ruleset requires, so a
+        # GitHub API outage or rate limit can now fail a gate unrelated to the
+        # change under review. If that proves to be a problem, add --offline:
+        # it keeps the register half blocking and drops only the
+        # network-dependent half. Do NOT restore continue-on-error, which
+        # reinstates the invisibility above.
         env:
           # contents: read suffices — this only resolves public refs.
           GITHUB_TOKEN: ${{ github.token }}

--- a/SECURITY-PIPELINE.md
+++ b/SECURITY-PIPELINE.md
@@ -230,16 +230,41 @@ Adding or removing a workflow step that carries a `uses:` line also moves the
 `(×N)` count and the totals headline. That is the ×8→×9 case above, and the check
 now fails on it rather than leaving it to a reader.
 
-The step is `continue-on-error: true` for now. It was proven in
-linked-data-explorer over two bumps
+**The step blocks.** It ran `continue-on-error: true` from its adoption
+([#81](https://github.com/sgort/ronl-business-api/issues/81)) until
+[#83](https://github.com/sgort/ronl-business-api/issues/83) promoted it, waiting
+on exactly one thing: evidence that the paragraph above — update the register on
+the bump's own branch — is a habit that holds _here_, and not only in
+linked-data-explorer, where it was proven over two bumps
 ([#66](https://github.com/sgort/linked-data-explorer/pull/66),
-[#67](https://github.com/sgort/linked-data-explorer/pull/67)) and promoted to
-blocking there; promote it here once the same habit holds. Do not leave it
-non-blocking indefinitely: `continue-on-error` rewrites the _step's_ reported
-conclusion as well as the job's, and the honest result is not exposed by the REST
-API — so a finding is visible only in the step's log while the checks list, the
-job and the step all read "success". See issue
-[#81](https://github.com/sgort/ronl-business-api/issues/81).
+[#67](https://github.com/sgort/linked-data-explorer/pull/67)).
+
+[#101](https://github.com/sgort/ronl-business-api/pull/101) supplied it.
+Renovate bumped `zizmorcore/zizmor-action` from v0.6.2 to v0.6.4 and, as
+described above, left this register behind; the register was then updated on
+Renovate's branch and the check went green there, before any merge.
+
+That same pull request is also the argument against waiting any longer. Before
+the register was fixed, the check reported:
+
+```
+1 finding(s):
+  [register] zizmorcore/zizmor-action: workflow pins cc914d7f3750… (v0.6.4)
+             but SECURITY-PIPELINE.md records only 3dc1ecc9bcb9… (v0.6.2)
+```
+
+— while the step, the job and the pull request's checks list **all read
+"success"**. `continue-on-error` rewrites the _step's_ reported conclusion as
+well as the job's, and the honest result (`outcome: failure`) is not exposed by
+the REST API at all, so nothing outside that one log knew. A check nobody can
+see fail is not protecting anything; it is a check that has to be remembered,
+which is the condition this register drifted in to begin with.
+
+The cost, stated plainly: a network call now sits inside a required check, so a
+GitHub API outage or rate limit can fail a gate unrelated to the change under
+review. `--offline` is the answer if that ever bites — it keeps the register
+half blocking and drops only the half that needs the network. Restoring
+`continue-on-error` is not, because it restores the invisibility above.
 
 ## Pending work
 


### PR DESCRIPTION
`check-supply-chain` has run with `continue-on-error: true` since it was adopted in #81. This removes it. Item C3 of the CI alignment against [`ci-posture-across-repos.md`](https://github.com/sgort/linked-data-explorer/blob/acc/docs/ci-posture-across-repos.md); closes #83.

## What it was waiting on, and what supplied it

Not caution in the abstract. Renovate rewrites workflow pins and their version comments together and never touches `SECURITY-PIPELINE.md`, so **every** action-bump pull request fails the register half until the register is updated by hand. Blocking on that would fail a required check on routine dependency updates — which is how gates get resented and then bypassed.

The answer was always the same: update the register **on the bump's own branch, before merging**. That was proven in linked-data-explorer over two bumps ([#66](https://github.com/sgort/linked-data-explorer/pull/66), [#67](https://github.com/sgort/linked-data-explorer/pull/67)) — but borrowed evidence is not evidence about this repository's own drift mode.

#101 supplied ours. Renovate bumped `zizmorcore/zizmor-action` v0.6.2 → v0.6.4; the register was updated on Renovate's branch in `7b7e403`; the audit went green **there**, before any merge (run `34688955467`: `OK — digests, version comments and the register all agree`).

## Why not wait longer

The same pull request is the argument against it. Before `7b7e403`, run `34688637026` reported a real finding:

```
1 finding(s):
  [register] zizmorcore/zizmor-action: workflow pins cc914d7f3750… (v0.6.4)
             but SECURITY-PIPELINE.md records only 3dc1ecc9bcb9… (v0.6.2)
```

…while **the step, the job and the pull request's checks list all read "success"**.

That is worth being precise about, because it is easy to assume `continue-on-error` only keeps the *job* green. It rewrites the **step's** reported conclusion too, and the honest result (`outcome: failure`) is not exposed by the REST API at all — so nothing outside that one step's log knew there was a finding. A check nobody can see fail is not protecting anything; it is a check that has to be remembered, which is the condition the register drifted in to begin with.

## The cost, stated rather than glossed

A network call now sits inside a required check, so a GitHub API outage or rate limit can fail a gate unrelated to the change under review.

`--offline` is the remedy if that ever bites: it keeps the register half blocking and drops only the half that needs the network. Restoring `continue-on-error` is **not** the remedy, because it restores the invisibility above. Both files now say so.

## Verification

- **YAML sweep across every workflow**: no `continue-on-error` key on any job or step. The word survives only in `zizmor.yml`'s comment prose; the parsed step carries exactly `name, if, env, run`.
- `npm run check-supply-chain`: `30 pinned reference(s) across 5 action(s)` — `OK — digests, version comments and the register all agree`. The register rewrite left the table and the totals headline the parser reads untouched.
- `npm run check-format`: clean, so this lands green on its own newly-blocking check rather than red.

## One thing to know before merging this

Once this is on `acc`, **#101 cannot merge unless `7b7e403` stays on its branch.** If Renovate regenerates `renovate/zizmorcore-zizmor-action-0.x`, the register commit disappears and the now-blocking check goes red. The fix in that case is to re-apply the register update on the branch — not to relax the gate. #101 is still held by its 14-day `renovate/stability-days` cooldown, so there is room for that to happen unnoticed; its register commit is worth re-checking at merge time.
