### PR TITLE
ci: align the Renovate config with the cross-repo posture

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -3,25 +3,52 @@
   "description": [
     "Supply-chain policy for ronl-business-api. Companion to .github/zizmor.yml",
     "and the Supply-chain audit workflow: zizmor enforces that every action",
-    "reference is a commit digest, Renovate keeps those digests current.",
-    "dependencyDashboardApproval is TEMPORARY - see the note on that key."
+    "reference is a commit digest, Renovate keeps those digests current. Pinning",
+    "without automated updates decays into an unpatched tree, which is worse",
+    "than floating. See SECURITY-PIPELINE.md.",
+    "baseBranchPatterns targets acc, this repository's integration and default",
+    "branch. main is promoted from acc and must never receive dependency pull",
+    "requests directly.",
+    "prConcurrentLimit 5 is a sized cap, and what sizes it here is REVIEWER",
+    "ATTENTION, not Static Web Apps staging environments. That is the opposite",
+    "of linked-data-explorer, and the reasoning does not transfer: the three acc",
+    "SWA workflows carry paths: filters on pull_request as well as push, and",
+    "none of those filters watches the root lockfile or package.json. So a",
+    "dependency pull request -- lock-file maintenance above all -- consumes NO",
+    "preview environment at all. The frontend app is Free (3 environments) while",
+    "pa-demo and public-site are Standard (10) in a different subscription, but",
+    "none of that binds on this key. What does cost previews: a change under",
+    "packages/shared/** or packages/pa-cockpit/**, which both frontend-acc and",
+    "pa-demo-acc watch, so it holds two at once."
   ],
-  "extends": ["config:recommended", "helpers:pinGitHubActionDigests"],
+  "extends": ["config:recommended", ":dependencyDashboard", "helpers:pinGitHubActionDigests"],
   "minimumReleaseAge": "14 days",
   "internalChecksFilter": "strict",
