### PR TITLE
ci: keep @ronl/shared free of logic, and check it

### DIFF
--- a/.github/workflows/zizmor.yml
+++ b/.github/workflows/zizmor.yml
@@ -138,6 +138,28 @@ jobs:
         if: always()
         run: npm run check-format
 
+      - name: Verify @ronl/shared holds no logic
+        # @ronl/shared has no test runner, so a function placed there escapes
+        # the per-file 80% branch floor every other workspace is held to (#80).
+        # It is not under-tested -- it is outside the measurement entirely, and
+        # nothing signals that: no run fails and no number moves. v2026.09.4
+        # moved a branching helper back out of that package for exactly this
+        # reason, found by hand rather than by any check. #84.
+        #
+        # Here rather than in a workspace suite, for the same reason the
+        # formatter is: this job has no paths filter and is the required check,
+        # so every pull request reaches it. A suite that only runs when
+        # packages/shared/** changes would not catch the pull request that adds
+        # the first function to a package the filter does not yet watch.
+        #
+        # Costs nothing on top of the npm ci above, which the formatter already
+        # needed -- this reads the TypeScript compiler from node_modules.
+        #
+        # if: always() for the same reason as the validator above -- one run
+        # should report on every half of the policy, not stop at the first.
+        if: always()
+        run: npm run check-shared
+
       - name: Verify pin truth and register agreement
         # zizmor validates pin FORMAT — that `uses:` names a 40-character SHA.
         # It cannot say the SHA is the RIGHT one, so a wrong or hostile digest

--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
     "lint:fix": "npm run lint:fix --workspaces --if-present",
     "check-supply-chain": "node scripts/check-supply-chain.mjs",
     "check-mirror": "bash scripts/check-mirror.sh",
+    "check-shared": "node scripts/check-shared-declarations.mjs",
     "check-format": "prettier --check \"**/*.{ts,tsx,json,md}\" --ignore-path .gitignore",
     "format": "prettier --write \"**/*.{ts,tsx,json,md}\" --ignore-path .gitignore",
     "test": "npm run test --workspaces --if-present",

