### PR TITLE
ci: give acc the deletion and non_fast_forward rules main already had

### DIFF
--- a/SECURITY-PIPELINE.md
+++ b/SECURITY-PIPELINE.md
@@ -13,18 +13,21 @@ build shape differs, and the differences matter in both directions.
 
 These are GitHub settings, not files. Without them parts of the policy are inert.
 
-| Setting                         | Required state                 | Why                                                                                            |
-| ------------------------------- | ------------------------------ | ---------------------------------------------------------------------------------------------- |
-| Renovate GitHub App             | installed, scoped to this repo | `renovate.json` is inert until it is                                                           |
-| Dependabot **alerts**           | enabled                        | `vulnerabilityAlerts` consumes this feed; without it the no-cooldown security lane never fires |
-| Dependabot **security updates** | **disabled**                   | it opens competing PRs that ignore the 14-day cooldown                                         |
-| Merge methods                   | merge commits only             | squash and rebase rewrite the SHAs a changelog entry names                                     |
-| `acc` ruleset                   | require PR + `audit` check     | a workflow that runs but cannot block is advice, not a gate                                    |
+| Setting                         | Required state                                 | Why                                                                                            |
+| ------------------------------- | ---------------------------------------------- | ---------------------------------------------------------------------------------------------- |
+| Renovate GitHub App             | installed, scoped to this repo                 | `renovate.json` is inert until it is                                                           |
+| Dependabot **alerts**           | enabled                                        | `vulnerabilityAlerts` consumes this feed; without it the no-cooldown security lane never fires |
+| Dependabot **security updates** | **disabled**                                   | it opens competing PRs that ignore the 14-day cooldown                                         |
+| Merge methods                   | merge commits only                             | squash and rebase rewrite the SHAs a changelog entry names                                     |
+| `acc` ruleset                   | PR + `audit` + `deletion` + `non_fast_forward` | a workflow that runs but cannot block is advice, not a gate                                    |
+| `main` ruleset                  | the same four rules                            | `main` is promoted from `acc`; the branch that deploys production must not be the weaker one   |
 
 ## Pinned
 
 **31 `uses:` references across 10 workflows, all 31 digest-pinned.** Verified on
-`acc` at `bdad286`, 12 September 2026.
+`acc` at `8e8fcdb`, 12 September 2026 — by `npm run check-supply-chain`, which
+blocks the `audit` job, so this headline cannot drift from the workflows without
+failing a merge.
 
 | Dependency                          | Pin                                                 | Version           | Maintained by                                                                        |
 | ----------------------------------- | --------------------------------------------------- | ----------------- | ------------------------------------------------------------------------------------ |
@@ -99,24 +102,33 @@ open a routine-looking digest update reverting **all nine** references to
 old. Updates for this dependency are therefore disabled in `renovate.json`, with
 the reasoning recorded inline there too.
 
-### `node-version` floats — and three sources disagree
+### ~~`node-version` floats — and three sources disagree~~ — closed 2026-09-12
 
-Eight of the nine workflows request `node-version: '20'`, which resolves to
-whatever 20.x `actions/setup-node` downloads at run time. Under a policy of
-"nothing a pipeline downloads may float", that is an exception.
+**No longer an exception.** Kept here rather than deleted, because what it got
+wrong is worth more than what it got right.
 
-The ninth is deliberate and pinned differently: the `renovate-config-validator`
-step in `zizmor.yml` sets `node-version: '24'`, because `renovate@44.50.3`
-declares `engines.node ^24.11.0` and npm accepts a mismatch with an
-`EBADENGINE` **warning** rather than refusing — so the validator had been
-running unsupported and green.
+It read: eight of the nine workflows request `node-version: '20'`, resolving to
+whatever 20.x the runner downloads; `.nvmrc` says `22`; `engines.node` says
+`>=20.13.0`; developers therefore work on a different major than the one
+producing the deployed artifact.
 