-  "dependencyDashboardApproval": true,
   "vulnerabilityAlerts": {
     "description": [
       "Security advisories bypass the cooldown. Without this override the",
       "14-day wait would delay exactly the updates that must not wait, which",
       "is why such policies get disabled mid-incident. Requires GitHub",
       "Dependabot ALERTS to be enabled on the repository; Dependabot security",
-      "UPDATES must stay off, or it opens competing PRs that ignore the cooldown."
+      "UPDATES must stay off, or it opens competing PRs that ignore the cooldown.",
+      "dependencyDashboardApproval is set false here explicitly, because major",
+      "updates below need approval: a security fix that happens to be a major",
+      "version must not wait on a checkbox."
     ],
     "minimumReleaseAge": null,
-    "labels": ["security"]
+    "labels": ["security"],
+    "dependencyDashboardApproval": false
   },
   "packageRules": [
+    {
+      "description": [
+        "Actions land across all ten workflows at once, so they are grouped",
+        "separately from the workspace dependencies below."
+      ],
+      "matchManagers": ["github-actions"],
+      "groupName": "github actions",
+      "matchUpdateTypes": ["minor", "patch", "digest"]
+    },
     {
       "description": [
         "Azure/static-web-apps-deploy publishes v1 as BOTH a 2021 tag",
@@ -30,11 +57,139 @@
         "branch head; Renovate's github-tags datasource resolves the tag, so it",
         "would open a routine-looking digest update that reverts nine deploy",
         "steps to 3.5-year-old code. minimumReleaseAge gives no protection - the",
-        "target commit is years old. See SECURITY-PIPELINE.md."
+        "target commit is years old. Re-resolve by hand if this action ever",
+        "needs to move. See SECURITY-PIPELINE.md."
       ],
       "matchManagers": ["github-actions"],
       "matchDepNames": ["Azure/static-web-apps-deploy"],
       "enabled": false
+    },
+    {
+      "description": [
+        "Four deployables, four groups. An update that breaks one workspace",
+        "should not be entangled with the others in a single pull request -",
+        "each has its own deploy workflow and its own acceptance site.",
+        "There are six packages but only four groups: pa-cockpit is",
+        "private: true and compiled into both frontend and pa-demo, and shared",
+        "feeds both frontend and backend. Neither deploys on its own, so an",
+        "update under either stays ungrouped and arrives as its own pull",
+        "request - which is also the honest shape, because it is the one case",
+        "that redeploys two sites at once.",
+        "matchUpdateTypes lists every update type EXCEPT lockFileMaintenance.",
+        "Without it these rules stamp a group name onto lock-file maintenance",
+        "too, and one refresh arrives as several identical pull requests with",
+        "byte-identical lockfiles, multiplying its share of prConcurrentLimit.",
+        "Its own default is groupName null. Learned in linked-data-explorer",
+        "(#92, #93, #94); see linked-data-explorer#97."
+      ],
+      "matchFileNames": ["packages/backend/**"],
+      "groupName": "backend dependencies",
+      "matchUpdateTypes": [
+        "major",
+        "minor",
+        "patch",
+        "pin",
+        "pinDigest",
+        "digest",
+        "rollback",
+        "bump",
+        "replacement"
+      ]
+    },
+    {
+      "matchFileNames": ["packages/frontend/**"],
+      "groupName": "frontend dependencies",
+      "matchUpdateTypes": [
+        "major",
+        "minor",
+        "patch",
+        "pin",
+        "pinDigest",
+        "digest",
+        "rollback",
+        "bump",
+        "replacement"
+      ]
+    },
+    {
+      "matchFileNames": ["packages/pa-demo/**"],
+      "groupName": "pa-demo dependencies",
+      "matchUpdateTypes": [
+        "major",
+        "minor",
+        "patch",
+        "pin",
+        "pinDigest",
+        "digest",
+        "rollback",
+        "bump",
+        "replacement"
+      ]
+    },
+    {
+      "matchFileNames": ["packages/public-site/**"],
+      "groupName": "public-site dependencies",
+      "matchUpdateTypes": [
+        "major",
+        "minor",
+        "patch",
+        "pin",
+        "pinDigest",
+        "digest",
+        "rollback",
+        "bump",
+        "replacement"
+      ]
+    },
+    {
+      "description": [
+        "Major updates wait in the Dependency Dashboard (#16) as checkboxes and",
+        "hold no slot in prConcurrentLimit until someone ticks one. This is what",
+        "replaces the global dependencyDashboardApproval that governed every",
+        "update until now (#20, superseded): that key was set during adoption so",
+        "Renovate raised nothing while the same workflow files were being pinned",
+        "by hand on a branch. That race ended when pinning finished, but removing",
+        "the key outright would release the whole queue at once.",
+        "The queue is why the replacement is scoped to majors rather than dropped",
+        "entirely: of 35 entries pending approval on 2026-09-12, all but four are",
+        "majors - express 5, react 19, typescript 7, vite 8, jest 30, eslint 10,",
+        "tailwindcss 4, node 24, postgres 18 - which nobody merges on autopilot",
+        "anyway. Behind this rule they stay checkboxes; the four genuine",
+        "minor/patch updates flow normally under the 14-day cooldown."
+      ],
+      "matchUpdateTypes": ["major"],
+      "dependencyDashboardApproval": true
+    },
+    {
+      "description": [
+        "Lock-file maintenance is the ONLY thing that moves the transitive tree.",
+        "Nothing has ever refreshed this one: the key was absent entirely until",
+        "now, and the first authenticated Semgrep scan of this repository, on",
+        "2026-09-12, found 435 findings of which 419 are Supply Chain (249",
+        "reachable) across 1266 npm dependencies.",
+        "In linked-data-explorer a single refresh closed 63 of 66 Supply Chain",
+        "findings with no manifest change, which is the specific reason this key",
+        "is here rather than in a later pass: triaging those findings by hand",
+        "before refreshing the lockfile would be work thrown away.",
+        "prPriority makes it the first branch created when a slot frees - but",
+        "only against branches eligible in the same run, and lock-file",
+        "maintenance is only eligible inside its Monday schedule. During the week,",
+        "updates eligible any time fill every free slot first, so priority alone",
+        "cannot hold one for it; majors needing approval, above, is what does.",
+        "See linked-data-explorer#97."
+      ],
+      "matchUpdateTypes": ["lockFileMaintenance"],
+      "prPriority": 10
     }
-  ]
+  ],
+  "prConcurrentLimit": 5,
+  "prHourlyLimit": 2,
+  "baseBranchPatterns": ["acc"],
+  "labels": ["dependencies"],
+  "rangeStrategy": "bump",
+  "postUpdateOptions": ["npmDedupe"],
+  "lockFileMaintenance": {
+    "enabled": true,
+    "schedule": ["before 5am on monday"]
+  }
 }