--- a/packages/shared/README.md
+++ b/packages/shared/README.md
@@ -1,0 +1,67 @@
+# `@ronl/shared`
+
+Types and constant data that the backend and the frontends must never author
+separately. The RIP phase→process-key map, the PA dossier seed, the Operaton and
+auth type declarations.
+
+## There is no `test` script here, deliberately
+
+Every other workspace has a test runner and is held to a **per-file 80% branch
+floor** ([#80](https://github.com/sgort/ronl-business-api/issues/80)). This one
+has neither, and that is a decision rather than an omission
+([#84](https://github.com/sgort/ronl-business-api/issues/84)).
+
+**The package contains no executable logic**: no functions, no `if`, no
+`switch`, no loops. Today that is 11 files and ~1,500 lines of type declarations
+and constant arrays. A test runner over that would measure an empty set and
+report a green check that means nothing — the same false comfort the coverage
+floor exists to remove.
+
+So instead of measuring the logic, the package is kept free of it, and
+`npm run check-shared` enforces that:
+
+```
+check-shared-declarations: 11 file(s) in packages/shared/src/ — declarations and constant data only.
+```
+
+It runs in the `audit` job, which has no `paths:` filter and is a required
+check, so every pull request reaches it.
+
+## Why this matters more than it sounds
+
+A function placed here is not _under-tested_. It is **outside the measurement
+entirely** — no run fails, no reviewer sees a number move, and the first hint is
+someone wondering later why coverage dropped in the package that had to
+re-implement it.
+
+That is not hypothetical. **v2026.09.4 moved a branching label helper out of
+this package** for exactly this reason. The helper was correct; its branches
+were simply never counted, and a passing test run concealed that.
+
+This package is the natural home for anything both frontend and backend need,
+which is precisely why the rule needs a check rather than a convention.
+
+## If you were about to add a function here
+
+Put it in the package that uses it. If both frontend and backend need it, it
+belongs in whichever one owns the behaviour — duplicating a few lines is
+cheaper than moving branching logic somewhere nothing measures it.
+
+If the package genuinely needs runtime logic, that is a deliberate change and
+the documented fallback, not a workaround:
+
+1. Give it a Vitest runner with the same per-file `branches: 80` floor.
+2. Wire that suite into the workflows that already carry `packages/shared/**` in
+   their `paths:` filter — the way `pa-cockpit`'s suite was added to the
+   frontend workflows.
+3. Delete `scripts/check-shared-declarations.mjs` and its npm script, and this
+   section with them.
+
+Do all three or none. Deleting the check without adding the runner removes the
+only thing standing between this package and unmeasured logic.
+
+## Build
+
+`tsc` to `dist/`, consumed by the other workspaces through the workspace
+protocol. `npm run build --workspace=@ronl/shared` — the backend and frontend
+builds do this for you.

--- a/scripts/check-shared-declarations.mjs
+++ b/scripts/check-shared-declarations.mjs
@@ -1,0 +1,125 @@
+#!/usr/bin/env node
+/**
+ * check-shared-declarations.mjs — @ronl/shared holds declarations, not logic.
+ *
+ * THE GAP THIS CLOSES (#84). The per-file 80% branch floor (#80) is enforced in
+ * the five workspaces that have a test runner. `@ronl/shared` is not one of
+ * them, so a function placed there is not under-tested — it is outside the
+ * measurement entirely. No run fails, no reviewer sees a number move, and the
+ * first hint is someone wondering later why coverage dropped in the package
+ * that had to re-implement it.
+ *
+ * That is not hypothetical: v2026.09.4 moved a branching label helper OUT of
+ * this package for exactly this reason. The helper was fine; the measurement
+ * was silently absent.
+ *
+ * WHY A CHECK RATHER THAN A TEST RUNNER. Giving `shared` its own runner was the
+ * other option, and it is worse today: the package contains zero executable
+ * lines, so the runner would measure an empty set and report a green check that
+ * means nothing — the same class of false comfort the coverage floor exists to
+ * remove. "This package is declarations and constants" is a real, checkable
+ * property, and it explains WHY there is no runner. If `shared` ever genuinely
+ * needs runtime logic, delete this script and give it a Vitest runner with the
+ * same per-file floor; that is the documented fallback, not a workaround.
+ *
+ * WHY THE COMPILER API RATHER THAN GREP. A regex cannot tell
+ * `(x: string) => void` in an interface — a FunctionType, perfectly fine here —
+ * from `const f = (x) => {...}`, an ArrowFunction, which is not. It would also
+ * miss a function expression assigned to a const. The TypeScript parser knows
+ * the difference; a pattern over text does not, and a check with false
+ * positives gets disabled.
+ *
+ * Exit 0 when the package is declarations and constant data only, 1 otherwise.
+ * The failure names the file, the line, and where the logic should live
+ * instead — a check that only says "a rule was broken" makes the reader guess
+ * at the fix.
+ */
+
+import { readFileSync, readdirSync, statSync } from 'node:fs';
+import { join, relative } from 'node:path';
+import ts from 'typescript';
+
+const ROOT = 'packages/shared/src';
+
+/** Every .ts file under ROOT, recursively. */
+function sources(dir) {
+  const out = [];
+  for (const name of readdirSync(dir)) {
+    const full = join(dir, name);
+    if (statSync(full).isDirectory()) out.push(...sources(full));
+    else if (name.endsWith('.ts') && !name.endsWith('.d.ts')) out.push(full);
+  }
+  return out.sort();
+}
+
+/**
+ * Node kinds that mean "this package now executes something".
+ *
+ * Deliberately NOT flagged: FunctionType and MethodSignature (a function shape
+ * inside an interface is a declaration), and every type-level construct --
+ * conditional types, mapped types, unions. Those are what this package is for.
+ */
+const FORBIDDEN = new Map([
+  [ts.SyntaxKind.FunctionDeclaration, 'a function declaration'],
+  [ts.SyntaxKind.FunctionExpression, 'a function expression'],
+  [ts.SyntaxKind.ArrowFunction, 'an arrow function'],
+  [ts.SyntaxKind.ClassDeclaration, 'a class declaration'],
+  [ts.SyntaxKind.MethodDeclaration, 'a method implementation'],
+  [ts.SyntaxKind.IfStatement, 'an if statement'],
+  [ts.SyntaxKind.SwitchStatement, 'a switch statement'],
+  [ts.SyntaxKind.ConditionalExpression, 'a ternary'],
+  [ts.SyntaxKind.ForStatement, 'a for loop'],
+  [ts.SyntaxKind.ForOfStatement, 'a for-of loop'],
+  [ts.SyntaxKind.ForInStatement, 'a for-in loop'],
+  [ts.SyntaxKind.WhileStatement, 'a while loop'],
+  [ts.SyntaxKind.TryStatement, 'a try/catch'],
+]);
+
+const findings = [];
+
+for (const file of sources(ROOT)) {
+  const text = readFileSync(file, 'utf8');
+  const sf = ts.createSourceFile(file, text, ts.ScriptTarget.Latest, true);
+
+  const visit = (node) => {
+    const what = FORBIDDEN.get(node.kind);
+    if (what) {
+      const { line } = sf.getLineAndCharacterOfPosition(node.getStart(sf));
+      findings.push({ file: relative('.', file), line: line + 1, what });
+    }
+    ts.forEachChild(node, visit);
+  };
+  ts.forEachChild(sf, visit);
+}
+
+const files = sources(ROOT).length;
+
+if (findings.length === 0) {
+  console.log(
+    `check-shared-declarations: ${files} file(s) in ${ROOT}/ — declarations and constant data only.`
+  );
+  process.exit(0);
+}
+
+console.error(`\n${findings.length} finding(s) in ${ROOT}/:\n`);
+for (const f of findings) {
+  console.error(`  ${f.file}:${f.line} — ${f.what}`);
+}
+console.error(
+  `
+@ronl/shared has no test runner, so executable logic placed here escapes the
+per-file 80% branch floor that every other workspace is held to (#80, #84). It
+is not under-tested; it is unmeasured.
+
+Put the function in the package that uses it. If both frontend and backend need
+it, it belongs in whichever one owns the behaviour -- duplicate a few lines
+rather than move branching logic somewhere nothing measures it. That is what
+v2026.09.4 did with the label helper this rule comes from.
+
+If this package genuinely needs runtime logic now, that is a deliberate change,
+not a workaround: give it a Vitest runner with the same per-file floor, wire it
+into the workflows that already carry packages/shared/** in their paths filter,
+and delete this script. See packages/shared/README.md.
+`
+);
+process.exit(1);


### PR DESCRIPTION
Closes #84.

The per-file 80% branch floor (#80) is enforced in the five workspaces that have a test runner. `@ronl/shared` is not one of them, so a function placed there is **not under-tested — it is outside the measurement entirely.** No run fails, no reviewer sees a number move, and the first hint is someone wondering later why coverage dropped in the package that had to re-implement it.

Not hypothetical: **v2026.09.4 moved a branching label helper out of this package** for exactly that reason. The helper was correct; its branches were simply never counted, and a passing test run concealed it. That was caught by hand, by someone who happened to look.

## Option 2 of the three the issue lays out

A test runner for `shared` was the alternative, and it is worse today: the package holds **zero executable lines**, so the runner would measure an empty set and report a green check that means nothing — the same false comfort the coverage floor exists to remove.

"This package is declarations and constants" is a real, checkable property, and it explains *why* there is no runner.

## Why the compiler API, not a regex

Load-bearing, not fastidiousness:

| construct | verdict |
| --- | --- |
| `format: (v: string) => string` in an interface | **fine** — a `FunctionType`, a declaration |
| `describe(value: string): string` | **fine** — a `MethodSignature` |
| `type Mapper<T> = (input: T) => string` | **fine** |
| `type Maybe<T> = T extends null ? never : T` | **fine** — a conditional *type* |
| `const shorten = (s: string) => s.slice(0, 3)` | **rejected** — an `ArrowFunction` |
| `function labelFor(…) { if (…) … }` | **rejected** |

A pattern over text cannot separate rows 1–4 from rows 5–6, and would also miss a function expression assigned to a const. A check with false positives is one people disable.

## Exercised in both directions

Not just "it passes today":

```
planted: function declaration + if statement + arrow function
  -> 3 finding(s), each with file, line and kind, exit 1

planted: function type + method signature + generic fn-type alias
         + conditional type + Record constant
  -> exit 0
```

## Where it runs, and why there

The `audit` job, alongside the formatter — **not** a workspace suite. `audit` has no `paths:` filter and is the required check, so every pull request reaches it. A suite gated on `packages/shared/**` would not catch the pull request that first adds a function to a package the filter does not yet watch.

It costs nothing beyond the `npm ci` the formatter already needed — it reads the TypeScript compiler from `node_modules`.

## The failure names the fix

Not merely that a rule was broken:

> Put the function in the package that uses it. If both frontend and backend need it, it belongs in whichever one owns the behaviour — duplicate a few lines rather than move branching logic somewhere nothing measures it.

And `packages/shared/README.md` records the decision **where someone opening the package to add a helper will actually meet it** — issue acceptance criterion 1. It also states the documented fallback: if the package ever genuinely needs runtime logic, give it a Vitest runner with the same per-file floor, wire it into the workflows already carrying `packages/shared/**` in their paths filter, and delete this check. All three or none — deleting the check alone removes the only thing standing between the package and unmeasured logic.

## Verification

- `npm run check-shared`: `11 file(s) in packages/shared/src/ — declarations and constant data only.`
- `npm run check-format`: clean
- `npm run check-supply-chain`: **OK**, 31 references — the new step is a `run:` step, so it adds no `uses:` and the register is untouched
- The `audit` job parses with the step between `Check formatting` and `Verify pin truth and register agreement`, `if: always()` like its neighbours