### PR TITLE
ci: scan for code and supply-chain findings with Semgrep

### DIFF
--- a/.github/workflows/semgrep.yml
+++ b/.github/workflows/semgrep.yml
@@ -1,0 +1,140 @@
+name: Semgrep
+
+# Semgrep Code and Supply Chain, on every pull request and on every push to acc
+# and main. Supply Chain covers what check-supply-chain structurally cannot:
+# check-supply-chain verifies that GitHub Actions digest pins resolve to the
+# versions their comments claim, and says nothing at all about the packages in
+# package-lock.json. Renovate remediates that tree; this is what verifies it.
+#
+# One job covers the whole monorepo. All six workspaces -- backend, frontend,
+# pa-cockpit, pa-demo, public-site, shared -- resolve through the single root
+# package-lock.json, so there is one lockfile for Supply Chain to read and no
+# per-workspace fan-out to keep in step with the workspace list.
+#
+# Ported from linked-data-explorer, which ported it from ttl-editor, where it
+# was introduced and triaged (ttl-editor#112, #113). Section 2 of
+# linked-data-explorer's docs/ci-posture-across-repos.md, "The other supply
+# chain", records why each decision below was taken; this file repeats only the
+# reasoning that is TRUE HERE, and says where this repository differs.
+#
+# Same trigger shape as zizmor.yml, and for the same reason documented at length
+# there: no branches filter and no paths filter on pull_request, so a pull
+# request cannot skip the scan by targeting an unwatched base or by touching
+# nothing watched. push stays filtered to the two branches that deploy.
+#
+# `scan` is NOT a required check on the day this lands, unlike in the two
+# repositories upstream of it. Both rulesets here -- "acc supply-chain gate" and
+# "main promotion gate" -- require `audit` and nothing else. That is deliberate:
+# the baseline has never been scanned in CI, and requiring a check before
+# knowing what it reports is how a gate ends up bypassed in its first week.
+# Promotion is a ruleset change, reversible without touching this file, which is
+# also why nothing here will move when it happens.
+#
+# `continue-on-error` is the obvious alternative to that staging and is the
+# wrong tool, for the reason zizmor.yml now spells out at length: it rewrites the
+# STEP's reported conclusion as well as the job's, and the honest result is not
+# exposed by the REST API, so a finding shows up only in the log while every
+# check reads "success". A separate un-required workflow reports honestly and
+# gates nothing; that is the shape to use while triaging.
+#
+# No fork caveat here, and none is needed: this repository has no forks, so no
+# pull request arrives without SEMGREP_APP_TOKEN. If one ever does, `semgrep ci`
+# cannot start and --no-suppress-errors fails the step -- harmless while the
+# check is not required, and a blocker the day it is. ttl-editor#128 has the
+# fork-safe shape; do that before promoting this to required if a fork exists by
+# then.
+on:
+  pull_request:
+  push:
+    branches:
+      - acc
+      - main
+
+# Same group key as every other workflow here, but NOT their unconditional
+# cancel-in-progress: true -- the one deliberate divergence in this file.
+#
+# The push runs on acc and main are what write the Semgrep Cloud baseline.
+# Cancelling one mid-upload leaves the dashboard describing a scan that never
+# finished, and nothing is queued to correct it. Pull-request runs write nothing
+# durable, so superseding a stale one is free. Hence: cancel on pull_request,
+# never on push. Do not "tidy" this into line with the siblings.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
+# Read-only. Findings go to Semgrep Cloud over the API, not to the GitHub
+# security tab, so security-events: write is not needed. If SARIF upload is ever
+# added, that permission comes with it -- and zizmor.yml sets
+# advanced-security: false for precisely this reason.
+permissions:
+  contents: read
+
+jobs:
+  semgrep:
+    name: scan
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+          # semgrep ci is diff-aware on a pull request: it scans the merge base
+          # against the head and reports only what the pull request introduces.
+          # It cannot compute that from a shallow clone, and degrades quietly to
+          # a full scan rather than failing -- which would put the whole backlog
+          # on every pull request and train everyone to ignore it.
+          fetch-depth: 0
+
+      # No actions/setup-node here, unlike every other workflow in this
+      # repository. Semgrep is a Python tool and this job runs no npm script, so
+      # a Node setup would be a pin to maintain for nothing. That is also why
+      # this workflow adds exactly one `uses:` reference to the register --
+      # actions/checkout, taking it from x9 to x10.
+      - name: Install Semgrep
+        # Hand-pinned, like zizmor's `version:` input and the renovate@44.50.3
+        # argument in the audit workflow. Renovate's managers do not parse a
+        # version out of a run: block, so this is bumped by hand; it is recorded
+        # in SECURITY-PIPELINE.md's Pinned table as a manual row, alongside those
+        # two.
+        #
+        # The venv is required, not stylistic: ubuntu-latest marks its system
+        # Python as externally-managed (PEP 668), so a bare `pip install` exits
+        # 1 with error: externally-managed-environment.
+        run: |
+          python3 -m venv "$RUNNER_TEMP/semgrep-venv"
+          "$RUNNER_TEMP/semgrep-venv/bin/pip" install --quiet semgrep==1.176.1
+          echo "$RUNNER_TEMP/semgrep-venv/bin" >> "$GITHUB_PATH"
+
+      - name: Verify the pinned version installed
+        # Cheap, and it makes the log state which Semgrep produced the findings
+        # below it. A scan whose tool version is not in its own output is how
+        # ttl-editor's first triage became ambiguous.
+        run: semgrep --version
+
+      - name: Scan
+        env:
+          # Required. Without it `semgrep ci` refuses to run, and an
+          # unauthenticated `semgrep scan` silently drops Supply Chain -- the
+          # half of this job nothing else in the repository covers. Agent (CI)
+          # scope only; this job never calls the Web API.
+          SEMGREP_APP_TOKEN: ${{ secrets.SEMGREP_APP_TOKEN }}
+        # No --dry-run: results go to the Semgrep Cloud dashboard so the count
+        # is tracked over time rather than living in a run log that expires.
+        #
+        # The push runs must be what establish the baseline. Semgrep derives the
+        # project identity from its environment: inside Actions it reads
+        # GITHUB_REPOSITORY and registers sgort/ronl-business-api, while a
+        # workstation run registers local_scan/ronl-business-api. Seeding the
+        # baseline from a laptop would split the history across two projects.
+        #
+        # Exit status is policy-driven: semgrep ci exits non-zero only on
+        # findings the Semgrep Cloud policy marks BLOCKING. Tighten the policy to
+        # make it bite, not this file.
+        #
+        # --no-suppress-errors is deliberate. By default semgrep ci prints
+        # "There were errors during analysis but Semgrep will succeed" and exits
+        # 0, which is how a broken install once went unnoticed upstream: the scan
+        # crashed and still reported success. Warn-level PartialParsing notices
+        # do not fail the job; a tool that cannot run does.
+        run: semgrep ci --no-suppress-errors