### PR DESCRIPTION
Item C6 of the CI alignment against [`ci-posture-across-repos.md`](https://github.com/sgort/linked-data-explorer/blob/acc/docs/ci-posture-across-repos.md). **Supersedes draft [#20](https://github.com/sgort/ronl-business-api/pull/20)**, open since 28 August, whose one-line change is subsumed here.

| | before | after |
| --- | --- | --- |
| `dependencyDashboardApproval` | global — governs **every** update | scoped to **majors only** |
| `lockFileMaintenance` | **absent entirely** | enabled, Mondays before 5am, `prPriority: 10` |
| `prConcurrentLimit` | unset | **5** |
| `baseBranchPatterns` | **absent** | `["acc"]` |
| `packageRules` | 1 | 8 |

## The one that matters: `lockFileMaintenance`

Renovate maintains **declared dependencies, not what they resolve to.** Lock-file maintenance is the only mechanism that moves the transitive tree, and this repository has never had it — the key was absent, not disabled.

This morning's first authenticated Semgrep scan (#104) found **435 findings across 1,266 npm dependencies** — 419 Supply Chain, of which **249 reachable**.

In linked-data-explorer, **one refresh closed 63 of 66 Supply Chain findings with no manifest change** ([#92](https://github.com/sgort/linked-data-explorer/pull/92)). That is the specific reason this lands *before* any triage of those 435: triaging by hand first would be work thrown away.

`prPriority: 10` makes it the first branch created when a slot frees — but only against branches eligible in the same run, and it is only eligible inside its Monday window. During the week, updates eligible any day fill every free slot first. Priority alone cannot hold a slot for it; **majors needing approval is what does.**

## Why majors-only rather than dropping the key

Draft #20 proposed removing `dependencyDashboardApproval` outright. That was right about the reason it was set — Renovate had to raise nothing while the same `uses:` lines were being pinned by hand on a branch — and that race is long over.

But removing it outright releases the whole queue at once, and the queue today is **35 pending approval + 5 pending status checks**. All but four are majors:

> `express` 5 · `react` 19 · `typescript` 7 · `vite` 8 · `jest` 30 · `eslint` 10 · `tailwindcss` 4 · `node` 24 · `postgres` 18 · `keycloak` 26 · `react-router-dom` 7 · …

Nobody merges those on autopilot. Behind the scoped rule they stay checkboxes holding **no slot** in `prConcurrentLimit`; the four genuine minor/patch updates (`altcha-lib`, `eslint-plugin-react-refresh`, `prettier` 3.9.6, and lockfile variants) flow normally under the 14-day cooldown.

`vulnerabilityAlerts` sets `dependencyDashboardApproval: false` explicitly, so **a security fix that happens to be a major version never waits on a checkbox.**

## `prConcurrentLimit: 5` — and why the scoping premise was wrong

This item was scoped on sizing the cap to the Free-plan three-environment ceiling. **That premise does not hold**, and the config now records why.

All three acc SWA workflows carry `paths:` filters on `pull_request` as well as `push` (plan item 5, already Done). None of those filters watches the root lockfile or `package.json`. So:

| change touches | previews consumed |
| --- | --- |
| root lockfile / `package.json` — **i.e. every dependency PR** | **0** |
| `packages/frontend/**` | 1 |
| `packages/public-site/**` | 1 |
| `packages/pa-demo/**` | 1 |
| `packages/shared/**` or `packages/pa-cockpit/**` | **2** — both `frontend-acc` and `pa-demo-acc` watch them |

The apps are not uniformly Free either: `ronl-business-frontend-acc` is Free (3 environments), while `ronl-business-pademo-site-acc` and `ronl-business-public-site-acc` are **Standard (10)** in a different Azure subscription.

So the cap is sized on **reviewer attention**, not environments — the opposite of linked-data-explorer's reasoning, where frontend and lockfile PRs each do hold a preview. The description says so, at length, because a borrowed justification that is false here would read as verified and is not.

## Four groups, not three

The reference groups three deployables. This repository has **six packages but four deployables**: `pa-cockpit` is `private: true` and compiled into both frontend and pa-demo; `shared` feeds frontend and backend. Neither deploys on its own, so updates under either stay **ungrouped** and arrive as their own PR — which is the honest shape, since that is exactly the case that redeploys two sites.

## The bug a validator cannot catch

Every group rule lists nine update types **except `lockFileMaintenance`**. Omit that exclusion and group names get stamped onto lock-file maintenance too, so one refresh arrives as several PRs with byte-identical lockfiles, multiplying its share of the concurrency cap — [linked-data-explorer#92, #93, #94](https://github.com/sgort/linked-data-explorer/pull/92) are what that looks like.

The config is schema-valid either way, so this is asserted structurally rather than trusted:

```
rules: 8
  0 group=github actions        | updateTypes=3
  1 DISABLED                    | updateTypes=(none)
  2 group=backend dependencies  | updateTypes=9
  3 group=frontend dependencies | updateTypes=9
  4 group=pa-demo dependencies  | updateTypes=9
  5 group=public-site deps      | updateTypes=9
  6 ddApproval=true             | updateTypes=1
  7 prPriority=10               | updateTypes=1
No group rule includes lockFileMaintenance — correct
```

## Verification

- `renovate-config-validator --strict` (the pinned `renovate@44.50.3` the `audit` job runs): `Config validated successfully against 1 file(s)`. `--strict` also rejects config Renovate would silently auto-migrate — which is how `baseBranches` → `baseBranchPatterns` was caught in linked-data-explorer. The new spelling is used here.
- `npm run check-format`: clean.
- `npm run check-supply-chain`: `OK` — 31 references, register agrees.

## What merging this does

- Releases **four** updates into normal flow; the other 31 stay as checkboxes.
- On the **first Monday after merge**, lock-file maintenance runs for the first time in this repository's history. That is the run to watch — it is the one most likely to move the 249 reachable Supply Chain findings.

Closing #20 as superseded and marking item 8 of `docs/superpowers/plans/2026-08-28-ci-follow-ups.md` as Done follows once this lands.