-Worth recording alongside it: **`.nvmrc` says `22`** while CI builds on 20, and
-`package.json` declares `engines.node >= 20.13.0`. Developers therefore work on a
-different Node major than the one producing the deployed artifact. Not a
-supply-chain defect, but a divergence that belongs on the record — and
-`node-version-file: .nvmrc` would close both issues at once if the two are meant
-to agree.
+**There was a fourth source, and it was the one that settled it.** Both App
+Service plans run **`NODE|22-lts`**. So the workflows were not merely floating —
+they were building the deployed backend on a major the host does not run. That
+fact appears nowhere in the paragraph above, and it is what turned a
+three-way stylistic disagreement into a one-sided answer.
+
+Closed by [#36](https://github.com/sgort/ronl-business-api/issues/36): the eight
+deploy workflows now read `node-version-file: .nvmrc`, `.nvmrc` carries an exact
+`22.22.0` rather than a bare major — the same "may not float" rule the digests
+above follow — and `engines.node` is `>=22`. Renovate's `node` manager parses
+`.nvmrc`, so it stays maintained rather than hand-bumped.
+
+`zizmor.yml` keeps its literal `node-version: '24'`, and that part was right all
+along: `renovate@44.50.3` declares `engines.node ^24.11.0`, and npm accepts a
+mismatch with an `EBADENGINE` **warning** rather than refusing — so the validator
+had been running unsupported and green. That pin is load-bearing; do not sweep it
+into the shared file.
 
 ### The backend is deployed outside CI, and its dependencies are unpinned
 
@@ -175,7 +187,10 @@ What that means for this document's scope:
   structural, not carelessness.
 
 This is the widest floating surface in the repository and, unlike the container
-exception above, it is fixable from our side — see "Queued CI improvements".
+exception above, it is fixable from our side —
+[#34](https://github.com/sgort/ronl-business-api/issues/34) pins the bundle's
+dependencies, [#35](https://github.com/sgort/ronl-business-api/issues/35) moves
+the deploy into a workflow. Both still open.
 
 ## What the audit cannot see
 

--- a/docs/the-gate-has-teeth.md
+++ b/docs/the-gate-has-teeth.md
@@ -230,18 +230,52 @@ no manifest change.
 
 ### 3.7 The rulesets — what makes it _enforcement_
 
-A workflow that runs but cannot block is advice. **Two** rulesets exist, and both
-require a pull request and a passing `audit`:
+A workflow that runs but cannot block is advice. **Two** rulesets exist, and
+since 12 September 2026 they carry the same four rules:
 
-| Ruleset                 | Branch | Requires               |
-| ----------------------- | ------ | ---------------------- |
-| `acc supply-chain gate` | `acc`  | pull request + `audit` |
-| `main promotion gate`   | `main` | pull request + `audit` |
+| Ruleset                 | Branch | Rules                                                                             |
+| ----------------------- | ------ | --------------------------------------------------------------------------------- |
+| `acc supply-chain gate` | `acc`  | `pull_request`, `required_status_checks: [audit]`, `deletion`, `non_fast_forward` |
+| `main promotion gate`   | `main` | the same four                                                                     |
 
-Both are needed together: the check alone still lets a direct push bypass the
-gate. Neither sets `strict_required_status_checks_policy`, so a branch need not
-be up to date with its base to merge — which is why a stale red check on an
-un-rebased branch is not always a real failure.
+`deletion` and `non_fast_forward` reached `acc` last. `main` got them when it was
+created, during the promotion; `acc` went without for a month because the
+alignment work that was supposed to add them started at the item after and never
+came back. Two rulesets in one repository differed in a way nobody had decided —
+worth recording, because that is how the difference would have been read next
+time somebody compared them.
+
+**The two differ in exactly one parameter, deliberately:**
+
+|        | `require_extra_approval_for_unattributed_changes` |
+| ------ | ------------------------------------------------- |
+| `acc`  | `true`                                            |
+| `main` | **`false`**                                       |
+
+`main`'s was set false on purpose. Its promotion pull request carried commits
+under three author identities and the ruleset requires **zero** approvals, so
+with the flag on there would have been nobody able to give the extra approval it
+demanded — the gate would have deadlocked the merge it existed to protect. On
+`acc`, ordinary pull requests do not hit that shape, so the stricter default
+stays.
+
+Do not "tidy" them into agreement in either direction, and **read a ruleset back
+after writing it**. Omitting that parameter is not the same as setting it false:
+GitHub stores it as `true`, invisibly, and the create call that made `main`'s
+ruleset did exactly that before it was caught.
+
+Both rules are needed together with the check: `audit` alone still lets a direct
+push bypass the gate. Neither ruleset sets
+`strict_required_status_checks_policy`, so a branch need not be up to date with
+its base to merge — which is why a stale red check on an un-rebased branch is not
+always a real failure.
+
+**Classic branch protection still reports `allow_force_pushes: true` on both
+branches, and that is not a hole.** It is a second, older layer; the ruleset's
+`non_fast_forward` is what actually refuses the push. Read
+`gh api repos/…/rules/branches/<branch>` rather than the classic protection
+endpoint — it reports the **effective** rules from every ruleset at once, which is
+the only view that answers "what would actually stop me".
 
 Squash and rebase merging are **disabled repo-wide**, leaving merge commits only.
 Changelog entries name commits by SHA, and both alternatives rewrite those hashes


### PR DESCRIPTION
**C1 — the last item of the CI alignment.** The work started at C2 and only came back to this one at the end, so for a month `acc` could be force-pushed by anyone who could push to it, while `main` — created the same week, during the promotion — carried both rules.

The ruleset is edited, not the repository, so **this PR is the record rather than the change.**

## Applied and read back

A `PUT` replacing the full rules array, then read back — because the response to a write is not evidence. This repository already learned that omitting `require_extra_approval_for_unattributed_changes` has GitHub store it as `true`, invisibly, which nearly deadlocked the promotion PR the `main` ruleset existed to protect.

| | `acc` | `main` |
| --- | --- | --- |
| effective rules | `deletion`, `non_fast_forward`, `pull_request`, `required_status_checks: [audit]` | identical |
| `require_extra_approval_for_unattributed_changes` | **`true`** — preserved | **`false`** — deliberate, untouched |

Confirmed against `gh api repos/…/rules/branches/acc`, which reports the **effective** rules from every ruleset at once rather than one ruleset in isolation.

**The one remaining difference is deliberate.** `main`'s flag is `false` because its promotion carried commits under three author identities against a ruleset requiring **zero** approvals — the flag would have demanded an approval nobody could give. Preserved rather than harmonised, and now written down in both docs so the next person to compare them does not read it as drift.

**Classic protection still reports `allow_force_pushes: true` on both branches.** That is not a hole and never was for `main`: the ruleset's `non_fast_forward` refuses the push, and the classic setting is a vestigial second layer. Recorded, because reading the classic endpoint alone gives the wrong answer.

## Two corrections found while editing, both false rather than stale

- **An exception that no longer exists.** `SECURITY-PIPELINE.md` still read *"Eight of the nine workflows request `node-version: '20'`"* — false since #36. Marked **closed** rather than deleted, and it now records what the original missed: there was a **fourth** source, and it decided the matter — both App Service plans run `NODE|22-lts`, so the workflows were building the deployed backend on a major the host does not run.
- **A dangling cross-reference** to a *"Queued CI improvements"* section that does not exist in that file. It now cites #34 and #35 directly.

Plus the register's verification stamp moves to the current `acc` head, with a note that `check-supply-chain` blocks — so that headline can no longer drift from the workflows without failing a merge.

## Verification

`check-supply-chain` **OK**, 31 references — which mattered, since I rewrote the headline line its parser reads · `check-format` clean · `check-shared` passes · 8 tables across both files, 0 malformed.