--- a/.semgrepignore
+++ b/.semgrepignore
@@ -1,0 +1,87 @@
+# Paths Semgrep should not scan, in .gitignore syntax.
+#
+# Semgrep already limits itself to files tracked by git, so node_modules/,
+# dist/, build/ and the backend's deploy/ tree are excluded by .gitignore
+# without needing a line here. This file is for paths that ARE tracked and ARE
+# meant to be, but are not application code.
+#
+# Derived from linked-data-explorer's file rather than copied. Three of its
+# rules apply here unchanged, one applies for a DIFFERENT reason, and one glob
+# is wider. Each divergence is noted where it occurs -- a borrowed comment that
+# describes the other repository's tree is worse than no comment, because it
+# reads as verified and is not.
+
+# Reference material at the repository root: the Flevoland organisation export
+# -- BPMN processes, DMN decision tables, Camunda forms and document templates,
+# plus two HTML fixtures. Thirty-six tracked files, loaded by no package and
+# built by nothing. Deployed to Operaton by hand and by the e2e fixtures.
+#
+# The leading slash is deliberate but NOT for the reason linked-data-explorer
+# gives. There, a bare `examples/` would also have swallowed a served
+# packages/frontend/public/examples/, and dropping it from the scan was caught
+# only by set-differencing the scanned file lists. This repository has no nested
+# examples/ directory at all -- the root one is the only one, and none of the
+# three served public/ trees (frontend, pa-demo, public-site) contains one.
+#
+# So the anchor buys nothing today. It is here because it costs nothing and
+# because the day someone adds packages/frontend/public/examples/, the bare form
+# would silently stop scanning a served file while the finding count stayed
+# identical. Anchor now, when it is free, rather than discovering it the way
+# ttl-editor did.
+#
+# Unlike linked-data-explorer, this rule is not expected to silence much: its
+# examples/organizations/ holds executable scripts (eval-detected,
+# hardcoded-password-default-argument), and this one holds no scripts at all --
+# only process models, forms and templates. The justification is "reference
+# material is not application code", not a finding count.
+/examples/
+
+# Test files are excluded from Code scanning, but NOT from Secrets scanning,
+# which carries its own separate ignore list in the Semgrep project settings and
+# keeps covering them. A hardcoded credential in a test is the one finding class
+# here worth having, and it survives these rules.
+#
+# Reading a fixture off disk means path.resolve; asserting on generated text
+# means building a RegExp from a variable. Both are ordinary test code, so
+# path-join-resolve-traversal and detect-non-literal-regexp fire on it forever,
+# and triaging each new test file by hand is not a strategy. The narrower fix,
+# scoping those two rules to non-test paths, is not available: Semgrep has no
+# per-rule path setting, and forking two registry rules to add paths.exclude is
+# more to maintain than this is worth.
+#
+# The third glob is where this file is WIDER than the one it was derived from.
+# linked-data-explorer's says "every test file in this repository is .test.ts or
+# .test.tsx; there are no .spec files", and tells the next reader to widen it if
+# that changes. Here it already has: 290 files are .test.ts/.test.tsx, and 12
+# more are .spec.ts -- the Playwright journeys under packages/frontend/e2e/,
+# packages/pa-demo/e2e/ and packages/public-site/e2e/.
+#
+# Those twelve are the files most likely to hold a real login credential, which
+# is exactly why excluding them from Code scanning is safe: Secrets scanning is
+# what would catch that, and it is unaffected by this file. What the exclusion
+# drops is Code noise on E2E journeys, which is what it is meant to drop.
+#
+# There are no JavaScript tests -- no .test.js, no .spec.js, nothing under
+# .mjs/.cjs. Widen this if that changes.
+*.test.ts
+*.test.tsx
+*.spec.ts
+
+# Restores two rules from Semgrep's built-in default ignore list, which this file
+# REPLACES rather than extends. That replacement is the trap: adding a
+# .semgrepignore at all silently brings back into scope everything the defaults
+# were excluding, and the finding count can come out identical either way --
+# linked-data-explorer brought 16 files back without any count moving, and found
+# it only by diffing the scanned file sets.
+#
+# Four directories match here: packages/frontend/src/test/,
+# packages/pa-cockpit/src/test/, packages/pa-demo/src/test/ and
+# packages/public-site/src/test/ -- all Vitest setup and support.
+#
+# Bare on purpose, unlike /examples/ above: every directory of either name in
+# this repository is test support, and none sits under a served public/ tree
+# (checked, not assumed). The other defaults -- node_modules/, dist/, build/,
+# vendor/, *.min.js -- are not restored because nothing matching them is
+# tracked, and Semgrep scans only tracked files.
+test/
+tests/

