### PR TITLE
fix: make an unmodelled RIP phase unrepresentable

### DIFF
--- a/packages/backend/src/routes/rip.routes.test.ts
+++ b/packages/backend/src/routes/rip.routes.test.ts
@@ -45,21 +45,7 @@ import { RIP_PHASE_KEYS } from '@ronl/shared';
 import { parseSwimlane } from '../rip-swimlane/bpmn-swimlane';
 
 /** Every phase modelled as BPMN — the exact list both phase endpoints query. */
-const MODELLED_KEYS = RIP_PHASE_KEYS.map((p) => p.processDefinitionKey).filter(Boolean);
-
-/**
- * A phase the catalogue knows but has no process model for, used to exercise
- * the 409 branch. Derived rather than pinned: R2.3 held this role until it was
- * deployed, and a literal means every future deployment breaks two tests that
- * have nothing to do with the phase being deployed.
- *
- * When the whole ladder is modelled this becomes undefined and the two tests
- * below skip visibly. That is the signal to delete them AND the
- * PHASE_NOT_MODELLED branch they cover, deliberately -- not to leave them
- * limping.
- */
-const UNMODELLED_CODE = RIP_PHASE_KEYS.find((p) => !p.processDefinitionKey)?.code;
-const itIfUnmodelled = UNMODELLED_CODE ? it : it.skip;
+const MODELLED_KEYS = RIP_PHASE_KEYS.map((p) => p.processDefinitionKey);
 
 const svc = operatonService as unknown as {
   getRipPhaseActiveList: jest.Mock;
@@ -103,18 +89,6 @@ describe('lists', () => {
     expect(svc.getRipPhaseActiveList).not.toHaveBeenCalled();
   });
 
-  itIfUnmodelled(
-    'GET /phases/:code/active answers 409, not an empty list, for a known but unmodelled phase',
-    async () => {
-      // The distinction that matters: a caller must be able to tell "this phase
-      // has no process yet" from "this phase is deployed and currently idle".
-      const res = await auth(request(app).get(`/v1/rip/phases/${UNMODELLED_CODE}/active`));
-      expect(res.status).toBe(409);
-      expect(res.body.error.code).toBe('PHASE_NOT_MODELLED');
-      expect(svc.getRipPhaseActiveList).not.toHaveBeenCalled();
-    }
-  );
-
   it('GET /phases/:code/active → 500 on service failure', async () => {
     svc.getRipPhaseActiveList.mockRejectedValue(new Error('boom'));
     const res = await auth(request(app).get('/v1/rip/phases/R2.1/active'));
@@ -134,15 +108,6 @@ describe('lists', () => {
     expect(res.status).toBe(404);
     expect(res.body.error.code).toBe('UNKNOWN_PHASE');
   });
-
-  itIfUnmodelled(
-    'GET /phases/:code/completed answers 409 for a known but unmodelled phase',
-    async () => {
-      const res = await auth(request(app).get(`/v1/rip/phases/${UNMODELLED_CODE}/completed`));
-      expect(res.status).toBe(409);
-      expect(res.body.error.code).toBe('PHASE_NOT_MODELLED');
-    }
-  );
 
   it('the fixed /phases routes are not swallowed by /phases/:code', async () => {
     // deployment-status, counts and active sit one path segment shorter than
@@ -422,13 +387,6 @@ describe('GET /phases/:code/model', () => {
     const res = await auth(request(app).get('/v1/rip/phases/R9.9/model'));
     expect(res.status).toBe(404);
     expect(res.body.error.code).toBe('UNKNOWN_PHASE');
-    expect(svc.getPhaseSwimlaneModel).not.toHaveBeenCalled();
-  });
-
-  itIfUnmodelled('409s a known but unmodelled phase without touching the engine', async () => {
-    const res = await auth(request(app).get(`/v1/rip/phases/${UNMODELLED_CODE}/model`));
-    expect(res.status).toBe(409);
-    expect(res.body.error.code).toBe('PHASE_NOT_MODELLED');
     expect(svc.getPhaseSwimlaneModel).not.toHaveBeenCalled();
   });
 

--- a/packages/backend/src/routes/rip.routes.ts
+++ b/packages/backend/src/routes/rip.routes.ts
@@ -12,20 +12,30 @@ const logger = createLogger('rip-routes');
 router.use(jwtMiddleware);
 router.use(tenantMiddleware);
 
-/** Every RIP phase modelled as BPMN, in ladder order. */
-const modelledKeys = () =>
-  RIP_PHASE_KEYS.map((p) => p.processDefinitionKey).filter((k): k is string => !!k);
+/**
+ * Every RIP phase's process-definition key, in ladder order.
+ *
+ * No filter since #85: `processDefinitionKey` is required on `RipPhaseKey`, so
+ * every entry has one. This used to drop the unmodelled phases, of which there
+ * have been none since R5.3 completed the ladder (#72).
+ */
+const modelledKeys = () => RIP_PHASE_KEYS.map((p) => p.processDefinitionKey);
 
 /**
  * Resolve a `:code` path param to its process-definition key, answering on
  * `res` and returning null when it cannot.
  *
- * The two failure modes are deliberately distinct. An unknown code is a
- * client error — a typo or a stale link — and 404s. A known code with no
- * process model yet (R2.3 today) is a state of the world, not a bad request,
- * and 409s with the phase echoed back. Neither returns an empty list: a phase
- * that has no deployed process must not be indistinguishable from a deployed
- * one that happens to have no instances.
+ * One failure mode, not two. An unknown code is a client error — a typo or a
+ * stale link — and 404s.
+ *
+ * There used to be a second: a known code with no process model yet answered
+ * 409 PHASE_NOT_MODELLED, so that a caller could tell "this phase has no
+ * process" from "this phase is deployed and currently idle". R5.3 completed the
+ * ladder (#72) and `processDefinitionKey` became required on `RipPhaseKey`
+ * (#85), which makes that state unrepresentable rather than merely absent — the
+ * compiler rejects an entry without a key, so no input can reach the branch.
+ * Its three tests had been skipping since the ladder closed; they were deleted
+ * with it rather than left limping.
  */
 function resolvePhaseKey(code: string, res: Response): string | null {
   const phase = RIP_PHASE_KEYS.find((p) => p.code === code);
@@ -33,16 +43,6 @@ function resolvePhaseKey(code: string, res: Response): string | null {
     res.status(404).json({
       success: false,
       error: { code: 'UNKNOWN_PHASE', message: `Unknown RIP phase '${code}'` },
-    });
-    return null;
-  }
-  if (!phase.processDefinitionKey) {
-    res.status(409).json({
-      success: false,
-      error: {
-        code: 'PHASE_NOT_MODELLED',
-        message: `RIP phase '${code}' has no process model deployed yet`,
-      },
     });
     return null;
   }
@@ -78,11 +78,12 @@ router.get('/phases/active', async (req, res) => {
     });
   }
   const tenantId = req.user.tenantId;
-  const phases = RIP_PHASE_KEYS.filter(
-    (p): p is typeof p & { processDefinitionKey: string } => !!p.processDefinitionKey
-  );
+  // No filter since #85 — every phase carries a process-definition key, so the
+  // type predicate that used to narrow this list has nothing left to narrow.
   const settled = await Promise.allSettled(
-    phases.map((p) => operatonService.getRipPhaseActiveList(p.processDefinitionKey, tenantId))
+    RIP_PHASE_KEYS.map((p) =>
+      operatonService.getRipPhaseActiveList(p.processDefinitionKey, tenantId)
+    )
   );
   const rows: Array<
     Awaited<ReturnType<typeof operatonService.getRipPhaseActiveList>>[number] & {
@@ -94,11 +95,11 @@ router.get('/phases/active', async (req, res) => {
     if (result.status === 'fulfilled') {
       anySucceeded = true;
       for (const instance of result.value) {
-        rows.push({ ...instance, phaseCode: phases[i].code });
+        rows.push({ ...instance, phaseCode: RIP_PHASE_KEYS[i].code });
       }
     } else {
       logger.error('Failed to list active RIP phase instances for the aggregate', {
-        phaseCode: phases[i].code,
+        phaseCode: RIP_PHASE_KEYS[i].code,
         tenantId,
         error:
           result.reason instanceof Error

--- a/packages/frontend/src/components/InfraBoardDashboard/PhaseDetail.tsx
+++ b/packages/frontend/src/components/InfraBoardDashboard/PhaseDetail.tsx
@@ -55,13 +55,13 @@ function computeHealth(blocked: string | null, daysInStep: number): HealthKey {
 
 export default function PhaseDetail({ phaseCode, onBack }: Props) {
   const phase = ripPhaseByCode(phaseCode);
-  // Null for a phase with no process model: there are no instances to ask
-  // for, and the phase endpoints answer 409 rather than an empty list.
-  const livePhaseCode = phase?.processDefinitionKey ? phaseCode : null;
-  // The phase whose completed instances feed this one's ready list. Null when
-  // that predecessor has no process model, since it can have no completions.
+  // Null for a code the catalogue does not know — there are no instances to ask
+  // for. Since #85 every catalogued phase has a process model, so this no
+  // longer tests for a missing key, only for a missing phase.
+  const livePhaseCode = phase ? phaseCode : null;
+  // The phase whose completed instances feed this one's ready list.
   const predecessor = previousModelledPhase(phaseCode);
-  const predecessorLiveCode = predecessor?.processDefinitionKey ? predecessor.code : null;
+  const predecessorLiveCode = predecessor ? predecessor.code : null;
   const { data: deployment } = useDeployedProcessKeys();
   const { data: liveCountsRaw } = useLivePhaseCounts();
   const [tab, setTab] = useState<'starten' | 'wip' | 'gereed'>('starten');
@@ -208,7 +208,7 @@ export default function PhaseDetail({ phaseCode, onBack }: Props) {
           // and start without one.
           const candidate = readiness.candidates.find((c) => c.projectNumber === nr);
           return businessApi.process.start(
-            phase!.processDefinitionKey!,
+            phase!.processDefinitionKey,
             candidate
               ? { projectNumber: candidate.projectNumber, projectName: candidate.projectName }
               : { projectNumber: nr },
@@ -230,7 +230,7 @@ export default function PhaseDetail({ phaseCode, onBack }: Props) {
     setSubmitting(true);
     setFallbackError(null);
     try {
-      const res = await businessApi.process.start(phase!.processDefinitionKey!, {});
+      const res = await businessApi.process.start(phase!.processDefinitionKey, {});
       if (res.success) {
         setFallbackStarted(true);
         reloadWip();

--- a/packages/frontend/src/components/InfraBoardDashboard/ProjectDetail.tsx
+++ b/packages/frontend/src/components/InfraBoardDashboard/ProjectDetail.tsx
@@ -234,9 +234,10 @@ export default function ProjectDetail({ projectRef, onBack }: Props) {
   // than guessed.
   const isOtherPhaseSelected = isLive && selPhase !== currentPhaseCode;
   const businessKey = currentRow?.businessKey ?? null;
-  // Unmodelled phase codes 409 the completed-instances endpoint on purpose
-  // (see infra.api.ts) — only ask for phases that actually have a process.
-  const selPhaseModelled = !!ripPhaseByCode(selPhase)?.processDefinitionKey;
+  // Every catalogued phase has a process since #85, so this now only asks
+  // whether the code is one the catalogue knows — an unknown code still 404s
+  // rather than being sent to the engine.
+  const selPhaseModelled = !!ripPhaseByCode(selPhase);
   const { data: selPhaseCompleted } = useRipPhaseCompleted(
     isOtherPhaseSelected && selPhaseModelled ? selPhase : null
   );

--- a/packages/frontend/src/pages/infra-board/rip-phase-counts.ts
+++ b/packages/frontend/src/pages/infra-board/rip-phase-counts.ts
@@ -84,7 +84,7 @@ export function normalizeLiveCounts(
 ): Record<string, PhaseCounts> {
   const out: Record<string, PhaseCounts> = {};
   for (const phase of phases) {
-    if (!phase.processDefinitionKey) continue;
+    // No key guard since #85 — every phase has one.
     const c = raw[phase.processDefinitionKey];
     if (c) out[phase.code] = { wip: c.wip, gereed: c.gereed };
   }

--- a/packages/frontend/src/pages/infra-board/rip-phases.catalog.test.ts
+++ b/packages/frontend/src/pages/infra-board/rip-phases.catalog.test.ts
@@ -96,23 +96,25 @@ describe('previousModelledPhase / skippedPhasesBefore', () => {
 
 describe('getPhaseDeployStatus', () => {
   const withKey: RipPhase = { ...ripPhaseByCode('R2.1')! };
-  // Synthesised, because no real phase can play this role any more: every
-  // phase in the catalogue now either carries a processDefinitionKey or is
-  // is consulted. The branch is still reachable in practice -- a phase
-  // catalogued ahead of its BPMN being deployed sits in exactly this state --
-  // so the fixture is built rather than deleted along with the coverage.
-  const withoutKey: RipPhase = { ...ripPhaseByCode('R6.1')!, processDefinitionKey: undefined };
+
+  // The third case here was 'is ontwerp when the phase has no key', against a
+  // synthesised `{ ...phase, processDefinitionKey: undefined }` fixture. #85
+  // made `processDefinitionKey` required, so that object no longer type-checks
+  // and the state it described is unrepresentable.
+  //
+  // Its comment argued the branch was "still reachable in practice -- a phase
+  // catalogued ahead of its BPMN being deployed". That conflated two different
+  // things, and the distinction is why the remaining two tests are enough:
+  // catalogued-ahead-of-DEPLOYMENT is the second case below, which is live and
+  // covered. Catalogued-ahead-of-MODELLING is what the deleted fixture stood
+  // for, and the compiler now rejects it.
 
   it('is gedeployed when the phase has a key and it is in the deployed set', () => {
     expect(getPhaseDeployStatus(withKey, new Set(['RipR21Process']))).toBe('gedeployed');
   });
 
-  it('is ontwerp when the phase has a key but it is not in the deployed set', () => {
+  it('is ontwerp when the phase is modelled but not deployed on this environment', () => {
     expect(getPhaseDeployStatus(withKey, new Set())).toBe('ontwerp');
-  });
-
-  it('is ontwerp when the phase has no key', () => {
-    expect(getPhaseDeployStatus(withoutKey, new Set())).toBe('ontwerp');
   });
 });
 

--- a/packages/frontend/src/pages/infra-board/rip-phases.catalog.ts
+++ b/packages/frontend/src/pages/infra-board/rip-phases.catalog.ts
@@ -36,7 +36,17 @@ export interface RipPhase {
   kredietBeslisser?: string;
   weeks: number;
   bron: string;
-  processDefinitionKey?: string;
+  /**
+   * Required, mirroring `RipPhaseKey` in `@ronl/shared` since #85. Every phase
+   * in the ladder is modelled and deployed, so a phase without a process is
+   * unrepresentable rather than merely absent — the guards that used to test
+   * for one are gone from here and from the backend's 409 branch alike.
+   *
+   * Note this is a SECOND declaration of the same fact, populated from
+   * RIP_PHASE_KEYS below. Narrowing the shared type does not narrow this one;
+   * they have to be kept in step by hand.
+   */
+  processDefinitionKey: string;
   /**
    * True when finishing this phase does not imply moving on to the next one.
    * R5.3 is the only one: it has four end events and just one leads to R5.4 —
@@ -444,10 +454,26 @@ const CONTENT: Omit<RipPhase, 'processDefinitionKey'>[] = [
   },
 ];
 
-export const RIP_PHASES: RipPhase[] = CONTENT.map((c) => ({
-  ...c,
-  processDefinitionKey: RIP_PHASE_KEYS.find((k) => k.code === c.code)?.processDefinitionKey,
-}));
+export const RIP_PHASES: RipPhase[] = CONTENT.map((c) => {
+  const key = RIP_PHASE_KEYS.find((k) => k.code === c.code)?.processDefinitionKey;
+  // CONTENT and RIP_PHASE_KEYS must cover the same twelve codes. They are two
+  // hand-maintained lists of the same ladder -- this file holds the editorial
+  // content, @ronl/shared holds the engine fact -- and nothing but this join
+  // relates them.
+  //
+  // Before #85 a miss yielded `undefined` and the phase rendered as "ontwerp"
+  // forever: a silent wrong answer, which is how R2.2 once read "In ontwerp"
+  // while RipR22Process was deployed and running. Throwing is louder and
+  // cheaper: both lists are static, so this fires at module load in the first
+  // test that imports the catalogue, not in front of a user.
+  if (!key) {
+    throw new Error(
+      `RIP phase '${c.code}' is in the catalogue but has no processDefinitionKey in @ronl/shared. ` +
+        `Add it to RIP_PHASE_KEYS, or remove the phase from CONTENT.`
+    );
+  }
+  return { ...c, processDefinitionKey: key };
+});
 
 export const ripPhaseByCode = (code: string): RipPhase | undefined =>
   RIP_PHASES.find((p) => p.code === code);
@@ -478,10 +504,11 @@ export function getPhaseDeployStatus(
   phase: RipPhase,
   deployedKeys: ReadonlySet<string>
 ): RipDeployStatus {
-  if (phase.processDefinitionKey && deployedKeys.has(phase.processDefinitionKey)) {
-    return 'gedeployed';
-  }
-  return 'ontwerp';
+  // Modelled is not deployed. Every phase carries a process-definition key
+  // since #85, so the `phase.processDefinitionKey &&` half of this guard is
+  // gone -- but "ontwerp" is very much alive: it is what a phase reads when its
+  // process is modelled and simply not on this environment yet.
+  return deployedKeys.has(phase.processDefinitionKey) ? 'gedeployed' : 'ontwerp';
 }
 
 /**

--- a/packages/frontend/src/services/infra.api.ts
+++ b/packages/frontend/src/services/infra.api.ts
@@ -399,10 +399,9 @@ function startOfDay(d: Date) {
  * entirely by INFRA_PROCESS_KEYS below.
  */
 const PROCESS_DISPLAY_NAMES: Record<string, string> = Object.fromEntries(
-  RIP_PHASES.filter((p) => p.processDefinitionKey).map((p) => [
-    p.processDefinitionKey as string,
-    `RIP ${p.code} — ${p.name}`,
-  ])
+  // No filter and no cast since #85: processDefinitionKey is required on
+  // RipPhase, so every catalogued phase contributes a name.
+  RIP_PHASES.map((p) => [p.processDefinitionKey, `RIP ${p.code} — ${p.name}`])
 );
 
 /**

--- a/packages/shared/src/rip-phases.ts
+++ b/packages/shared/src/rip-phases.ts
@@ -3,13 +3,21 @@
  * process-definition key. This is the one fact backend and frontend must
  * never author separately — see docs/superpowers/specs/2026-08-10-rip-phase-catalogue-deployment-status-design.md.
  *
- * `processDefinitionKey` is undefined until a phase is modelled as BPMN;
- * fill it in at the same time the process itself is deployed.
+ * `processDefinitionKey` is REQUIRED. It was optional while the ladder was
+ * being built — R2.3 was the last phase to carry no model — and the backend
+ * answered 409 PHASE_NOT_MODELLED for such a phase. R5.3 completed the ladder
+ * (#72), every entry below has a key, and #85 removed that branch: an
+ * unmodelled phase is now unrepresentable rather than merely absent, so the
+ * compiler rejects one instead of the code answering for it at runtime.
+ *
+ * A phase added here without a deployed process would therefore be a type
+ * error, which is the point. Model and deploy the process first, then add the
+ * entry — the order the ladder was built in anyway.
  */
 export interface RipPhaseKey {
   code: string; // 'R2.1' … 'R6.1'
   stage: string; // 'R2' | 'R3' | 'R4' | 'R5' | 'R6'
-  processDefinitionKey?: string;
+  processDefinitionKey: string;
 }
 
 export const RIP_PHASE_KEYS: RipPhaseKey[] = [


### PR DESCRIPTION
Closes #85. `processDefinitionKey` becomes **required** on `RipPhaseKey` in `@ronl/shared`, and the `PHASE_NOT_MODELLED` 409 branch goes with it.

The branch answered for a phase the catalogue knew but had no BPMN process for — R2.3 held that role last. R5.3 completed the ladder (#72), all twelve entries carry a key, and the branch became unreachable: **no input can produce a phase without one.** Its three tests had been reporting as skipped on every run since, which is exactly what the fixture was built to signal:

> When the whole ladder is modelled this becomes undefined and the two tests below skip visibly. **That is the signal to delete them AND the `PHASE_NOT_MODELLED` branch they cover**, deliberately — not to leave them limping.

## Option 1, not option 2

Deleting the branch while leaving the type optional would have been cheaper and worse: a future phase added without a key would then reach Operaton with `undefined` instead of getting a clean 409. Requiring the field makes that a **compile error** instead — the state is unrepresentable rather than merely absent.

## One of the issue's arguments does not hold

#85 says the dead branch is "dead weight pulling `rip.routes.ts` down … under the new threshold". Measured before the change: **94.11% branches**, against a floor of `branches: 80`. It was 14 points clear, and the floor was never at risk.

Deleting it still improves the number honestly — **98.13 → 100% statements, 94.11 → 96.96% branches** — but the coverage framing is not repeated in the code comments, because it was not true.

## Two consumers the issue did not name mattered more than the two it did

**`PhaseDetail.tsx` used `phase!.processDefinitionKey!`** — a *double* non-null assertion, at two call sites. Both lose their second `!`. That is the strongest argument for narrowing rather than merely deleting, and it appears nowhere in the issue.

**`rip-phases.catalog.ts` re-declares `processDefinitionKey`** in a frontend-local `RipPhase`, populated from `RIP_PHASE_KEYS` via a `?.` lookup. **Narrowing the shared type does not narrow that one.** It now follows, carrying a comment saying it is a second declaration of the same fact that has to be kept in step by hand.

That lookup previously yielded `undefined` on a miss and the phase rendered `ontwerp` forever — a silent wrong answer, and precisely how R2.2 once read *"In ontwerp"* while `RipR22Process` was deployed and running. It now throws, naming the phase and both lists. Both are static and agree **12/12**, so a miss is an editing mistake that fires in the first test importing the catalogue, never in front of a user.

## A deleted test argued against this change

`rip-phases.catalog.test.ts` built a `withoutKey` fixture whose comment said the branch was *"still reachable in practice — a phase catalogued ahead of its BPMN being deployed sits in exactly this state"*.

That conflates two different things:

| | status |
| --- | --- |
| catalogued ahead of **deployment** | **live** — that is what `ontwerp` means, still covered; the remaining test is renamed to say so |
| catalogued ahead of **modelling** | what the fixture stood for — now a type error |

The reasoning is recorded where the fixture used to be, rather than the test simply disappearing.

## Verification

Full suites, every workspace, no filters:

| workspace | result |
| --- | --- |
| `@ronl/backend` | **86 suites, 2008 tests, 0 skipped** (was 3 skipped / 2011) |
| `@ronl/frontend` | 110 files, 1103 tests |
| `@ronl/pa-cockpit` | 43 files, 476 tests |
| `@ronl/pa-demo` | 19 files, 106 tests |
| `@ronl/public-site` | 31 files, 225 tests |

`type-check` exit 0 in all six workspaces · backend and frontend lint clean · `check-format` clean · `check-supply-chain` **OK**, 31 references.

## Verified in the running app

Against a local Operaton with all twelve RIP processes deployed, on this branch:

> **`12 / 12` Deelprocessen inzetbaar · `0` Wacht op deployment** — every phase reads **Gedeployed**, per-phase Klaar/WIP/Gereed counts populated.

That exercises three things no unit test covers end to end: the catalogue join actually resolving (the merge throws if it cannot), the simplified `getPhaseDeployStatus` guard, and `normalizeLiveCounts` without its deleted key guard.

## Acceptance

- [x] A decision recorded in the code, not only in the issue
- [x] The three `itIfUnmodelled` tests and the helper removed; backend suite reports **0 skipped**
- [x] `processDefinitionKey` required in `@ronl/shared`; the `!!k` / `!!p.processDefinitionKey` filters at `rip.routes.ts:17` and `:82` are gone rather than justified
