### PR TITLE
fix: coerce axios response header to string at both form call sites

### DIFF
--- a/packages/backend/src/services/operaton.service.ts
+++ b/packages/backend/src/services/operaton.service.ts
@@ -1308,7 +1308,11 @@ export class OperatonService {
         '/deployed-start-form',
         { responseType: 'text' }
       );
-      const contentType: string = response.headers['content-type'] ?? 'application/octet-stream';
+      // String(), not a cast. Axios 1.18 widened header values to
+      // string | number | boolean | string[] | AxiosHeaders, and `as string`
+      // would silence the compiler while still handing a non-string to callers
+      // that put this straight into a Content-Type response header.
+      const contentType = String(response.headers['content-type'] ?? 'application/octet-stream');
       return { data: response.data, contentType };
     } catch (error) {
       logger.error('Failed to fetch deployed start form', {
@@ -1330,7 +1334,11 @@ export class OperatonService {
       const response = await this.client.get(`/task/${taskId}/deployed-form`, {
         responseType: 'text',
       });
-      const contentType: string = response.headers['content-type'] ?? 'application/octet-stream';
+      // String(), not a cast. Axios 1.18 widened header values to
+      // string | number | boolean | string[] | AxiosHeaders, and `as string`
+      // would silence the compiler while still handing a non-string to callers
+      // that put this straight into a Content-Type response header.
+      const contentType = String(response.headers['content-type'] ?? 'application/octet-stream');
       return { data: response.data as string, contentType };
     } catch (error) {
       logger.error('Failed to fetch deployed task form', {


### PR DESCRIPTION
Unblocks #109, the `axios` security bump, whose `build` check fails with 1,859 tests passing and one suite failing to compile.

```
src/services/operaton.service.ts:1333:13 - error TS2322:
  Type 'string | number | boolean | string[] | AxiosHeaders' is not assignable to type 'string'.
```

axios 1.18 widened header values, so assigning one to a `string` no longer compiles.

## Why this is its own PR rather than a commit on the Renovate branch

The obvious move is to commit the fix onto `renovate/npm-axios-vulnerability`, the way the supply-chain register fix was committed onto #101's branch earlier today.

Renovate **force-updated that branch while this was being diagnosed** — `9b658a1...f54599d (forced update)`. A commit pushed there can be discarded the same way on the next run. Landing the fix on `acc` first means #109 rebases onto a tree where the line already compiles, and nothing the bot does can undo it.

## Two call sites, not one

CI named line 1333. TypeScript halts a file at its first error, so `getDeployedStartForm` at **1311** carried the identical expression behind `getDeployedTaskForm` at 1333, undiagnosed. Fixing only what CI printed would have produced a second red run on the same pull request.

## `String()`, not `as string`

A cast satisfies the compiler and still hands a non-string to callers that put this value straight into a `Content-Type` response header. `String()` is correct for every member of the union. Both sites carry a comment saying so, so it does not get simplified back into a cast later.

## Verification

- `tsc --noEmit` on the backend: **exit 0**
- `operaton.service.test.ts`: **149/149 passed** — the suite that failed to compile
- `npm run lint --workspace=@ronl/backend`: clean
- `npm run check-format`: clean

No behaviour change: every value this expression produced before was already a string at runtime: only its static type widened.