--- a/SECURITY-PIPELINE.md
+++ b/SECURITY-PIPELINE.md
@@ -23,18 +23,19 @@ These are GitHub settings, not files. Without them parts of the policy are inert
 
 ## Pinned
 
-**30 `uses:` references across 9 workflows, all 30 digest-pinned.** Verified on
-`acc` at `570f973`, 29 August 2026.
+**31 `uses:` references across 10 workflows, all 31 digest-pinned.** Verified on
+`acc` at `bdad286`, 12 September 2026.
 
 | Dependency                          | Pin                                                 | Version           | Maintained by                                                                        |
 | ----------------------------------- | --------------------------------------------------- | ----------------- | ------------------------------------------------------------------------------------ |
-| `actions/checkout` (×9)             | `3d3c42e5aac5ba805825da76410c181273ba90b1`          | v7.0.1            | Renovate                                                                             |
+| `actions/checkout` (×10)            | `3d3c42e5aac5ba805825da76410c181273ba90b1`          | v7.0.1            | Renovate                                                                             |
 | `actions/setup-node` (×9)           | `820762786026740c76f36085b0efc47a31fe5020`          | v7.0.0            | Renovate                                                                             |
 | `Azure/static-web-apps-deploy` (×9) | `4d27395796ac319302594769cfe812bd207490b1`          | v1                | **manual** — Renovate updates are disabled for it, see below                         |
 | `actions/upload-artifact` (×2)      | `043fb46d1a93c77aae656e7c1c64a875d1fc6a0a`          | v7.0.1            | Renovate                                                                             |
 | `zizmorcore/zizmor-action`          | `3dc1ecc9bcb9e94e9b2c709687979e1298497054`          | v0.6.2            | Renovate                                                                             |
 | zizmor itself                       | `version: '1.29.0'` input, not `latest`             | 1.29.0            | **manual** — an action input, which Renovate's github-actions manager does not parse |
 | `renovate-config-validator`         | `npx --package renovate@44.50.3`                    | 44.50.3           | **manual** — an inline npx argument, not a manifest entry                            |
+| Semgrep itself                      | `pip install semgrep==1.176.1`                      | 1.176.1           | **manual** — a version inside a `run:` block, which no Renovate manager parses       |
 | npm dependencies                    | `package-lock.json`, `sha512` integrity per package | lockfileVersion 3 | Renovate                                                                             |
 
 The zizmor pin is stronger than it looks: `zizmor-action` resolves the requested


### PR DESCRIPTION
`check-supply-chain` verifies that GitHub Actions digest pins resolve to the versions their comments claim. It says **nothing whatever** about the packages in `package-lock.json`. Renovate remediates that tree; nothing in this repository verified it. This is the half that was missing.

Item C5 of the CI alignment against [`ci-posture-across-repos.md`](https://github.com/sgort/linked-data-explorer/blob/acc/docs/ci-posture-across-repos.md), where this repository is the only one of the three without it. Ported from linked-data-explorer, which ported it from ttl-editor ([#112](https://github.com/sgort/ttl-editor/issues/112), [#113](https://github.com/sgort/ttl-editor/issues/113)).

## It gates nothing on merge, deliberately

Both rulesets here — `acc supply-chain gate` and `main promotion gate` — require `audit` and nothing else, and they stay that way with this merge.

The baseline has never been scanned in CI. Requiring a check before knowing what it reports is how a gate gets resented and bypassed in its first week; linked-data-explorer ran it as reporting-only while triaging **76 findings down to 4**, then required it. Promotion here is a ruleset edit — reversible, and it touches no file, which is why nothing in `semgrep.yml` will move when it happens.

`continue-on-error` is the obvious alternative to that staging and is the wrong tool, for the reason `zizmor.yml` now spells out at length after #103: it rewrites the **step's** reported conclusion as well as the job's, so a finding shows up only in the log while every check reads "success". An un-required workflow reports honestly and gates nothing. That is the right shape while triaging.

## `.semgrepignore` is derived, not copied

Three divergences from the reference file, each recorded in the file itself rather than left for a reader to discover:

| | linked-data-explorer | here |
| --- | --- | --- |
| `/examples/` anchoring | required — a served `packages/frontend/public/examples/` would be swallowed by the bare form | **no nested `examples/` exists at all**; anchored anyway, as free insurance, and the comment says *that* rather than borrowing a collision this repo does not have |
| test globs | `*.test.ts`, `*.test.tsx` — "there are no `.spec` files; widen this if that changes" | **it already changed**: `*.spec.ts` added for 12 Playwright journeys under `packages/*/e2e/` |
| `test/` `tests/` | restores two of Semgrep's built-in defaults, which the file **replaces** rather than extends | same, and load-bearing here — see below |

Excluding the 12 E2E specs from **Code** scanning is safe because Secrets scanning carries its own separate ignore list in the Semgrep project settings and keeps covering them. A hardcoded credential in a Playwright journey — the finding class actually worth having in those files — is still caught. What the exclusion drops is `detect-non-literal-regexp` / `path-join-resolve-traversal` noise.

## Verified by set-differencing, not by counting

The posture doc's own lesson is *"check the set, not the total"* — a wrong ignore rule once dropped a served `.dmn` file while both finding counts read identically. So:

```
scanned without .semgrepignore:  889
scanned with .semgrepignore:     553
dropped:                         337
```

| rule | dropped |
| --- | --- |
| `/examples/` | 36 |
| `*.test.ts` | 156 |
| `*.test.tsx` | 133 |
| `*.spec.ts` | 12 |
| `test/` `tests/` | 0 — *see below* |

- **Unexplained entries in the dropped set: 0.**
- **Dropped files under a served `public/` tree: 0.**

The arithmetic closes exactly: **345 matching paths = 337 dropped + 8 that were never Semgrep targets in either run.** Those 8 are TypeScript files under `packages/{frontend,pa-cockpit,pa-demo,public-site}/src/test/`, which Semgrep's *default* ignore list already excluded — which is precisely why the `test/` and `tests/` rules are in the file. This file **replaces** the defaults rather than extending them, so without those two lines, adding a `.semgrepignore` at all would have silently re-admitted those 8. That is the trap linked-data-explorer hit in the other direction, bringing back 16 files with no count moving.

## The register moves with the workflow

Now that `check-supply-chain` blocks (#103, merged earlier today), a new workflow that adds a `uses:` reference must update `SECURITY-PIPELINE.md` in the same commit or fail its own gate:

- `actions/checkout` ×9 → **×10**
- headline **30 across 9 workflows** → **31 across 10**
- new hand-pinned row: `semgrep==1.176.1`, alongside `zizmor 1.29.0` and `renovate@44.50.3` — no Renovate manager parses a version out of a `run:` block

There is no `actions/setup-node` in this workflow: Semgrep is a Python tool and the job runs no npm script, so that count is unchanged at ×9.

## Verification

- `npm run check-supply-chain`: `31 pinned reference(s) across 5 action(s)` — `OK — digests, version comments and the register all agree`. Cross-checked against an independent count straight from the tree: 10 workflow files, 31 `uses:`, `checkout` ×10.
- `npm run check-format`: clean.
- YAML parses: job `semgrep` / check context `scan`, 4 steps, `permissions: contents: read`, and `cancel-in-progress: ${{ github.event_name == 'pull_request' }}` — the one deliberate divergence from the siblings' unconditional cancel, because a cancelled **push** run leaves the Semgrep Cloud baseline half-written.

## What to expect on this PR, and what not to read into it

A local unauthenticated `semgrep scan` found **13 Code findings** — 9 `detect-non-literal-regexp`, 2 `unsafe-formatstring`, 1 `prototype-pollution-loop`, 1 `unknown-value-with-script-tag`. **That is not the baseline and not a triage.** An unauthenticated scan resolves **no Supply Chain findings at all**, which is the half this job exists for, so the real figure will be higher and arrives on this PR's own run.

The baseline must be written by the `push` run on `acc`, not from a workstation: Semgrep derives project identity from `GITHUB_REPOSITORY`, so a local run registers `local_scan/ronl-business-api` and would split the history from `sgort/ronl-business-api`. Nothing was seeded from here.

Triage is follow-up work, not part of this PR.
